### PR TITLE
fix: Remove orange focus ring from graph container

### DIFF
--- a/src/webview/components/Graph.tsx
+++ b/src/webview/components/Graph.tsx
@@ -544,7 +544,7 @@ export default function Graph({ data, favorites = new Set() }: GraphProps): Reac
         <div
           ref={containerRef}
           onContextMenu={handleContextMenu}
-          className="absolute inset-0 rounded-lg border border-zinc-700 m-1 outline-none focus:outline-none"
+          className="graph-container absolute inset-0 rounded-lg border border-zinc-700 m-1 outline-none focus:outline-none"
           style={{ backgroundColor: '#18181b' }}
           tabIndex={0}
         />

--- a/src/webview/index.css
+++ b/src/webview/index.css
@@ -2,6 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Remove focus rings from graph container and vis-network canvas */
+.graph-container,
+.graph-container *,
+.graph-container canvas {
+  outline: none !important;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.graph-container:focus,
+.graph-container:focus-visible,
+.graph-container canvas:focus,
+.graph-container canvas:focus-visible {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
 :root {
   --color-primary: #e0e0e0;
   --color-secondary: #a0a0a0;


### PR DESCRIPTION
Closes #69

## Problem
An orange/yellow focus ring appears around the graph container when it has focus.

## Solution
- Added \graph-container\ class with explicit focus ring removal CSS
- Target canvas elements inside vis-network specifically
- Use \!important\ to override any conflicting browser/framework styles
- Disable webkit tap highlight color for mobile/touch

## Testing
- All 338 tests passing
- CSS-only change, no logic changes