### PR TITLE
feat: Plugin-specific default exclude patterns

### DIFF
--- a/src/core/plugins/types.ts
+++ b/src/core/plugins/types.ts
@@ -59,6 +59,11 @@ export interface IPlugin {
    * Optional preferred colors for supported file extensions.
    * These colors override generated colors but can be overridden by user settings.
    * 
+   * Supports three pattern types:
+   * - Extensions: `.ts`, `.md`
+   * - Exact filenames: `project.godot`, `Makefile`
+   * - Glob patterns: `**\/*.test.ts`
+   * 
    * @example
    * ```typescript
    * fileColors: {
@@ -68,6 +73,21 @@ export interface IPlugin {
    * ```
    */
   fileColors?: Record<string, string>;
+  
+  /**
+   * Optional default exclude patterns for this plugin's ecosystem.
+   * These are merged with user-defined exclude patterns.
+   * 
+   * @example
+   * ```typescript
+   * // TypeScript plugin
+   * defaultExclude: ['**\/node_modules\/**', '**\/dist\/**']
+   * 
+   * // Godot plugin  
+   * defaultExclude: ['**\/.godot\/**', '**\/*.import']
+   * ```
+   */
+  defaultExclude?: string[];
   
   /**
    * Detects connections (imports) in a file.

--- a/src/plugins/typescript/index.ts
+++ b/src/plugins/typescript/index.ts
@@ -47,6 +47,18 @@ export function createTypeScriptPlugin(): IPlugin {
     version: '1.0.0',
     supportedExtensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'],
     
+    // Default exclude patterns for TypeScript/JavaScript ecosystem
+    defaultExclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/build/**',
+      '**/out/**',
+      '**/.next/**',
+      '**/.nuxt/**',
+      '**/coverage/**',
+      '**/.turbo/**',
+    ],
+    
     // Plugin-preferred colors for file extensions and config files
     fileColors: {
       // TypeScript/JavaScript source files


### PR DESCRIPTION
## Summary
Plugins can now define sensible default exclude patterns for their ecosystems.

Closes #31

## Changes
- Added \defaultExclude?: string[]\ to \IPlugin\ interface
- TypeScript plugin excludes: node_modules, dist, build, .next, .nuxt, coverage, .turbo
- GDScript plugin excludes: .godot, .import, .mono, addons  
- WorkspaceAnalyzer merges plugin defaults with user settings
- User patterns always take precedence

## Behavior
1. On analysis, collect \defaultExclude\ from all active plugins
2. Merge with user-defined \codegraphy.exclude\ patterns (deduplicated)
3. User patterns can override plugin defaults

## Benefits
- Smarter out-of-box experience per ecosystem
- No irrelevant ignores in settings
- Plugins can evolve their defaults independently