### PR TITLE
feat: Alt View System Architecture (#58)

### DIFF
--- a/src/core/views/ViewRegistry.ts
+++ b/src/core/views/ViewRegistry.ts
@@ -1,0 +1,217 @@
+/**
+ * @fileoverview View registry for managing CodeGraphy views.
+ * Handles registration, lookup, and lifecycle of views.
+ * @module core/views/ViewRegistry
+ */
+
+import { IView, IViewInfo, IViewContext } from './types';
+
+/**
+ * Registry for managing CodeGraphy views.
+ * 
+ * The registry maintains a collection of views and provides methods
+ * to register, unregister, and query views. Views can be core (always
+ * available) or plugin-provided (only available when plugin is active).
+ * 
+ * @example
+ * ```typescript
+ * const registry = new ViewRegistry();
+ * 
+ * // Register a core view
+ * registry.register(fileDependenciesView, { core: true });
+ * 
+ * // Register a plugin-provided view
+ * registry.register(typeGraphView, { core: false });
+ * 
+ * // Get available views
+ * const views = registry.getAvailableViews(context);
+ * ```
+ */
+export class ViewRegistry {
+  /** Map of view ID to view info */
+  private readonly _views = new Map<string, IViewInfo>();
+  
+  /** Counter for tracking registration order */
+  private _orderCounter = 0;
+  
+  /** Default view ID */
+  private _defaultViewId: string | undefined;
+
+  /**
+   * Registers a view with the registry.
+   * 
+   * @param view - The view to register
+   * @param options - Registration options
+   * @throws Error if a view with the same ID is already registered
+   */
+  register(
+    view: IView,
+    options: { core?: boolean; isDefault?: boolean } = {}
+  ): void {
+    if (this._views.has(view.id)) {
+      throw new Error(`View with ID '${view.id}' is already registered`);
+    }
+
+    const info: IViewInfo = {
+      view,
+      core: options.core ?? false,
+      order: this._orderCounter++,
+    };
+
+    this._views.set(view.id, info);
+    
+    // Set as default if specified or if it's the first view
+    if (options.isDefault || this._defaultViewId === undefined) {
+      this._defaultViewId = view.id;
+    }
+
+    console.log(`[CodeGraphy] Registered view: ${view.name} (${view.id})`);
+  }
+
+  /**
+   * Unregisters a view from the registry.
+   * 
+   * @param viewId - ID of the view to unregister
+   * @returns true if the view was found and removed, false otherwise
+   */
+  unregister(viewId: string): boolean {
+    const existed = this._views.delete(viewId);
+    
+    if (existed) {
+      console.log(`[CodeGraphy] Unregistered view: ${viewId}`);
+      
+      // If we removed the default view, pick a new one
+      if (this._defaultViewId === viewId) {
+        const remaining = Array.from(this._views.values());
+        this._defaultViewId = remaining.length > 0 
+          ? remaining.sort((a, b) => a.order - b.order)[0].view.id 
+          : undefined;
+      }
+    }
+    
+    return existed;
+  }
+
+  /**
+   * Gets a view by its ID.
+   * 
+   * @param viewId - ID of the view to get
+   * @returns The view info, or undefined if not found
+   */
+  get(viewId: string): IViewInfo | undefined {
+    return this._views.get(viewId);
+  }
+
+  /**
+   * Gets the default view ID.
+   * 
+   * @returns The default view ID, or undefined if no views are registered
+   */
+  getDefaultViewId(): string | undefined {
+    return this._defaultViewId;
+  }
+
+  /**
+   * Sets the default view ID.
+   * 
+   * @param viewId - ID of the view to set as default
+   * @throws Error if the view is not registered
+   */
+  setDefaultViewId(viewId: string): void {
+    if (!this._views.has(viewId)) {
+      throw new Error(`View with ID '${viewId}' is not registered`);
+    }
+    this._defaultViewId = viewId;
+  }
+
+  /**
+   * Gets all views that are available in the given context.
+   * A view is available if:
+   * - It's a core view, OR
+   * - Its plugin is in the activePlugins set, AND
+   * - Its isAvailable() method returns true (if defined)
+   * 
+   * @param context - The current view context
+   * @returns Array of available view info objects, sorted by registration order
+   */
+  getAvailableViews(context: IViewContext): IViewInfo[] {
+    const available: IViewInfo[] = [];
+    
+    for (const info of this._views.values()) {
+      const view = info.view;
+      
+      // Check plugin availability
+      if (view.pluginId && !context.activePlugins.has(view.pluginId)) {
+        continue;
+      }
+      
+      // Check custom availability
+      if (view.isAvailable && !view.isAvailable(context)) {
+        continue;
+      }
+      
+      available.push(info);
+    }
+    
+    // Sort by registration order (core views first)
+    return available.sort((a, b) => {
+      // Core views come first
+      if (a.core !== b.core) {
+        return a.core ? -1 : 1;
+      }
+      // Then by registration order
+      return a.order - b.order;
+    });
+  }
+
+  /**
+   * Gets all registered views.
+   * 
+   * @returns Array of all view info objects
+   */
+  list(): IViewInfo[] {
+    return Array.from(this._views.values()).sort((a, b) => a.order - b.order);
+  }
+
+  /**
+   * Gets the count of registered views.
+   */
+  get size(): number {
+    return this._views.size;
+  }
+
+  /**
+   * Checks if a view is available in the given context.
+   * 
+   * @param viewId - ID of the view to check
+   * @param context - The current view context
+   * @returns true if the view is available
+   */
+  isViewAvailable(viewId: string, context: IViewContext): boolean {
+    const info = this._views.get(viewId);
+    if (!info) return false;
+    
+    const view = info.view;
+    
+    // Check plugin availability
+    if (view.pluginId && !context.activePlugins.has(view.pluginId)) {
+      return false;
+    }
+    
+    // Check custom availability
+    if (view.isAvailable && !view.isAvailable(context)) {
+      return false;
+    }
+    
+    return true;
+  }
+
+  /**
+   * Clears all registered views.
+   */
+  clear(): void {
+    this._views.clear();
+    this._orderCounter = 0;
+    this._defaultViewId = undefined;
+  }
+}

--- a/src/core/views/coreViews.ts
+++ b/src/core/views/coreViews.ts
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview Core views that ship with CodeGraphy.
+ * These views are always available regardless of which plugins are active.
+ * @module core/views/coreViews
+ */
+
+import { IView, IViewContext } from './types';
+import { IGraphData } from '../../shared/types';
+
+/**
+ * File Dependencies view - the default view.
+ * Shows all files and their import relationships.
+ * This is the current default behavior of CodeGraphy.
+ */
+export const fileDependenciesView: IView = {
+  id: 'codegraphy.file-dependencies',
+  name: 'File Dependencies',
+  icon: 'symbol-file',
+  description: 'Shows all files and their import relationships',
+  
+  transform(data: IGraphData, _context: IViewContext): IGraphData {
+    // Pass through - this is the default view that shows everything
+    return data;
+  },
+};
+
+/**
+ * Depth Graph view - focuses on a specific file.
+ * Shows the selected file and its direct dependencies (1-hop connections).
+ * 
+ * This is a placeholder implementation. Full implementation will be in #62.
+ * Currently shows the focused file and its immediate neighbors.
+ */
+export const depthGraphView: IView = {
+  id: 'codegraphy.depth-graph',
+  name: 'Depth Graph',
+  icon: 'target',
+  description: 'Focus on current file and its immediate connections',
+  
+  transform(data: IGraphData, context: IViewContext): IGraphData {
+    // If no file is focused, return empty graph with a message
+    if (!context.focusedFile) {
+      return { nodes: [], edges: [] };
+    }
+    
+    const focusedFile = context.focusedFile;
+    
+    // Find all nodes connected to the focused file (1-hop)
+    const connectedNodeIds = new Set<string>([focusedFile]);
+    
+    for (const edge of data.edges) {
+      if (edge.from === focusedFile) {
+        connectedNodeIds.add(edge.to);
+      }
+      if (edge.to === focusedFile) {
+        connectedNodeIds.add(edge.from);
+      }
+    }
+    
+    // Filter nodes to only include connected ones
+    const filteredNodes = data.nodes.filter(node => connectedNodeIds.has(node.id));
+    
+    // Filter edges to only include those between connected nodes
+    const filteredEdges = data.edges.filter(
+      edge => connectedNodeIds.has(edge.from) && connectedNodeIds.has(edge.to)
+    );
+    
+    return {
+      nodes: filteredNodes,
+      edges: filteredEdges,
+      nodeSizeMode: data.nodeSizeMode,
+    };
+  },
+  
+  isAvailable(context: IViewContext): boolean {
+    // Only available when a file is focused
+    return context.focusedFile !== undefined;
+  },
+};
+
+/**
+ * Subfolder View - limits the graph to a specific folder.
+ * Shows only files within the selected folder and its subfolders.
+ * 
+ * This is a placeholder implementation.
+ */
+export const subfolderView: IView = {
+  id: 'codegraphy.subfolder',
+  name: 'Subfolder View',
+  icon: 'folder',
+  description: 'Limit view to files in a specific folder',
+  
+  transform(data: IGraphData, context: IViewContext): IGraphData {
+    // If no folder is selected, return everything
+    if (!context.selectedFolder) {
+      return data;
+    }
+    
+    const folderPrefix = context.selectedFolder.endsWith('/')
+      ? context.selectedFolder
+      : `${context.selectedFolder}/`;
+    
+    // Filter nodes to only include those in the folder
+    const filteredNodes = data.nodes.filter(
+      node => node.id.startsWith(folderPrefix) || node.id === context.selectedFolder
+    );
+    
+    const nodeIds = new Set(filteredNodes.map(n => n.id));
+    
+    // Filter edges to only include those between filtered nodes
+    const filteredEdges = data.edges.filter(
+      edge => nodeIds.has(edge.from) && nodeIds.has(edge.to)
+    );
+    
+    return {
+      nodes: filteredNodes,
+      edges: filteredEdges,
+      nodeSizeMode: data.nodeSizeMode,
+    };
+  },
+  
+  isAvailable(context: IViewContext): boolean {
+    // Only available when a folder is selected
+    return context.selectedFolder !== undefined;
+  },
+};
+
+/**
+ * All core views that ship with CodeGraphy.
+ * Register these on startup.
+ */
+export const coreViews: IView[] = [
+  fileDependenciesView,
+  depthGraphView,
+  subfolderView,
+];

--- a/src/core/views/index.ts
+++ b/src/core/views/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @fileoverview View system exports.
+ * @module core/views
+ */
+
+export { ViewRegistry } from './ViewRegistry';
+export { 
+  fileDependenciesView, 
+  depthGraphView, 
+  subfolderView, 
+  coreViews 
+} from './coreViews';
+export type { 
+  IView, 
+  IViewInfo, 
+  IViewContext, 
+  IViewChangeEvent 
+} from './types';

--- a/src/core/views/types.ts
+++ b/src/core/views/types.ts
@@ -1,0 +1,133 @@
+/**
+ * @fileoverview View system type definitions.
+ * Defines the interface that all CodeGraphy views must implement.
+ * Views can be core (built-in) or provided by plugins.
+ * @module core/views/types
+ */
+
+import { IGraphData } from '../../shared/types';
+
+/**
+ * Represents a view type that can be displayed in CodeGraphy.
+ * 
+ * Views transform the base file data into different visualizations.
+ * Each view can filter, transform, or reorganize the graph data
+ * to present a specific perspective on the codebase.
+ * 
+ * @example
+ * ```typescript
+ * const fileDependenciesView: IView = {
+ *   id: 'codegraphy.file-dependencies',
+ *   name: 'File Dependencies',
+ *   icon: 'symbol-file',
+ *   description: 'Shows all files and their import relationships',
+ *   
+ *   transform(data, context) {
+ *     // Return data as-is for the default view
+ *     return data;
+ *   }
+ * };
+ * ```
+ */
+export interface IView {
+  /** 
+   * Unique identifier for the view (e.g., 'codegraphy.file-dependencies').
+   * Should be namespaced to avoid conflicts.
+   */
+  id: string;
+  
+  /** 
+   * Human-readable name for display in the UI.
+   * @example 'File Dependencies', 'Type Graph', 'Depth View'
+   */
+  name: string;
+  
+  /**
+   * Codicon icon name for the view (without 'codicon-' prefix).
+   * @see https://microsoft.github.io/vscode-codicons/dist/codicon.html
+   * @example 'symbol-file', 'type-hierarchy', 'folder'
+   */
+  icon: string;
+  
+  /**
+   * Brief description of what this view shows.
+   * Used for tooltips and help text.
+   */
+  description: string;
+  
+  /**
+   * Optional plugin ID that provides this view.
+   * If set, the view will only be available when the plugin is active.
+   * Core views should leave this undefined.
+   */
+  pluginId?: string;
+  
+  /**
+   * Transforms the base graph data into the view's representation.
+   * 
+   * @param data - The complete graph data from workspace analysis
+   * @param context - Additional context for the transformation
+   * @returns Transformed graph data for rendering
+   */
+  transform(data: IGraphData, context: IViewContext): IGraphData;
+  
+  /**
+   * Optional validation to check if this view can be used.
+   * Return false to hide the view (e.g., if required data is missing).
+   * 
+   * @param context - Context to validate against
+   * @returns true if the view can be displayed
+   */
+  isAvailable?(context: IViewContext): boolean;
+}
+
+/**
+ * Context provided to view transformations.
+ * Contains information about the current state of the workspace.
+ */
+export interface IViewContext {
+  /**
+   * Currently focused file path (relative to workspace).
+   * Used by views like Depth Graph that center on a specific file.
+   */
+  focusedFile?: string;
+  
+  /**
+   * Currently selected folder path (relative to workspace).
+   * Used by views like Subfolder View that limit scope.
+   */
+  selectedFolder?: string;
+  
+  /**
+   * Set of active plugin IDs.
+   * Used to determine which plugin-provided views are available.
+   */
+  activePlugins: Set<string>;
+  
+  /**
+   * Workspace root path (absolute).
+   */
+  workspaceRoot?: string;
+}
+
+/**
+ * Information about a registered view.
+ */
+export interface IViewInfo {
+  /** The view instance */
+  view: IView;
+  /** Whether this is a core (built-in) view */
+  core: boolean;
+  /** Registration order (lower = registered earlier) */
+  order: number;
+}
+
+/**
+ * View change event payload.
+ */
+export interface IViewChangeEvent {
+  /** Previous view ID (undefined if first selection) */
+  previousViewId?: string;
+  /** New view ID */
+  newViewId: string;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -215,6 +215,22 @@ export interface IGraphData {
 /** Bidirectional edge display mode */
 export type BidirectionalEdgeMode = 'separate' | 'combined';
 
+/**
+ * View information sent to the webview for the view switcher.
+ */
+export interface IAvailableView {
+  /** Unique view identifier */
+  id: string;
+  /** Display name */
+  name: string;
+  /** Codicon icon name */
+  icon: string;
+  /** Description for tooltip */
+  description: string;
+  /** Whether this is the currently active view */
+  active: boolean;
+}
+
 export type ExtensionToWebviewMessage =
   | { type: 'GRAPH_DATA_UPDATED'; payload: IGraphData }
   | { type: 'FIT_VIEW' }
@@ -227,7 +243,8 @@ export type ExtensionToWebviewMessage =
   | { type: 'REQUEST_EXPORT_PNG' }
   | { type: 'REQUEST_EXPORT_SVG' }
   | { type: 'REQUEST_EXPORT_JSON' }
-  | { type: 'NODE_ACCESS_COUNT_UPDATED'; payload: { nodeId: string; accessCount: number } };
+  | { type: 'NODE_ACCESS_COUNT_UPDATED'; payload: { nodeId: string; accessCount: number } }
+  | { type: 'VIEWS_UPDATED'; payload: { views: IAvailableView[]; activeViewId: string } };
 
 /**
  * Messages sent from the Webview to the Extension.
@@ -270,7 +287,9 @@ export type WebviewToExtensionMessage =
   | { type: 'EXPORT_JSON'; payload: { json: string; filename?: string } }
   // Undo/Redo commands from webview keyboard shortcuts
   | { type: 'UNDO' }
-  | { type: 'REDO' };
+  | { type: 'REDO' }
+  // View switching
+  | { type: 'CHANGE_VIEW'; payload: { viewId: string } };
 
 /**
  * File information returned from extension for tooltips.

--- a/src/webview/components/ViewSwitcher.tsx
+++ b/src/webview/components/ViewSwitcher.tsx
@@ -1,0 +1,92 @@
+/**
+ * @fileoverview View switcher dropdown component.
+ * Allows users to switch between available graph views.
+ * @module webview/components/ViewSwitcher
+ */
+
+import React from 'react';
+import { IAvailableView, WebviewToExtensionMessage } from '../../shared/types';
+
+// Get VSCode API if available
+declare function acquireVsCodeApi(): {
+  postMessage: (message: WebviewToExtensionMessage) => void;
+  getState: () => unknown;
+  setState: (state: unknown) => void;
+};
+
+let vscode: ReturnType<typeof acquireVsCodeApi> | null = null;
+try {
+  if (typeof acquireVsCodeApi !== 'undefined') {
+    vscode = acquireVsCodeApi();
+  }
+} catch {
+  vscode = null;
+}
+
+interface ViewSwitcherProps {
+  views: IAvailableView[];
+  activeViewId: string;
+  onViewChange?: (viewId: string) => void;
+}
+
+/**
+ * Dropdown component for switching between graph views.
+ * 
+ * @example
+ * ```tsx
+ * <ViewSwitcher
+ *   views={availableViews}
+ *   activeViewId="codegraphy.file-dependencies"
+ *   onViewChange={(id) => console.log('Switched to', id)}
+ * />
+ * ```
+ */
+export function ViewSwitcher({ views, activeViewId, onViewChange }: ViewSwitcherProps): React.ReactElement | null {
+  // Don't render if there's only one view or no views
+  if (views.length <= 1) {
+    return null;
+  }
+
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const viewId = event.target.value;
+    
+    // Notify extension
+    if (vscode) {
+      vscode.postMessage({ type: 'CHANGE_VIEW', payload: { viewId } });
+    }
+    
+    // Notify local handler if provided
+    onViewChange?.(viewId);
+  };
+
+  const activeView = views.find(v => v.id === activeViewId);
+
+  return (
+    <div className="view-switcher flex items-center gap-2">
+      <label htmlFor="view-select" className="sr-only">
+        Select view
+      </label>
+      <div className="relative">
+        <select
+          id="view-select"
+          value={activeViewId}
+          onChange={handleChange}
+          className="appearance-none bg-[var(--vscode-dropdown-background,#3c3c3c)] text-[var(--vscode-dropdown-foreground,#cccccc)] border border-[var(--vscode-dropdown-border,#3c3c3c)] rounded px-3 py-1 pr-8 text-sm cursor-pointer hover:bg-[var(--vscode-dropdown-hoverBackground,#505050)] focus:outline-none focus:ring-1 focus:ring-[var(--vscode-focusBorder,#007fd4)]"
+          title={activeView?.description || 'Select view'}
+        >
+          {views.map(view => (
+            <option key={view.id} value={view.id} title={view.description}>
+              {view.name}
+            </option>
+          ))}
+        </select>
+        {/* Dropdown arrow icon */}
+        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-[var(--vscode-dropdown-foreground,#cccccc)]">
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/core/views/ViewRegistry.test.ts
+++ b/tests/core/views/ViewRegistry.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ViewRegistry, IView, IViewContext } from '../../../src/core/views';
+import { IGraphData } from '../../../src/shared/types';
+
+// Helper to create a mock view
+function createMockView(overrides: Partial<IView> = {}): IView {
+  return {
+    id: 'test.view',
+    name: 'Test View',
+    icon: 'symbol-file',
+    description: 'A test view',
+    transform: (data: IGraphData) => data,
+    ...overrides,
+  };
+}
+
+// Helper to create a basic view context
+function createMockContext(overrides: Partial<IViewContext> = {}): IViewContext {
+  return {
+    activePlugins: new Set(),
+    ...overrides,
+  };
+}
+
+describe('ViewRegistry', () => {
+  let registry: ViewRegistry;
+
+  beforeEach(() => {
+    registry = new ViewRegistry();
+  });
+
+  describe('register', () => {
+    it('should register a view', () => {
+      const view = createMockView();
+      registry.register(view);
+
+      expect(registry.size).toBe(1);
+      expect(registry.get(view.id)).toBeDefined();
+    });
+
+    it('should register view as core when specified', () => {
+      const view = createMockView();
+      registry.register(view, { core: true });
+
+      const info = registry.get(view.id);
+      expect(info?.core).toBe(true);
+    });
+
+    it('should set first registered view as default', () => {
+      const view = createMockView();
+      registry.register(view);
+
+      expect(registry.getDefaultViewId()).toBe(view.id);
+    });
+
+    it('should respect isDefault option', () => {
+      const view1 = createMockView({ id: 'first' });
+      const view2 = createMockView({ id: 'second' });
+      registry.register(view1);
+      registry.register(view2, { isDefault: true });
+
+      expect(registry.getDefaultViewId()).toBe('second');
+    });
+
+    it('should throw if view ID already exists', () => {
+      const view = createMockView();
+      registry.register(view);
+
+      expect(() => registry.register(view)).toThrow(
+        "View with ID 'test.view' is already registered"
+      );
+    });
+  });
+
+  describe('unregister', () => {
+    it('should unregister a view', () => {
+      const view = createMockView();
+      registry.register(view);
+
+      const result = registry.unregister(view.id);
+
+      expect(result).toBe(true);
+      expect(registry.size).toBe(0);
+      expect(registry.get(view.id)).toBeUndefined();
+    });
+
+    it('should return false for non-existent view', () => {
+      const result = registry.unregister('non.existent');
+      expect(result).toBe(false);
+    });
+
+    it('should update default view when unregistering current default', () => {
+      const view1 = createMockView({ id: 'first' });
+      const view2 = createMockView({ id: 'second' });
+      registry.register(view1);
+      registry.register(view2);
+
+      registry.unregister('first');
+
+      expect(registry.getDefaultViewId()).toBe('second');
+    });
+  });
+
+  describe('get', () => {
+    it('should return view info by ID', () => {
+      const view = createMockView();
+      registry.register(view, { core: true });
+
+      const info = registry.get(view.id);
+
+      expect(info).toBeDefined();
+      expect(info?.view).toBe(view);
+      expect(info?.core).toBe(true);
+    });
+
+    it('should return undefined for non-existent view', () => {
+      const info = registry.get('non.existent');
+      expect(info).toBeUndefined();
+    });
+  });
+
+  describe('setDefaultViewId', () => {
+    it('should set the default view', () => {
+      const view1 = createMockView({ id: 'first' });
+      const view2 = createMockView({ id: 'second' });
+      registry.register(view1);
+      registry.register(view2);
+
+      registry.setDefaultViewId('second');
+
+      expect(registry.getDefaultViewId()).toBe('second');
+    });
+
+    it('should throw for non-existent view', () => {
+      expect(() => registry.setDefaultViewId('non.existent')).toThrow(
+        "View with ID 'non.existent' is not registered"
+      );
+    });
+  });
+
+  describe('getAvailableViews', () => {
+    it('should return all views when no constraints', () => {
+      const view1 = createMockView({ id: 'first' });
+      const view2 = createMockView({ id: 'second' });
+      registry.register(view1, { core: true });
+      registry.register(view2, { core: true });
+
+      const context = createMockContext();
+      const views = registry.getAvailableViews(context);
+
+      expect(views).toHaveLength(2);
+    });
+
+    it('should filter views by plugin availability', () => {
+      const coreView = createMockView({ id: 'core' });
+      const pluginView = createMockView({ id: 'plugin', pluginId: 'typescript-plugin' });
+      registry.register(coreView, { core: true });
+      registry.register(pluginView);
+
+      // Without the plugin
+      const contextWithout = createMockContext({ activePlugins: new Set() });
+      const viewsWithout = registry.getAvailableViews(contextWithout);
+      expect(viewsWithout).toHaveLength(1);
+      expect(viewsWithout[0].view.id).toBe('core');
+
+      // With the plugin
+      const contextWith = createMockContext({ activePlugins: new Set(['typescript-plugin']) });
+      const viewsWith = registry.getAvailableViews(contextWith);
+      expect(viewsWith).toHaveLength(2);
+    });
+
+    it('should filter views by isAvailable', () => {
+      const alwaysView = createMockView({ id: 'always' });
+      const conditionalView = createMockView({
+        id: 'conditional',
+        isAvailable: (ctx) => ctx.focusedFile !== undefined,
+      });
+      registry.register(alwaysView, { core: true });
+      registry.register(conditionalView, { core: true });
+
+      // Without focused file
+      const contextWithout = createMockContext();
+      const viewsWithout = registry.getAvailableViews(contextWithout);
+      expect(viewsWithout).toHaveLength(1);
+
+      // With focused file
+      const contextWith = createMockContext({ focusedFile: 'src/app.ts' });
+      const viewsWith = registry.getAvailableViews(contextWith);
+      expect(viewsWith).toHaveLength(2);
+    });
+
+    it('should sort core views before plugin views', () => {
+      const pluginView = createMockView({ id: 'plugin', pluginId: 'test' });
+      const coreView = createMockView({ id: 'core' });
+      registry.register(pluginView);
+      registry.register(coreView, { core: true });
+
+      const context = createMockContext({ activePlugins: new Set(['test']) });
+      const views = registry.getAvailableViews(context);
+
+      expect(views[0].view.id).toBe('core');
+      expect(views[1].view.id).toBe('plugin');
+    });
+  });
+
+  describe('list', () => {
+    it('should return all registered views', () => {
+      const view1 = createMockView({ id: 'first' });
+      const view2 = createMockView({ id: 'second' });
+      registry.register(view1);
+      registry.register(view2);
+
+      const views = registry.list();
+
+      expect(views).toHaveLength(2);
+      expect(views.map(v => v.view.id)).toContain('first');
+      expect(views.map(v => v.view.id)).toContain('second');
+    });
+
+    it('should return empty array when no views registered', () => {
+      expect(registry.list()).toEqual([]);
+    });
+  });
+
+  describe('isViewAvailable', () => {
+    it('should return true for available core view', () => {
+      const view = createMockView();
+      registry.register(view, { core: true });
+
+      const context = createMockContext();
+      expect(registry.isViewAvailable(view.id, context)).toBe(true);
+    });
+
+    it('should return false for non-existent view', () => {
+      const context = createMockContext();
+      expect(registry.isViewAvailable('non.existent', context)).toBe(false);
+    });
+
+    it('should return false when plugin is not active', () => {
+      const view = createMockView({ pluginId: 'required-plugin' });
+      registry.register(view);
+
+      const context = createMockContext({ activePlugins: new Set() });
+      expect(registry.isViewAvailable(view.id, context)).toBe(false);
+    });
+
+    it('should return true when plugin is active', () => {
+      const view = createMockView({ pluginId: 'required-plugin' });
+      registry.register(view);
+
+      const context = createMockContext({ activePlugins: new Set(['required-plugin']) });
+      expect(registry.isViewAvailable(view.id, context)).toBe(true);
+    });
+
+    it('should respect isAvailable method', () => {
+      const view = createMockView({
+        isAvailable: (ctx) => ctx.selectedFolder !== undefined,
+      });
+      registry.register(view, { core: true });
+
+      const contextWithout = createMockContext();
+      expect(registry.isViewAvailable(view.id, contextWithout)).toBe(false);
+
+      const contextWith = createMockContext({ selectedFolder: 'src' });
+      expect(registry.isViewAvailable(view.id, contextWith)).toBe(true);
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all views', () => {
+      const view1 = createMockView({ id: 'first' });
+      const view2 = createMockView({ id: 'second' });
+      registry.register(view1);
+      registry.register(view2);
+
+      registry.clear();
+
+      expect(registry.size).toBe(0);
+      expect(registry.getDefaultViewId()).toBeUndefined();
+    });
+  });
+});

--- a/tests/core/views/coreViews.test.ts
+++ b/tests/core/views/coreViews.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import {
+  fileDependenciesView,
+  depthGraphView,
+  subfolderView,
+  coreViews,
+} from '../../../src/core/views';
+import { IGraphData } from '../../../src/shared/types';
+import { IViewContext } from '../../../src/core/views';
+
+// Sample graph data for testing
+const sampleGraphData: IGraphData = {
+  nodes: [
+    { id: 'src/app.ts', label: 'app.ts', color: '#93C5FD' },
+    { id: 'src/utils/helpers.ts', label: 'helpers.ts', color: '#93C5FD' },
+    { id: 'src/utils/format.ts', label: 'format.ts', color: '#93C5FD' },
+    { id: 'src/components/Button.tsx', label: 'Button.tsx', color: '#67E8F9' },
+    { id: 'tests/app.test.ts', label: 'app.test.ts', color: '#93C5FD' },
+  ],
+  edges: [
+    { id: 'src/app.ts->src/utils/helpers.ts', from: 'src/app.ts', to: 'src/utils/helpers.ts' },
+    { id: 'src/app.ts->src/components/Button.tsx', from: 'src/app.ts', to: 'src/components/Button.tsx' },
+    { id: 'src/utils/helpers.ts->src/utils/format.ts', from: 'src/utils/helpers.ts', to: 'src/utils/format.ts' },
+    { id: 'tests/app.test.ts->src/app.ts', from: 'tests/app.test.ts', to: 'src/app.ts' },
+  ],
+};
+
+function createContext(overrides: Partial<IViewContext> = {}): IViewContext {
+  return {
+    activePlugins: new Set(),
+    ...overrides,
+  };
+}
+
+describe('Core Views', () => {
+  describe('coreViews array', () => {
+    it('should contain all core views', () => {
+      expect(coreViews).toHaveLength(3);
+      expect(coreViews).toContain(fileDependenciesView);
+      expect(coreViews).toContain(depthGraphView);
+      expect(coreViews).toContain(subfolderView);
+    });
+  });
+
+  describe('fileDependenciesView', () => {
+    it('should have correct metadata', () => {
+      expect(fileDependenciesView.id).toBe('codegraphy.file-dependencies');
+      expect(fileDependenciesView.name).toBe('File Dependencies');
+      expect(fileDependenciesView.icon).toBe('symbol-file');
+      expect(fileDependenciesView.pluginId).toBeUndefined();
+    });
+
+    it('should pass through data unchanged', () => {
+      const context = createContext();
+      const result = fileDependenciesView.transform(sampleGraphData, context);
+
+      expect(result).toBe(sampleGraphData);
+      expect(result.nodes).toHaveLength(5);
+      expect(result.edges).toHaveLength(4);
+    });
+  });
+
+  describe('depthGraphView', () => {
+    it('should have correct metadata', () => {
+      expect(depthGraphView.id).toBe('codegraphy.depth-graph');
+      expect(depthGraphView.name).toBe('Depth Graph');
+      expect(depthGraphView.icon).toBe('target');
+      expect(depthGraphView.pluginId).toBeUndefined();
+    });
+
+    it('should return empty graph when no file is focused', () => {
+      const context = createContext({ focusedFile: undefined });
+      const result = depthGraphView.transform(sampleGraphData, context);
+
+      expect(result.nodes).toHaveLength(0);
+      expect(result.edges).toHaveLength(0);
+    });
+
+    it('should return focused file and immediate connections', () => {
+      const context = createContext({ focusedFile: 'src/app.ts' });
+      const result = depthGraphView.transform(sampleGraphData, context);
+
+      // app.ts connects to: helpers.ts, Button.tsx, and is imported by app.test.ts
+      expect(result.nodes).toHaveLength(4);
+      expect(result.nodes.map(n => n.id)).toContain('src/app.ts');
+      expect(result.nodes.map(n => n.id)).toContain('src/utils/helpers.ts');
+      expect(result.nodes.map(n => n.id)).toContain('src/components/Button.tsx');
+      expect(result.nodes.map(n => n.id)).toContain('tests/app.test.ts');
+
+      // Should include edges to/from the focused file
+      expect(result.edges).toHaveLength(3);
+    });
+
+    it('should filter to only 1-hop connections', () => {
+      // format.ts is 2 hops from app.ts (app -> helpers -> format)
+      const context = createContext({ focusedFile: 'src/app.ts' });
+      const result = depthGraphView.transform(sampleGraphData, context);
+
+      expect(result.nodes.map(n => n.id)).not.toContain('src/utils/format.ts');
+    });
+
+    it('should be unavailable when no file is focused', () => {
+      const context = createContext({ focusedFile: undefined });
+      expect(depthGraphView.isAvailable?.(context)).toBe(false);
+    });
+
+    it('should be available when a file is focused', () => {
+      const context = createContext({ focusedFile: 'src/app.ts' });
+      expect(depthGraphView.isAvailable?.(context)).toBe(true);
+    });
+  });
+
+  describe('subfolderView', () => {
+    it('should have correct metadata', () => {
+      expect(subfolderView.id).toBe('codegraphy.subfolder');
+      expect(subfolderView.name).toBe('Subfolder View');
+      expect(subfolderView.icon).toBe('folder');
+      expect(subfolderView.pluginId).toBeUndefined();
+    });
+
+    it('should return all data when no folder is selected', () => {
+      const context = createContext({ selectedFolder: undefined });
+      const result = subfolderView.transform(sampleGraphData, context);
+
+      expect(result).toBe(sampleGraphData);
+    });
+
+    it('should filter to only files in selected folder', () => {
+      const context = createContext({ selectedFolder: 'src/utils' });
+      const result = subfolderView.transform(sampleGraphData, context);
+
+      // Only helpers.ts and format.ts are in src/utils
+      expect(result.nodes).toHaveLength(2);
+      expect(result.nodes.map(n => n.id)).toContain('src/utils/helpers.ts');
+      expect(result.nodes.map(n => n.id)).toContain('src/utils/format.ts');
+
+      // Only the edge between helpers and format
+      expect(result.edges).toHaveLength(1);
+    });
+
+    it('should handle folder path without trailing slash', () => {
+      const context = createContext({ selectedFolder: 'src' });
+      const result = subfolderView.transform(sampleGraphData, context);
+
+      // All src files: app.ts, helpers.ts, format.ts, Button.tsx
+      expect(result.nodes).toHaveLength(4);
+    });
+
+    it('should handle folder path with trailing slash', () => {
+      const context = createContext({ selectedFolder: 'src/' });
+      const result = subfolderView.transform(sampleGraphData, context);
+
+      expect(result.nodes).toHaveLength(4);
+    });
+
+    it('should be unavailable when no folder is selected', () => {
+      const context = createContext({ selectedFolder: undefined });
+      expect(subfolderView.isAvailable?.(context)).toBe(false);
+    });
+
+    it('should be available when a folder is selected', () => {
+      const context = createContext({ selectedFolder: 'src' });
+      expect(subfolderView.isAvailable?.(context)).toBe(true);
+    });
+
+    it('should preserve nodeSizeMode in output', () => {
+      const dataWithMode: IGraphData = { ...sampleGraphData, nodeSizeMode: 'file-size' };
+      const context = createContext({ selectedFolder: 'src' });
+      const result = subfolderView.transform(dataWithMode, context);
+
+      expect(result.nodeSizeMode).toBe('file-size');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements view registry pattern and view switching UI for CodeGraphy.

## Changes

### View System Core
- **ViewRegistry** class with register/unregister/getViews methods
- **IView** interface defining: id, name, icon, description, transform(), isAvailable?(), pluginId?
- **IViewContext** containing: focusedFile, selectedFolder, activePlugins, workspaceRoot

### Core Views
- **File Dependencies** - Default view showing all files and imports (pass-through)
- **Depth Graph** - Focus on current file and 1-hop connections (placeholder for #62)
- **Subfolder View** - Limit view to files in a specific folder

### UI
- View switcher dropdown in webview header (next to search bar)
- Shows available views with smooth switching
- Only displays when >1 view is available

### Persistence
- Selected view stored per workspace via VSCode workspace state
- Restores last view on reload

### Plugin Integration
- Views can specify `pluginId` dependency
- Plugin views only appear when their plugin is active
- Core views always available

## Technical Details
- Views transform raw graph data before sending to webview
- ViewContext updated on analyze with activePlugins from PluginRegistry
- Depth Graph requires focusedFile context, Subfolder requires selectedFolder

## Tests
- **ViewRegistry.test.ts** - 20+ tests covering registration, availability, filtering
- **coreViews.test.ts** - Tests for all three core view transform functions

## Acceptance Criteria
- [x] View switcher UI (dropdown)
- [x] Plugin API for registering views
- [x] Core views work without plugins
- [x] Plugin views only appear when plugin is active
- [x] View preference persists per workspace

Closes #58