### PR TITLE
[codex] add monorepo import map resolution

### DIFF
--- a/.changeset/monorepo-import-map.md
+++ b/.changeset/monorepo-import-map.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy/extension": patch
+---
+
+Allow repo settings to map monorepo package imports to workspace files so type-only package imports can connect inside the graph.

--- a/packages/extension/src/extension/config/defaults.ts
+++ b/packages/extension/src/extension/config/defaults.ts
@@ -31,6 +31,8 @@ export interface ICodeGraphyConfig {
   include: string[];
   /** Whether to respect .gitignore patterns */
   respectGitignore: boolean;
+  /** Map bare import specifiers to workspace-local files or package roots */
+  monorepoImportMap: Record<string, string>;
   /** Whether to show orphan nodes (files with no connections) */
   showOrphans: boolean;
   /** How to display bidirectional connections */

--- a/packages/extension/src/extension/config/reader.ts
+++ b/packages/extension/src/extension/config/reader.ts
@@ -65,6 +65,14 @@ export class Configuration {
   }
 
   /**
+   * Bare import specifiers mapped to workspace-local files or package roots.
+   * @default {}
+   */
+  get monorepoImportMap(): Record<string, string> {
+    return this.config.get<Record<string, string>>('monorepoImportMap', {});
+  }
+
+  /**
    * Whether to show orphan nodes (files with no imports and not imported by others).
    * @default true
    */
@@ -147,6 +155,7 @@ export class Configuration {
       maxFiles: this.maxFiles,
       include: this.include,
       respectGitignore: this.respectGitignore,
+      monorepoImportMap: this.monorepoImportMap,
       showOrphans: this.showOrphans,
       bidirectionalEdges: this.bidirectionalEdges,
       plugins: this.plugins,

--- a/packages/extension/src/extension/pipeline/graph/build.ts
+++ b/packages/extension/src/extension/pipeline/graph/build.ts
@@ -1,6 +1,7 @@
 import type { IProjectedConnection, IPlugin } from '../../../core/plugins/types/contracts';
 import type { IGraphData } from '../../../shared/graph/contracts';
 import { buildWorkspaceGraphData } from './data';
+import type { MonorepoImportMap } from './monorepoImportMap/resolve';
 
 const VISITS_KEY = 'codegraphy.fileVisits';
 
@@ -25,6 +26,7 @@ export interface WorkspacePipelineGraphDependencies {
   disabledPlugins: ReadonlySet<string>;
   fileConnections: ReadonlyMap<string, IProjectedConnection[]>;
   getPluginForFile: (absolutePath: string) => IPlugin | undefined;
+  monorepoImportMap?: MonorepoImportMap;
   showOrphans: boolean;
   workspaceRoot: string;
   workspaceState: WorkspacePipelineGraphWorkspaceState;
@@ -42,6 +44,7 @@ export function buildWorkspacePipelineGraph(
     fileConnections: dependencies.fileConnections,
     showOrphans: dependencies.showOrphans,
     visitCounts,
+    monorepoImportMap: dependencies.monorepoImportMap ?? {},
     workspaceRoot: dependencies.workspaceRoot,
     getPluginForFile: dependencies.getPluginForFile,
   });
@@ -53,12 +56,14 @@ export function buildWorkspacePipelineGraphForSource(
   workspaceRoot: string,
   showOrphans: boolean,
   disabledPlugins: Set<string>,
+  monorepoImportMap: MonorepoImportMap = {},
 ): IGraphData {
   return buildWorkspacePipelineGraph({
     cacheFiles: source._cache.files,
     disabledPlugins,
     fileConnections,
     getPluginForFile: absolutePath => source._registry.getPluginForFile(absolutePath),
+    monorepoImportMap,
     showOrphans,
     workspaceRoot,
     workspaceState: source._context.workspaceState,

--- a/packages/extension/src/extension/pipeline/graph/data.ts
+++ b/packages/extension/src/extension/pipeline/graph/data.ts
@@ -7,11 +7,13 @@ import type { IProjectedConnection, IPlugin } from '../../../core/plugins/types/
 import type { IGraphData } from '../../../shared/graph/contracts';
 import { buildWorkspaceGraphEdges } from './edges';
 import { buildWorkspaceGraphNodes } from './nodes';
+import type { MonorepoImportMap } from './monorepoImportMap/resolve';
 
 export interface IWorkspaceGraphDataOptions {
   cacheFiles: Record<string, { size?: number }>;
   disabledPlugins: ReadonlySet<string>;
   fileConnections: ReadonlyMap<string, IProjectedConnection[]>;
+  monorepoImportMap?: MonorepoImportMap;
   showOrphans: boolean;
   visitCounts: Record<string, number>;
   workspaceRoot: string;
@@ -25,6 +27,7 @@ export function buildWorkspaceGraphData(options: IWorkspaceGraphDataOptions): IG
     fileConnections,
     showOrphans,
     visitCounts,
+    monorepoImportMap = {},
     workspaceRoot,
     getPluginForFile,
   } = options;
@@ -33,6 +36,7 @@ export function buildWorkspaceGraphData(options: IWorkspaceGraphDataOptions): IG
     disabledPlugins,
     fileConnections,
     getPluginForFile,
+    monorepoImportMap,
     workspaceRoot,
   });
   const nodes = buildWorkspaceGraphNodes({

--- a/packages/extension/src/extension/pipeline/graph/edgeTargets.ts
+++ b/packages/extension/src/extension/pipeline/graph/edgeTargets.ts
@@ -2,16 +2,31 @@ import * as path from 'path';
 import type { IProjectedConnection, IPlugin } from '../../../core/plugins/types/contracts';
 import { isExternalPackageSpecifier } from './packageSpecifiers/match';
 import { getExternalPackageNodeId } from './packageSpecifiers/nodeId';
+import {
+  resolveMonorepoImportMapTargetId,
+  type MonorepoImportMap,
+} from './monorepoImportMap/resolve';
 
 export function getConnectionTargetId(
   _plugin: IPlugin | undefined,
   connection: IProjectedConnection,
   fileConnections: ReadonlyMap<string, IProjectedConnection[]>,
   workspaceRoot: string,
+  monorepoImportMap: MonorepoImportMap = {},
 ): string | null {
   if (connection.resolvedPath) {
     const targetRelative = path.relative(workspaceRoot, connection.resolvedPath);
     return fileConnections.has(targetRelative) ? targetRelative : null;
+  }
+
+  const mappedTargetId = resolveMonorepoImportMapTargetId(
+    connection.specifier,
+    monorepoImportMap,
+    fileConnections,
+    workspaceRoot,
+  );
+  if (mappedTargetId) {
+    return mappedTargetId;
   }
 
   return isExternalPackageSpecifier(connection.specifier)

--- a/packages/extension/src/extension/pipeline/graph/edges.ts
+++ b/packages/extension/src/extension/pipeline/graph/edges.ts
@@ -9,11 +9,13 @@ import type { IGraphEdge } from '../../../shared/graph/contracts';
 import { createGraphEdgeId } from '../../../shared/graph/edgeIdentity';
 import { createEdgeSource } from './edgeSources';
 import { getConnectionTargetId } from './edgeTargets';
+import type { MonorepoImportMap } from './monorepoImportMap/resolve';
 
 export interface IWorkspaceGraphEdgesOptions {
   disabledPlugins: ReadonlySet<string>;
   fileConnections: ReadonlyMap<string, IProjectedConnection[]>;
   getPluginForFile: (absolutePath: string) => IPlugin | undefined;
+  monorepoImportMap?: MonorepoImportMap;
   workspaceRoot: string;
 }
 
@@ -43,6 +45,7 @@ function appendConnectionEdge(
     edgeMap: Map<string, IGraphEdge>;
     edges: IGraphEdge[];
     fileConnections: ReadonlyMap<string, IProjectedConnection[]>;
+    monorepoImportMap: MonorepoImportMap;
     nodeIds: Set<string>;
     plugin: IPlugin | undefined;
     workspaceRoot: string;
@@ -58,6 +61,7 @@ function appendConnectionEdge(
     connection,
     options.fileConnections,
     options.workspaceRoot,
+    options.monorepoImportMap,
   );
   if (!targetId) {
     return;
@@ -100,6 +104,7 @@ export function buildWorkspaceGraphEdges(
     disabledPlugins,
     fileConnections,
     getPluginForFile,
+    monorepoImportMap = {},
     workspaceRoot,
   } = options;
 
@@ -120,6 +125,7 @@ export function buildWorkspaceGraphEdges(
         edgeMap,
         edges,
         fileConnections,
+        monorepoImportMap,
         nodeIds,
         plugin,
         workspaceRoot,

--- a/packages/extension/src/extension/pipeline/graph/monorepoImportMap/resolve.ts
+++ b/packages/extension/src/extension/pipeline/graph/monorepoImportMap/resolve.ts
@@ -1,0 +1,162 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export type MonorepoImportMap = Record<string, string>;
+
+const IMPORT_RESOLUTION_EXTENSIONS = [
+  '',
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+] as const;
+
+interface MatchedMonorepoImport {
+  mappedPath: string;
+  packageName: string;
+  subpath: string;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeRelativePath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}
+
+function toWorkspaceRelativePath(workspaceRoot: string, absolutePath: string): string | null {
+  const relativePath = path.relative(workspaceRoot, absolutePath);
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return normalizeRelativePath(relativePath);
+}
+
+function resolveConfiguredPath(workspaceRoot: string, configuredPath: string): string {
+  return path.isAbsolute(configuredPath)
+    ? configuredPath
+    : path.resolve(workspaceRoot, configuredPath);
+}
+
+function findMappedImport(
+  specifier: string,
+  monorepoImportMap: MonorepoImportMap,
+): MatchedMonorepoImport | null {
+  return Object.entries(monorepoImportMap)
+    .filter(([packageName, mappedPath]) =>
+      typeof mappedPath === 'string'
+      && mappedPath.length > 0
+      && (specifier === packageName || specifier.startsWith(`${packageName}/`)))
+    .sort(([left], [right]) => right.length - left.length)
+    .map(([packageName, mappedPath]) => ({
+      mappedPath,
+      packageName,
+      subpath: specifier === packageName ? '' : specifier.slice(packageName.length + 1),
+    }))
+    .at(0) ?? null;
+}
+
+function collectPackageExportCandidates(value: unknown, candidates: string[]): void {
+  if (typeof value === 'string') {
+    candidates.push(value);
+    return;
+  }
+
+  if (!isPlainRecord(value)) {
+    return;
+  }
+
+  for (const field of ['types', 'typings', 'import', 'require', 'node', 'default']) {
+    collectPackageExportCandidates(value[field], candidates);
+  }
+}
+
+function readPackageEntryCandidates(packageRoot: string, subpath: string): string[] {
+  const packageJsonPath = path.join(packageRoot, 'package.json');
+  if (!fs.existsSync(packageJsonPath) || !fs.statSync(packageJsonPath).isFile()) {
+    return [];
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as unknown;
+    if (!isPlainRecord(packageJson)) {
+      return [];
+    }
+
+    const candidates: string[] = [];
+    const exportsField = packageJson.exports;
+    const exportKey = subpath ? `./${subpath}` : '.';
+    if (isPlainRecord(exportsField)) {
+      collectPackageExportCandidates(exportsField[exportKey], candidates);
+    }
+
+    if (subpath.length === 0) {
+      for (const field of ['types', 'typings', 'module', 'main']) {
+        const value = packageJson[field];
+        if (typeof value === 'string') {
+          candidates.push(value);
+        }
+      }
+    }
+
+    return candidates.map(candidate => path.resolve(packageRoot, candidate));
+  } catch {
+    return [];
+  }
+}
+
+function createFilePathCandidates(basePath: string): string[] {
+  const candidates: string[] = [];
+
+  for (const extension of IMPORT_RESOLUTION_EXTENSIONS) {
+    candidates.push(`${basePath}${extension}`);
+  }
+
+  for (const extension of IMPORT_RESOLUTION_EXTENSIONS.slice(1)) {
+    candidates.push(path.join(basePath, `index${extension}`));
+  }
+
+  return candidates;
+}
+
+function createMappedPathCandidates(
+  workspaceRoot: string,
+  match: MatchedMonorepoImport,
+): string[] {
+  const mappedBasePath = resolveConfiguredPath(workspaceRoot, match.mappedPath);
+  const basePath = match.subpath
+    ? path.join(mappedBasePath, match.subpath)
+    : mappedBasePath;
+
+  return [
+    ...readPackageEntryCandidates(mappedBasePath, match.subpath),
+    ...createFilePathCandidates(basePath),
+  ];
+}
+
+export function resolveMonorepoImportMapTargetId(
+  specifier: string,
+  monorepoImportMap: MonorepoImportMap,
+  fileConnections: ReadonlyMap<string, unknown>,
+  workspaceRoot: string,
+): string | null {
+  const match = findMappedImport(specifier, monorepoImportMap);
+  if (!match) {
+    return null;
+  }
+
+  for (const candidate of createMappedPathCandidates(workspaceRoot, match)) {
+    const targetRelative = toWorkspaceRelativePath(workspaceRoot, candidate);
+    if (targetRelative && fileConnections.has(targetRelative)) {
+      return targetRelative;
+    }
+  }
+
+  return null;
+}

--- a/packages/extension/src/extension/pipeline/service/base/internal.ts
+++ b/packages/extension/src/extension/pipeline/service/base/internal.ts
@@ -81,6 +81,7 @@ export abstract class WorkspacePipelineInternalBase extends WorkspacePipelineSta
       workspaceRoot,
       showOrphans,
       disabledPlugins,
+      this._config.monorepoImportMap,
     );
   }
 
@@ -98,6 +99,7 @@ export abstract class WorkspacePipelineInternalBase extends WorkspacePipelineSta
       workspaceRoot,
       showOrphans,
       disabledPlugins,
+      this._config.monorepoImportMap,
     );
   }
 

--- a/packages/extension/src/extension/pipeline/service/runtime/graph.ts
+++ b/packages/extension/src/extension/pipeline/service/runtime/graph.ts
@@ -3,6 +3,7 @@ import type { IFileAnalysisResult, IProjectedConnection } from '../../../../core
 import type { PluginRegistry } from '../../../../core/plugins/registry/manager';
 import type { IGraphData } from '../../../../shared/graph/contracts';
 import type { IWorkspaceAnalysisCache } from '../../cache';
+import type { MonorepoImportMap } from '../../graph/monorepoImportMap/resolve';
 import { projectConnectionMapFromFileAnalysis } from '../../projection';
 import { buildWorkspacePipelineGraphData } from '../../serviceAdapters';
 
@@ -14,6 +15,7 @@ export function buildWorkspacePipelineGraph(
   workspaceRoot: string,
   showOrphans: boolean,
   disabledPlugins: Set<string>,
+  monorepoImportMap: MonorepoImportMap = {},
 ): IGraphData {
   return buildWorkspacePipelineGraphData(
     cache,
@@ -23,6 +25,7 @@ export function buildWorkspacePipelineGraph(
     workspaceRoot,
     showOrphans,
     disabledPlugins,
+    monorepoImportMap,
   );
 }
 
@@ -34,6 +37,7 @@ export function buildWorkspacePipelineGraphFromAnalysis(
   workspaceRoot: string,
   showOrphans: boolean,
   disabledPlugins: Set<string>,
+  monorepoImportMap: MonorepoImportMap = {},
 ): IGraphData {
   return buildWorkspacePipelineGraph(
     cache,
@@ -43,5 +47,6 @@ export function buildWorkspacePipelineGraphFromAnalysis(
     workspaceRoot,
     showOrphans,
     disabledPlugins,
+    monorepoImportMap,
   );
 }

--- a/packages/extension/src/extension/pipeline/serviceAdapters.ts
+++ b/packages/extension/src/extension/pipeline/serviceAdapters.ts
@@ -7,6 +7,7 @@ import type { IProjectedConnection } from '../../core/plugins/types/contracts';
 import type { IGraphData } from '../../shared/graph/contracts';
 import type { IWorkspaceAnalysisCache } from './cache';
 import type { IWorkspaceFileAnalysisResult } from './fileAnalysis';
+import type { MonorepoImportMap } from './graph/monorepoImportMap/resolve';
 import {
   analyzeWorkspacePipelineSourceFiles,
   type WorkspacePipelineFilesSource,
@@ -79,6 +80,7 @@ export function buildWorkspacePipelineGraphData(
   workspaceRoot: string,
   showOrphans: boolean,
   disabledPlugins: Set<string> = new Set(),
+  monorepoImportMap: MonorepoImportMap = {},
 ): IGraphData {
   const source: WorkspacePipelineGraphSource = {
     _cache: cache,
@@ -92,6 +94,7 @@ export function buildWorkspacePipelineGraphData(
     workspaceRoot,
     showOrphans,
     disabledPlugins,
+    monorepoImportMap,
   );
 }
 

--- a/packages/extension/src/extension/repoSettings/defaults.ts
+++ b/packages/extension/src/extension/repoSettings/defaults.ts
@@ -13,6 +13,7 @@ export interface ICodeGraphyRepoSettings {
   maxFiles: number;
   include: string[];
   respectGitignore: boolean;
+  monorepoImportMap: Record<string, string>;
   showOrphans: boolean;
   plugins: string[];
   pluginOrder: string[];
@@ -54,6 +55,7 @@ export function createDefaultCodeGraphyRepoSettings(): ICodeGraphyRepoSettings {
     maxFiles: 500,
     include: ['**/*'],
     respectGitignore: true,
+    monorepoImportMap: {},
     showOrphans: true,
     plugins: [],
     pluginOrder: [],

--- a/packages/extension/src/extension/repoSettings/signatures.ts
+++ b/packages/extension/src/extension/repoSettings/signatures.ts
@@ -39,6 +39,7 @@ function createStableListSettings(settings: Partial<ICodeGraphyRepoSettings>) {
   return {
     include: settings.include ?? [],
     filterPatterns: settings.filterPatterns ?? [],
+    monorepoImportMap: sortRecord(settings.monorepoImportMap ?? {}),
     pluginOrder: settings.pluginOrder ?? [],
   };
 }

--- a/packages/extension/tests/extension/config/configuration.test.ts
+++ b/packages/extension/tests/extension/config/configuration.test.ts
@@ -116,6 +116,7 @@ describe('Configuration', () => {
         maxFiles: 500,
         include: ['**/*'],
         respectGitignore: true,
+        monorepoImportMap: {},
         showOrphans: true,
         bidirectionalEdges: 'separate',
         plugins: [],

--- a/packages/extension/tests/extension/pipeline/graph/build.test.ts
+++ b/packages/extension/tests/extension/pipeline/graph/build.test.ts
@@ -35,6 +35,7 @@ describe('pipeline/graph', () => {
       disabledPlugins: new Set<string>(['plugin.python']),
       fileConnections: new Map([['src/index.ts', []]]),
       getPluginForFile: expect.any(Function),
+      monorepoImportMap: {},
       showOrphans: true,
       visitCounts: { 'src/index.ts': 3 },
       workspaceRoot: '/workspace',

--- a/packages/extension/tests/extension/pipeline/graph/edgeTargets.test.ts
+++ b/packages/extension/tests/extension/pipeline/graph/edgeTargets.test.ts
@@ -93,4 +93,25 @@ describe('pipeline/graph/edgeTargets', () => {
       ),
     ).toBe('pkg:@scope/pkg');
   });
+
+  it('resolves unresolved bare package imports through the configured monorepo map', () => {
+    const connection: IProjectedConnection = {
+      kind: 'type-import',
+      resolvedPath: null,
+      sourceId: 'type-import',
+      specifier: '@codegraphy-vscode/plugin-api',
+    };
+
+    expect(
+      getConnectionTargetId(
+        createPlugin('codegraphy.treesitter'),
+        connection,
+        new Map([['packages/plugin-api/src/index.ts', []]]),
+        '/workspace',
+        {
+          '@codegraphy-vscode/plugin-api': 'packages/plugin-api/src/index.ts',
+        },
+      ),
+    ).toBe('packages/plugin-api/src/index.ts');
+  });
 });

--- a/packages/extension/tests/extension/pipeline/graph/monorepoImportMap/resolve.test.ts
+++ b/packages/extension/tests/extension/pipeline/graph/monorepoImportMap/resolve.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveMonorepoImportMapTargetId } from '../../../../../src/extension/pipeline/graph/monorepoImportMap/resolve';
+
+const tempRoots = new Set<string>();
+
+function createWorkspaceRoot(): string {
+  const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraphy-monorepo-map-'));
+  tempRoots.add(workspaceRoot);
+  return workspaceRoot;
+}
+
+function writeWorkspaceFile(workspaceRoot: string, relativePath: string, contents = ''): string {
+  const absolutePath = path.join(workspaceRoot, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents, 'utf8');
+  return absolutePath;
+}
+
+afterEach(() => {
+  for (const workspaceRoot of tempRoots) {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+  tempRoots.clear();
+});
+
+describe('pipeline/graph/monorepoImportMap/resolve', () => {
+  it('maps an exact bare import specifier to a discovered workspace file', () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const fileConnections = new Map([['packages/plugin-api/src/index.ts', []]]);
+
+    expect(
+      resolveMonorepoImportMapTargetId(
+        '@codegraphy-vscode/plugin-api',
+        {
+          '@codegraphy-vscode/plugin-api': 'packages/plugin-api/src/index.ts',
+        },
+        fileConnections,
+        workspaceRoot,
+      ),
+    ).toBe('packages/plugin-api/src/index.ts');
+  });
+
+  it('maps a package root through package.json type exports', () => {
+    const workspaceRoot = createWorkspaceRoot();
+    writeWorkspaceFile(
+      workspaceRoot,
+      'packages/plugin-api/package.json',
+      JSON.stringify({
+        name: '@codegraphy-vscode/plugin-api',
+        exports: {
+          '.': {
+            types: './src/index.ts',
+          },
+        },
+      }),
+    );
+    writeWorkspaceFile(workspaceRoot, 'packages/plugin-api/src/index.ts', 'export interface Plugin {}\n');
+    const fileConnections = new Map([['packages/plugin-api/src/index.ts', []]]);
+
+    expect(
+      resolveMonorepoImportMapTargetId(
+        '@codegraphy-vscode/plugin-api',
+        {
+          '@codegraphy-vscode/plugin-api': 'packages/plugin-api',
+        },
+        fileConnections,
+        workspaceRoot,
+      ),
+    ).toBe('packages/plugin-api/src/index.ts');
+  });
+
+  it('maps package subpaths through package.json type exports', () => {
+    const workspaceRoot = createWorkspaceRoot();
+    writeWorkspaceFile(
+      workspaceRoot,
+      'packages/plugin-api/package.json',
+      JSON.stringify({
+        name: '@codegraphy-vscode/plugin-api',
+        exports: {
+          './events': {
+            types: './src/events.ts',
+          },
+        },
+      }),
+    );
+    writeWorkspaceFile(workspaceRoot, 'packages/plugin-api/src/events.ts', 'export interface Event {}\n');
+    const fileConnections = new Map([['packages/plugin-api/src/events.ts', []]]);
+
+    expect(
+      resolveMonorepoImportMapTargetId(
+        '@codegraphy-vscode/plugin-api/events',
+        {
+          '@codegraphy-vscode/plugin-api': 'packages/plugin-api',
+        },
+        fileConnections,
+        workspaceRoot,
+      ),
+    ).toBe('packages/plugin-api/src/events.ts');
+  });
+
+  it('uses the longest matching map entry for package subpaths', () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const fileConnections = new Map([
+      ['packages/plugin-api/src/index.ts', []],
+      ['packages/plugin-api/src/events.ts', []],
+    ]);
+
+    expect(
+      resolveMonorepoImportMapTargetId(
+        '@codegraphy-vscode/plugin-api/events',
+        {
+          '@codegraphy-vscode/plugin-api': 'packages/plugin-api/src',
+          '@codegraphy-vscode/plugin-api/events': 'packages/plugin-api/src/events.ts',
+        },
+        fileConnections,
+        workspaceRoot,
+      ),
+    ).toBe('packages/plugin-api/src/events.ts');
+  });
+
+  it('returns null for unmapped specifiers and mapped files outside the workspace graph', () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const externalRoot = createWorkspaceRoot();
+    writeWorkspaceFile(externalRoot, 'plugin-api/src/index.ts', 'export interface Plugin {}\n');
+
+    expect(
+      resolveMonorepoImportMapTargetId(
+        'react',
+        {
+          '@codegraphy-vscode/plugin-api': 'packages/plugin-api/src/index.ts',
+        },
+        new Map(),
+        workspaceRoot,
+      ),
+    ).toBeNull();
+    expect(
+      resolveMonorepoImportMapTargetId(
+        '@codegraphy-vscode/plugin-api',
+        {
+          '@codegraphy-vscode/plugin-api': path.join(externalRoot, 'plugin-api/src/index.ts'),
+        },
+        new Map([['packages/plugin-api/src/index.ts', []]]),
+        workspaceRoot,
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/extension/tests/extension/pipeline/service/base/internal.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/base/internal.test.ts
@@ -92,6 +92,9 @@ class TestInternalBase extends WorkspacePipelineInternalBase {
 
   _config = {
     getAll: vi.fn(() => ({ pluginOrder: ['plugin.a', 'plugin.b'] })),
+    monorepoImportMap: {
+      '@codegraphy-vscode/plugin-api': 'packages/plugin-api/src/index.ts',
+    },
   } as unknown as Configuration;
 
   _registry = {
@@ -309,6 +312,9 @@ describe('extension/pipeline/service/internalBase', () => {
       '/workspace',
       true,
       disabledPlugins,
+      {
+        '@codegraphy-vscode/plugin-api': 'packages/plugin-api/src/index.ts',
+      },
     );
 
     expect(
@@ -330,6 +336,9 @@ describe('extension/pipeline/service/internalBase', () => {
       '/workspace',
       false,
       disabledPlugins,
+      {
+        '@codegraphy-vscode/plugin-api': 'packages/plugin-api/src/index.ts',
+      },
     );
   });
 

--- a/packages/extension/tests/extension/repoSettings/defaults.test.ts
+++ b/packages/extension/tests/extension/repoSettings/defaults.test.ts
@@ -15,6 +15,7 @@ describe('extension/repoSettings/defaults', () => {
       maxFiles: 500,
       include: ['**/*'],
       respectGitignore: true,
+      monorepoImportMap: {},
       showOrphans: true,
       plugins: [],
       pluginOrder: [],
@@ -58,6 +59,7 @@ describe('extension/repoSettings/defaults', () => {
     expect(second).toEqual(first);
     expect(second).not.toBe(first);
     expect(second.include).not.toBe(first.include);
+    expect(second.monorepoImportMap).not.toBe(first.monorepoImportMap);
     expect(second.plugins).not.toBe(first.plugins);
     expect(second.pluginOrder).not.toBe(first.pluginOrder);
     expect(second.disabledPlugins).not.toBe(first.disabledPlugins);

--- a/packages/extension/tests/extension/repoSettings/signatures.test.ts
+++ b/packages/extension/tests/extension/repoSettings/signatures.test.ts
@@ -62,6 +62,9 @@ describe('extension/repoSettings/signatures', () => {
     changed.maxFiles = 900;
     changed.include = ['src/**/*.ts'];
     changed.filterPatterns = ['**/*.png'];
+    changed.monorepoImportMap = {
+      '@codegraphy-vscode/plugin-api': 'packages/plugin-api/src/index.ts',
+    };
     changed.pluginOrder = ['codegraphy.typescript'];
 
     expect(createCodeGraphySettingsSignature(changed)).not.toBe(
@@ -77,6 +80,7 @@ describe('extension/repoSettings/signatures', () => {
       depthLimit: 1,
       include: [],
       filterPatterns: [],
+      monorepoImportMap: [],
       pluginOrder: [],
       nodeVisibility: [],
       edgeVisibility: [],
@@ -91,6 +95,9 @@ describe('extension/repoSettings/signatures', () => {
       depthLimit: 4,
       include: ['src/**/*.ts'],
       filterPatterns: ['**/*.png'],
+      monorepoImportMap: {
+        '@codegraphy-vscode/plugin-api': 'packages/plugin-api/src/index.ts',
+      },
       pluginOrder: ['codegraphy.typescript'],
       nodeVisibility: { package: false, file: true },
       edgeVisibility: { import: false, call: true },
@@ -101,6 +108,9 @@ describe('extension/repoSettings/signatures', () => {
       depthLimit: 4,
       include: ['src/**/*.ts'],
       filterPatterns: ['**/*.png'],
+      monorepoImportMap: [
+        ['@codegraphy-vscode/plugin-api', 'packages/plugin-api/src/index.ts'],
+      ],
       pluginOrder: ['codegraphy.typescript'],
       nodeVisibility: [
         ['file', true],


### PR DESCRIPTION
## Summary
- add optional `monorepoImportMap` repo setting for `.codegraphy/settings.json`
- resolve unmapped bare package imports through that map before creating external package nodes
- support direct file maps, package-root maps via `package.json` root exports/types, and package subpath exports

Example:

```json
{
  "monorepoImportMap": {
    "@codegraphy-vscode/plugin-api": "packages/plugin-api"
  }
}
```

That allows `import type { IPlugin } from '@codegraphy-vscode/plugin-api';` to connect to the discovered workspace file instead of falling back to `pkg:@codegraphy-vscode/plugin-api`.

## Validation
- `pnpm --filter @codegraphy/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/graph/monorepoImportMap/resolve.test.ts`
- `pnpm --filter @codegraphy/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/graph tests/extension/pipeline/serviceAdapters.test.ts tests/extension/pipeline/service/base/internal.test.ts tests/extension/config/configReaders.test.ts tests/extension/config/configuration.test.ts tests/extension/repoSettings`
- `pnpm --filter @codegraphy/extension typecheck`
- `pnpm --filter @codegraphy/extension lint`
- `pnpm run test`