### PR TITLE
[codex] Add type import graph edges

### DIFF
--- a/.changeset/type-import-edges.md
+++ b/.changeset/type-import-edges.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy/extension": minor
+"@codegraphy-vscode/plugin-api": minor
+---
+
+Add optional Type imports graph edges for TypeScript type-only imports.

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ blob-report/
 reports/
 .stryker-tmp/
 .pnpm-store/
+.codegraphy/

--- a/examples/example-typescript/packages/app/src/index.ts
+++ b/examples/example-typescript/packages/app/src/index.ts
@@ -1,6 +1,7 @@
 import { formatUser } from '../../shared/src/types';
+import type { UserName } from '../../shared/src/types';
 import { buildGreeting } from './utils';
 
-const currentUser = formatUser('CodeGraphy');
+const currentUser: UserName = formatUser('CodeGraphy');
 
 console.log(buildGreeting(currentUser));

--- a/examples/example-typescript/packages/shared/src/types.ts
+++ b/examples/example-typescript/packages/shared/src/types.ts
@@ -1,3 +1,5 @@
+export type UserName = string;
+
 export function formatUser(name: string): string {
   return name.trim();
 }

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyze/results.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyze/results.ts
@@ -86,6 +86,22 @@ export function addImportRelation(
   });
 }
 
+export function addTypeImportRelation(
+  relations: IAnalysisRelation[],
+  filePath: string,
+  specifier: string,
+  resolvedPath: string | null,
+): void {
+  addRelation(relations, {
+    kind: 'type-import',
+    sourceId: TREE_SITTER_SOURCE_IDS.typeImport,
+    fromFilePath: filePath,
+    specifier,
+    resolvedPath,
+    toFilePath: resolvedPath,
+  });
+}
+
 export function addCallRelation(
   relations: IAnalysisRelation[],
   filePath: string,

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeImportBinding/namedBindings.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeImportBinding/namedBindings.ts
@@ -9,6 +9,10 @@ export function addNamedImportBindings(
   resolvedPath: string | null,
 ): void {
   for (const importSpecifier of node.namedChildren.filter((child) => child.type === 'import_specifier')) {
+    if (importSpecifier.text.trimStart().startsWith('type ')) {
+      continue;
+    }
+
     const identifiers = importSpecifier.namedChildren.filter((child) =>
       child.type === 'identifier' || child.type === 'type_identifier',
     );

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeImportBinding/namedBindings.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeImportBinding/namedBindings.ts
@@ -9,7 +9,7 @@ export function addNamedImportBindings(
   resolvedPath: string | null,
 ): void {
   for (const importSpecifier of node.namedChildren.filter((child) => child.type === 'import_specifier')) {
-    if (importSpecifier.text.trimStart().startsWith('type ')) {
+    if ((importSpecifier.children ?? []).some((child) => child.type === 'type')) {
       continue;
     }
 

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeJavaScript/imports.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeJavaScript/imports.ts
@@ -5,7 +5,53 @@ import { resolveTreeSitterImportPath } from '../resolve';
 import { collectImportBindings } from '../analyze/imports';
 import type { ImportedBinding, SymbolWalkState, TreeWalkAction } from '../analyze/model';
 import { getStringSpecifier } from '../analyze/nodes';
-import { addImportRelation, addRelation } from '../analyze/results';
+import { addImportRelation, addRelation, addTypeImportRelation } from '../analyze/results';
+
+function hasDirectTypeKeyword(node: Parser.SyntaxNode): boolean {
+  return (node.children ?? []).some((child) => child.type === 'type');
+}
+
+function isTypeImportSpecifier(node: Parser.SyntaxNode): boolean {
+  return node.type === 'import_specifier' && node.text.trimStart().startsWith('type ');
+}
+
+function getImportClause(node: Parser.SyntaxNode): Parser.SyntaxNode | undefined {
+  return (node.namedChildren ?? []).find((child) => child.type === 'import_clause');
+}
+
+function getNamedImportSpecifiers(importClause: Parser.SyntaxNode | undefined): Parser.SyntaxNode[] {
+  const namedImports = importClause?.namedChildren.find((child) => child.type === 'named_imports');
+  return namedImports?.namedChildren.filter((child) => child.type === 'import_specifier') ?? [];
+}
+
+function hasTypeSpecifierImport(node: Parser.SyntaxNode): boolean {
+  return getNamedImportSpecifiers(getImportClause(node)).some(isTypeImportSpecifier);
+}
+
+function hasValueImport(node: Parser.SyntaxNode): boolean {
+  if (hasDirectTypeKeyword(node)) {
+    return false;
+  }
+
+  const importClause = getImportClause(node);
+  if (!importClause) {
+    return true;
+  }
+
+  return (importClause.namedChildren ?? []).some((child) => {
+    if (child.type === 'identifier' || child.type === 'namespace_import') {
+      return true;
+    }
+
+    if (child.type !== 'named_imports') {
+      return false;
+    }
+
+    return (child.namedChildren ?? []).some((specifier) =>
+      specifier.type === 'import_specifier' && !isTypeImportSpecifier(specifier),
+    );
+  });
+}
 
 export function handleJavaScriptImportStatement(
   node: Parser.SyntaxNode,
@@ -16,8 +62,13 @@ export function handleJavaScriptImportStatement(
   const specifier = getStringSpecifier(node.namedChildren.find((child) => child.type === 'string'));
   if (specifier) {
     const resolvedPath = resolveTreeSitterImportPath(filePath, specifier);
-    collectImportBindings(node, specifier, resolvedPath, importedBindings);
-    addImportRelation(relations, filePath, specifier, resolvedPath);
+    if (hasValueImport(node)) {
+      collectImportBindings(node, specifier, resolvedPath, importedBindings);
+      addImportRelation(relations, filePath, specifier, resolvedPath);
+    }
+    if (hasDirectTypeKeyword(node) || hasTypeSpecifierImport(node)) {
+      addTypeImportRelation(relations, filePath, specifier, resolvedPath);
+    }
   }
 
   return { skipChildren: true };

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeJavaScript/imports.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeJavaScript/imports.ts
@@ -28,6 +28,22 @@ function hasTypeSpecifierImport(node: Parser.SyntaxNode): boolean {
   return getNamedImportSpecifiers(getImportClause(node)).some(isTypeImportSpecifier);
 }
 
+function isValueImportSpecifier(node: Parser.SyntaxNode): boolean {
+  return node.type === 'import_specifier' && !isTypeImportSpecifier(node);
+}
+
+function isValueImportClauseChild(node: Parser.SyntaxNode): boolean {
+  if (node.type === 'identifier' || node.type === 'namespace_import') {
+    return true;
+  }
+
+  if (node.type !== 'named_imports') {
+    return false;
+  }
+
+  return (node.namedChildren ?? []).some(isValueImportSpecifier);
+}
+
 function hasValueImport(node: Parser.SyntaxNode): boolean {
   if (hasDirectTypeKeyword(node)) {
     return false;
@@ -38,19 +54,7 @@ function hasValueImport(node: Parser.SyntaxNode): boolean {
     return true;
   }
 
-  return (importClause.namedChildren ?? []).some((child) => {
-    if (child.type === 'identifier' || child.type === 'namespace_import') {
-      return true;
-    }
-
-    if (child.type !== 'named_imports') {
-      return false;
-    }
-
-    return (child.namedChildren ?? []).some((specifier) =>
-      specifier.type === 'import_specifier' && !isTypeImportSpecifier(specifier),
-    );
-  });
+  return (importClause.namedChildren ?? []).some(isValueImportClauseChild);
 }
 
 export function handleJavaScriptImportStatement(

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeJavaScript/imports.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyzeJavaScript/imports.ts
@@ -12,7 +12,7 @@ function hasDirectTypeKeyword(node: Parser.SyntaxNode): boolean {
 }
 
 function isTypeImportSpecifier(node: Parser.SyntaxNode): boolean {
-  return node.type === 'import_specifier' && node.text.trimStart().startsWith('type ');
+  return node.type === 'import_specifier' && (node.children ?? []).some((child) => child.type === 'type');
 }
 
 function getImportClause(node: Parser.SyntaxNode): Parser.SyntaxNode | undefined {

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/languages/catalog.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/languages/catalog.ts
@@ -23,6 +23,7 @@ export const TREE_SITTER_SOURCE_IDS = {
   inherit: 'codegraphy.treesitter:inherit',
   reference: 'codegraphy.treesitter:reference',
   reexport: 'codegraphy.treesitter:reexport',
+  typeImport: 'codegraphy.treesitter:type-import',
 } as const;
 
 export const TREE_SITTER_SUPPORTED_EXTENSIONS = [

--- a/packages/extension/src/shared/graphControls/defaults/edgeTypes.ts
+++ b/packages/extension/src/shared/graphControls/defaults/edgeTypes.ts
@@ -17,6 +17,12 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultVisible: true,
     },
     {
+      id: 'type-import',
+      label: 'Type imports',
+      defaultColor: '#38BDF8',
+      defaultVisible: false,
+    },
+    {
       id: 'reexport',
       label: 'Re-exports',
       defaultColor: '#A78BFA',

--- a/packages/extension/tests/extension/pipeline/examplesWorkspace.test.ts
+++ b/packages/extension/tests/extension/pipeline/examplesWorkspace.test.ts
@@ -83,6 +83,7 @@ describe('WorkspacePipeline examples workspace', { timeout: 30000 }, () => {
       'example-markdown/src/commented.ts->example-markdown/notes/Architecture.md#reference:static',
       'example-typescript/packages/app/src/index.ts->example-typescript/packages/app/src/utils.ts#import',
       'example-typescript/packages/app/src/index.ts->example-typescript/packages/shared/src/types.ts#import',
+      'example-typescript/packages/app/src/index.ts->example-typescript/packages/shared/src/types.ts#type-import',
       'example-typescript/packages/app/src/utils.ts->example-typescript/packages/feature-depth/src/deep.ts#import',
     ];
 

--- a/packages/extension/tests/extension/pipeline/treesitter/analyze.test.ts
+++ b/packages/extension/tests/extension/pipeline/treesitter/analyze.test.ts
@@ -158,6 +158,69 @@ describe('pipeline/plugins/treesitter/runtime/analyze', () => {
     );
   });
 
+  it('extracts TypeScript type-only imports as type-import relations', async () => {
+    const workspaceRoot = await createWorkspace({
+      'src/runtime.ts': [
+        'export interface RuntimeOptions { enabled: boolean }',
+        'export function boot() { return true; }',
+        '',
+      ].join('\n'),
+      'src/types.ts': 'export interface PluginContract { id: string }\n',
+    });
+    const appPath = path.join(workspaceRoot, 'src/app.ts');
+    const appSource = [
+      "import type { PluginContract } from './types';",
+      "import { type RuntimeOptions, boot } from './runtime';",
+      'const contract: PluginContract = { id: "plugin" };',
+      'const options: RuntimeOptions = { enabled: boot() };',
+      'void contract;',
+      'void options;',
+      '',
+    ].join('\n');
+
+    const result = await analyzeFileWithTreeSitter(appPath, appSource, workspaceRoot);
+
+    expect(result?.relations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'type-import',
+          pluginId: 'codegraphy.treesitter',
+          specifier: './types',
+          resolvedPath: path.join(workspaceRoot, 'src/types.ts'),
+          fromFilePath: appPath,
+          toFilePath: path.join(workspaceRoot, 'src/types.ts'),
+          sourceId: 'codegraphy.treesitter:type-import',
+        }),
+        expect.objectContaining({
+          kind: 'type-import',
+          pluginId: 'codegraphy.treesitter',
+          specifier: './runtime',
+          resolvedPath: path.join(workspaceRoot, 'src/runtime.ts'),
+          fromFilePath: appPath,
+          toFilePath: path.join(workspaceRoot, 'src/runtime.ts'),
+          sourceId: 'codegraphy.treesitter:type-import',
+        }),
+        expect.objectContaining({
+          kind: 'import',
+          pluginId: 'codegraphy.treesitter',
+          specifier: './runtime',
+          resolvedPath: path.join(workspaceRoot, 'src/runtime.ts'),
+          fromFilePath: appPath,
+          toFilePath: path.join(workspaceRoot, 'src/runtime.ts'),
+          sourceId: 'codegraphy.treesitter:import',
+        }),
+      ]),
+    );
+    expect(result?.relations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'import',
+          specifier: './types',
+        }),
+      ]),
+    );
+  });
+
   it('extracts symbols from arrow function and function expression variable declarations', async () => {
     const workspaceRoot = await createWorkspace({});
     const filePath = path.join(workspaceRoot, 'src/createFolder.ts');

--- a/packages/extension/tests/extension/pipeline/treesitter/analyze/results.test.ts
+++ b/packages/extension/tests/extension/pipeline/treesitter/analyze/results.test.ts
@@ -6,6 +6,7 @@ import {
   addImportRelation,
   addInheritRelation,
   addReferenceRelation,
+  addTypeImportRelation,
   createRange,
   createSymbol,
   createSymbolId,
@@ -131,6 +132,23 @@ describe('pipeline/plugins/treesitter/runtime/analyze/results', () => {
         resolvedPath: null,
         toFilePath: null,
         type: 'style',
+      },
+    ]);
+  });
+
+  it('adds type-import relations with their own edge kind and source id', () => {
+    const relations: unknown[] = [];
+
+    addTypeImportRelation(relations as never, '/workspace/app.ts', './types', '/workspace/types.ts');
+
+    expect(relations).toEqual([
+      {
+        kind: 'type-import',
+        sourceId: TREE_SITTER_SOURCE_IDS.typeImport,
+        fromFilePath: '/workspace/app.ts',
+        specifier: './types',
+        resolvedPath: '/workspace/types.ts',
+        toFilePath: '/workspace/types.ts',
       },
     ]);
   });

--- a/packages/extension/tests/extension/pipeline/treesitter/import/namedBindings.test.ts
+++ b/packages/extension/tests/extension/pipeline/treesitter/import/namedBindings.test.ts
@@ -68,6 +68,40 @@ describe('pipeline/plugins/treesitter/runtime/analyzeImportBinding/namedBindings
     );
   });
 
+  it('skips inline type-only import specifiers', () => {
+    const importedBindings = new Map();
+
+    addNamedImportBindings(
+      createNode({
+        type: 'named_imports',
+        namedChildren: [
+          createNode({
+            type: 'import_specifier',
+            text: 'type RuntimeOptions',
+            namedChildren: [createNode({ type: 'type_identifier', text: 'RuntimeOptions' })],
+          }),
+          createNode({
+            type: 'import_specifier',
+            text: 'boot',
+            namedChildren: [createNode({ type: 'identifier', text: 'boot' })],
+          }),
+        ],
+      }) as never,
+      importedBindings,
+      './runtime',
+      '/workspace/runtime.ts',
+    );
+
+    expect(addCollectedImportBinding).toHaveBeenCalledOnce();
+    expect(addCollectedImportBinding).toHaveBeenCalledWith(
+      importedBindings,
+      'boot',
+      'boot',
+      './runtime',
+      '/workspace/runtime.ts',
+    );
+  });
+
   it('skips specifiers without a local identifier', () => {
     addNamedImportBindings(
       createNode({

--- a/packages/extension/tests/extension/pipeline/treesitter/import/namedBindings.test.ts
+++ b/packages/extension/tests/extension/pipeline/treesitter/import/namedBindings.test.ts
@@ -7,11 +7,13 @@ vi.mock('../../../../../src/extension/pipeline/plugins/treesitter/runtime/analyz
 }));
 
 function createNode(overrides: Partial<{
+  children: unknown[];
   type: string;
   text: string;
   namedChildren: unknown[];
 }> = {}) {
   return {
+    children: [],
     type: 'identifier',
     text: '',
     namedChildren: [],
@@ -78,6 +80,7 @@ describe('pipeline/plugins/treesitter/runtime/analyzeImportBinding/namedBindings
           createNode({
             type: 'import_specifier',
             text: 'type RuntimeOptions',
+            children: [createNode({ type: 'type', text: 'type' })],
             namedChildren: [createNode({ type: 'type_identifier', text: 'RuntimeOptions' })],
           }),
           createNode({
@@ -97,6 +100,43 @@ describe('pipeline/plugins/treesitter/runtime/analyzeImportBinding/namedBindings
       importedBindings,
       'boot',
       'boot',
+      './runtime',
+      '/workspace/runtime.ts',
+    );
+  });
+
+  it('collects value imports named type', () => {
+    const importedBindings = new Map();
+
+    addNamedImportBindings(
+      createNode({
+        type: 'named_imports',
+        namedChildren: [
+          createNode({
+            type: 'import_specifier',
+            text: 'type as alias',
+            children: [
+              createNode({ type: 'identifier', text: 'type' }),
+              createNode({ type: 'as', text: 'as' }),
+              createNode({ type: 'identifier', text: 'alias' }),
+            ],
+            namedChildren: [
+              createNode({ type: 'identifier', text: 'type' }),
+              createNode({ type: 'identifier', text: 'alias' }),
+            ],
+          }),
+        ],
+      }) as never,
+      importedBindings,
+      './runtime',
+      '/workspace/runtime.ts',
+    );
+
+    expect(addCollectedImportBinding).toHaveBeenCalledOnce();
+    expect(addCollectedImportBinding).toHaveBeenCalledWith(
+      importedBindings,
+      'alias',
+      'type',
       './runtime',
       '/workspace/runtime.ts',
     );

--- a/packages/extension/tests/extension/pipeline/treesitter/javascript/imports.test.ts
+++ b/packages/extension/tests/extension/pipeline/treesitter/javascript/imports.test.ts
@@ -162,6 +162,48 @@ describe('extension/pipeline/treesitter/javascriptImports', () => {
     );
   });
 
+  it('records inline type-only specifier imports without value bindings', () => {
+    resolveTreeSitterImportPath.mockReturnValue('/workspace/packages/plugin-api/src/index.ts');
+    getStringSpecifier.mockReturnValue('@codegraphy-vscode/plugin-api');
+    const importedBindings = new Map();
+    const relations: never[] = [];
+
+    handleJavaScriptImportStatement(
+      {
+        children: [
+          { type: 'import' },
+          { type: 'import_clause' },
+          { type: 'from' },
+          { type: 'string' },
+        ],
+        namedChildren: [
+          {
+            type: 'import_clause',
+            namedChildren: [
+              {
+                type: 'named_imports',
+                namedChildren: [{ type: 'import_specifier', text: 'type Plugin' }],
+              },
+            ],
+          },
+          { type: 'string' },
+        ],
+      } as never,
+      '/workspace/packages/plugin-typescript/src/plugin.ts',
+      relations,
+      importedBindings as never,
+    );
+
+    expect(collectImportBindings).not.toHaveBeenCalled();
+    expect(addImportRelation).not.toHaveBeenCalled();
+    expect(addTypeImportRelation).toHaveBeenCalledWith(
+      relations,
+      '/workspace/packages/plugin-typescript/src/plugin.ts',
+      '@codegraphy-vscode/plugin-api',
+      '/workspace/packages/plugin-api/src/index.ts',
+    );
+  });
+
   it('skips import relation work when no string specifier exists', () => {
     getStringSpecifier.mockReturnValue(null);
 

--- a/packages/extension/tests/extension/pipeline/treesitter/javascript/imports.test.ts
+++ b/packages/extension/tests/extension/pipeline/treesitter/javascript/imports.test.ts
@@ -9,12 +9,14 @@ const {
   collectImportBindings,
   getStringSpecifier,
   addImportRelation,
+  addTypeImportRelation,
   addRelation,
 } = vi.hoisted(() => ({
   resolveTreeSitterImportPath: vi.fn(),
   collectImportBindings: vi.fn(),
   getStringSpecifier: vi.fn(),
   addImportRelation: vi.fn(),
+  addTypeImportRelation: vi.fn(),
   addRelation: vi.fn(),
 }));
 
@@ -32,6 +34,7 @@ vi.mock('../../../../../src/extension/pipeline/plugins/treesitter/runtime/analyz
 
 vi.mock('../../../../../src/extension/pipeline/plugins/treesitter/runtime/analyze/results', () => ({
   addImportRelation,
+  addTypeImportRelation,
   addRelation,
 }));
 
@@ -42,6 +45,7 @@ describe('extension/pipeline/treesitter/javascriptImports', () => {
     collectImportBindings.mockReset();
     getStringSpecifier.mockReset();
     addImportRelation.mockReset();
+    addTypeImportRelation.mockReset();
     addRelation.mockReset();
   });
 
@@ -73,6 +77,89 @@ describe('extension/pipeline/treesitter/javascriptImports', () => {
       './lib',
       '/workspace/src/lib.ts',
     );
+    expect(addTypeImportRelation).not.toHaveBeenCalled();
+  });
+
+  it('records top-level type-only imports as type-import relations without value bindings', () => {
+    resolveTreeSitterImportPath.mockReturnValue('/workspace/packages/plugin-api/src/index.ts');
+    getStringSpecifier.mockReturnValue('@codegraphy-vscode/plugin-api');
+    const importedBindings = new Map();
+    const relations: never[] = [];
+
+    handleJavaScriptImportStatement(
+      {
+        children: [
+          { type: 'import' },
+          { type: 'type' },
+          { type: 'import_clause' },
+          { type: 'from' },
+          { type: 'string' },
+        ],
+        namedChildren: [{ type: 'import_clause' }, { type: 'string' }],
+      } as never,
+      '/workspace/packages/plugin-typescript/src/plugin.ts',
+      relations,
+      importedBindings as never,
+    );
+
+    expect(collectImportBindings).not.toHaveBeenCalled();
+    expect(addImportRelation).not.toHaveBeenCalled();
+    expect(addTypeImportRelation).toHaveBeenCalledWith(
+      relations,
+      '/workspace/packages/plugin-typescript/src/plugin.ts',
+      '@codegraphy-vscode/plugin-api',
+      '/workspace/packages/plugin-api/src/index.ts',
+    );
+  });
+
+  it('records mixed value and type specifier imports with both edge kinds', () => {
+    resolveTreeSitterImportPath.mockReturnValue('/workspace/src/lib.ts');
+    getStringSpecifier.mockReturnValue('./lib');
+    const importedBindings = new Map();
+    const relations: never[] = [];
+
+    handleJavaScriptImportStatement(
+      {
+        children: [
+          { type: 'import' },
+          { type: 'import_clause' },
+          { type: 'from' },
+          { type: 'string' },
+        ],
+        namedChildren: [
+          {
+            type: 'import_clause',
+            namedChildren: [
+              {
+                type: 'named_imports',
+                namedChildren: [
+                  { type: 'import_specifier', text: 'type Foo' },
+                  { type: 'import_specifier', text: 'Bar' },
+                ],
+              },
+            ],
+          },
+          { type: 'string' },
+        ],
+      } as never,
+      '/workspace/src/app.ts',
+      relations,
+      importedBindings as never,
+    );
+
+    expect(collectImportBindings).toHaveBeenCalledOnce();
+    expect(addImportRelation).toHaveBeenCalledWith(
+      relations,
+      '/workspace/src/app.ts',
+      './lib',
+      '/workspace/src/lib.ts',
+    );
+    expect(addTypeImportRelation).toHaveBeenCalledWith(
+      relations,
+      '/workspace/src/app.ts',
+      './lib',
+      '/workspace/src/lib.ts',
+    );
   });
 
   it('skips import relation work when no string specifier exists', () => {
@@ -89,6 +176,7 @@ describe('extension/pipeline/treesitter/javascriptImports', () => {
     expect(resolveTreeSitterImportPath).not.toHaveBeenCalled();
     expect(collectImportBindings).not.toHaveBeenCalled();
     expect(addImportRelation).not.toHaveBeenCalled();
+    expect(addTypeImportRelation).not.toHaveBeenCalled();
   });
 
   it('adds reexport relations only when an export specifier exists', () => {

--- a/packages/extension/tests/extension/pipeline/treesitter/javascript/imports.test.ts
+++ b/packages/extension/tests/extension/pipeline/treesitter/javascript/imports.test.ts
@@ -133,7 +133,11 @@ describe('extension/pipeline/treesitter/javascriptImports', () => {
               {
                 type: 'named_imports',
                 namedChildren: [
-                  { type: 'import_specifier', text: 'type Foo' },
+                  {
+                    type: 'import_specifier',
+                    text: 'type Foo',
+                    children: [{ type: 'type' }, { type: 'identifier' }],
+                  },
                   { type: 'import_specifier', text: 'Bar' },
                 ],
               },
@@ -182,7 +186,13 @@ describe('extension/pipeline/treesitter/javascriptImports', () => {
             namedChildren: [
               {
                 type: 'named_imports',
-                namedChildren: [{ type: 'import_specifier', text: 'type Plugin' }],
+                namedChildren: [
+                  {
+                    type: 'import_specifier',
+                    text: 'type Plugin',
+                    children: [{ type: 'type' }, { type: 'identifier' }],
+                  },
+                ],
               },
             ],
           },
@@ -202,6 +212,58 @@ describe('extension/pipeline/treesitter/javascriptImports', () => {
       '@codegraphy-vscode/plugin-api',
       '/workspace/packages/plugin-api/src/index.ts',
     );
+  });
+
+  it('keeps value imports named type as regular imports', () => {
+    resolveTreeSitterImportPath.mockReturnValue('/workspace/src/lib.ts');
+    getStringSpecifier.mockReturnValue('./lib');
+    const importedBindings = new Map();
+    const relations: never[] = [];
+
+    handleJavaScriptImportStatement(
+      {
+        children: [
+          { type: 'import' },
+          { type: 'import_clause' },
+          { type: 'from' },
+          { type: 'string' },
+        ],
+        namedChildren: [
+          {
+            type: 'import_clause',
+            namedChildren: [
+              {
+                type: 'named_imports',
+                namedChildren: [
+                  {
+                    type: 'import_specifier',
+                    text: 'type as alias',
+                    children: [
+                      { type: 'identifier' },
+                      { type: 'as' },
+                      { type: 'identifier' },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          { type: 'string' },
+        ],
+      } as never,
+      '/workspace/src/app.ts',
+      relations,
+      importedBindings as never,
+    );
+
+    expect(collectImportBindings).toHaveBeenCalledOnce();
+    expect(addImportRelation).toHaveBeenCalledWith(
+      relations,
+      '/workspace/src/app.ts',
+      './lib',
+      '/workspace/src/lib.ts',
+    );
+    expect(addTypeImportRelation).not.toHaveBeenCalled();
   });
 
   it('skips import relation work when no string specifier exists', () => {

--- a/packages/extension/tests/shared/graphControls/defaults/edgeTypes.test.ts
+++ b/packages/extension/tests/shared/graphControls/defaults/edgeTypes.test.ts
@@ -22,6 +22,12 @@ describe('shared/graphControls/defaults/edgeTypes', () => {
         defaultVisible: true,
       },
       {
+        id: 'type-import',
+        label: 'Type imports',
+        defaultColor: '#38BDF8',
+        defaultVisible: false,
+      },
+      {
         id: 'reexport',
         label: 'Re-exports',
         defaultColor: '#A78BFA',

--- a/packages/plugin-api/src/graph.ts
+++ b/packages/plugin-api/src/graph.ts
@@ -25,6 +25,7 @@ export type GraphNodeShape3D =
 
 export type CoreEdgeKind =
   | 'import'
+  | 'type-import'
   | 'reexport'
   | 'call'
   | 'inherit'


### PR DESCRIPTION
## Summary

Adds a distinct `type-import` graph edge kind for TypeScript type-only imports so type relationships can be toggled independently from runtime imports.

## Details

- Classifies `import type { ... }` as `type-import` instead of `import`.
- Classifies mixed imports like `import { type Foo, bar } from './module'` as both a `type-import` and a runtime `import`.
- Keeps type-only specifiers out of imported value bindings so they do not create false call relationships.
- Adds `Type imports` as a built-in edge type, hidden by default for optional visibility.
- Extends the plugin API `CoreEdgeKind` union with `type-import`.

## Validation

- `pnpm --filter @codegraphy/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/treesitter/analyze.test.ts tests/extension/pipeline/treesitter/javascript/imports.test.ts tests/extension/pipeline/treesitter/analyze/results.test.ts tests/extension/pipeline/treesitter/import/namedBindings.test.ts tests/shared/graphControls/defaults/edgeTypes.test.ts`
- `pnpm --filter @codegraphy/extension run lint`
- `pnpm --filter @codegraphy/extension run typecheck`
- `pnpm --filter @codegraphy-vscode/plugin-api run typecheck`
- `pnpm --filter @codegraphy/extension run test`
- `pnpm run test:release`
- pre-commit hook: `pnpm run typecheck` plus lint-staged ESLint
