### PR TITLE
[codex] connect local package imports to package nodes

### DIFF
--- a/.changeset/local-package-nodes.md
+++ b/.changeset/local-package-nodes.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy/extension": patch
+---
+
+Connect imports of locally discovered workspace packages to the matching package node instead of creating a separate external package node.

--- a/examples/example-typescript/packages/app/package.json
+++ b/examples/example-typescript/packages/app/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@codegraphy/example-app",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@codegraphy/example-shared": "workspace:*"
+  }
 }

--- a/examples/example-typescript/packages/app/src/index.ts
+++ b/examples/example-typescript/packages/app/src/index.ts
@@ -1,5 +1,5 @@
-import { formatUser } from '../../shared/src/types';
-import type { UserName } from '../../shared/src/types';
+import { formatUser } from '@codegraphy/example-shared';
+import type { UserName } from '@codegraphy/example-shared';
 import { buildGreeting } from './utils';
 
 const currentUser: UserName = formatUser('CodeGraphy');

--- a/examples/example-typescript/packages/shared/package.json
+++ b/examples/example-typescript/packages/shared/package.json
@@ -1,4 +1,11 @@
 {
   "name": "@codegraphy/example-shared",
-  "private": true
+  "private": true,
+  "exports": {
+    ".": {
+      "types": "./src/types.ts",
+      "default": "./src/types.ts"
+    }
+  },
+  "types": "src/types.ts"
 }

--- a/packages/extension/src/extension/pipeline/graph/data.ts
+++ b/packages/extension/src/extension/pipeline/graph/data.ts
@@ -7,6 +7,7 @@ import type { IProjectedConnection, IPlugin } from '../../../core/plugins/types/
 import type { IGraphData } from '../../../shared/graph/contracts';
 import { buildWorkspaceGraphEdges } from './edges';
 import { buildWorkspaceGraphNodes } from './nodes';
+import { buildWorkspacePackageRegistry } from './workspacePackages/registry';
 
 export interface IWorkspaceGraphDataOptions {
   cacheFiles: Record<string, { size?: number }>;
@@ -28,12 +29,14 @@ export function buildWorkspaceGraphData(options: IWorkspaceGraphDataOptions): IG
     workspaceRoot,
     getPluginForFile,
   } = options;
+  const workspacePackages = buildWorkspacePackageRegistry(fileConnections.keys(), workspaceRoot);
 
   const { connectedIds, edges, nodeIds } = buildWorkspaceGraphEdges({
     disabledPlugins,
     fileConnections,
     getPluginForFile,
     workspaceRoot,
+    workspacePackages,
   });
   const nodes = buildWorkspaceGraphNodes({
     cacheFiles,

--- a/packages/extension/src/extension/pipeline/graph/edgeTargets.ts
+++ b/packages/extension/src/extension/pipeline/graph/edgeTargets.ts
@@ -1,17 +1,26 @@
 import * as path from 'path';
 import type { IProjectedConnection, IPlugin } from '../../../core/plugins/types/contracts';
 import { isExternalPackageSpecifier } from './packageSpecifiers/match';
+import { getExternalPackageName } from './packageSpecifiers/name';
 import { getExternalPackageNodeId } from './packageSpecifiers/nodeId';
+import type { WorkspacePackageRegistry } from './workspacePackages/registry';
 
 export function getConnectionTargetId(
   _plugin: IPlugin | undefined,
   connection: IProjectedConnection,
   fileConnections: ReadonlyMap<string, IProjectedConnection[]>,
   workspaceRoot: string,
+  workspacePackages: WorkspacePackageRegistry = new Map(),
 ): string | null {
   if (connection.resolvedPath) {
     const targetRelative = path.relative(workspaceRoot, connection.resolvedPath);
     return fileConnections.has(targetRelative) ? targetRelative : null;
+  }
+
+  const packageName = getExternalPackageName(connection.specifier);
+  const workspacePackage = packageName ? workspacePackages.get(packageName) : undefined;
+  if (workspacePackage) {
+    return workspacePackage.nodeId;
   }
 
   return isExternalPackageSpecifier(connection.specifier)

--- a/packages/extension/src/extension/pipeline/graph/edges.ts
+++ b/packages/extension/src/extension/pipeline/graph/edges.ts
@@ -9,12 +9,14 @@ import type { IGraphEdge } from '../../../shared/graph/contracts';
 import { createGraphEdgeId } from '../../../shared/graph/edgeIdentity';
 import { createEdgeSource } from './edgeSources';
 import { getConnectionTargetId } from './edgeTargets';
+import type { WorkspacePackageRegistry } from './workspacePackages/registry';
 
 export interface IWorkspaceGraphEdgesOptions {
   disabledPlugins: ReadonlySet<string>;
   fileConnections: ReadonlyMap<string, IProjectedConnection[]>;
   getPluginForFile: (absolutePath: string) => IPlugin | undefined;
   workspaceRoot: string;
+  workspacePackages?: WorkspacePackageRegistry;
 }
 
 export interface IWorkspaceGraphEdgeBuildResult {
@@ -46,6 +48,7 @@ function appendConnectionEdge(
     nodeIds: Set<string>;
     plugin: IPlugin | undefined;
     workspaceRoot: string;
+    workspacePackages: WorkspacePackageRegistry;
   },
 ): void {
   const sourcePluginId = connection.pluginId ?? options.plugin?.id;
@@ -58,6 +61,7 @@ function appendConnectionEdge(
     connection,
     options.fileConnections,
     options.workspaceRoot,
+    options.workspacePackages,
   );
   if (!targetId) {
     return;
@@ -101,6 +105,7 @@ export function buildWorkspaceGraphEdges(
     fileConnections,
     getPluginForFile,
     workspaceRoot,
+    workspacePackages = new Map(),
   } = options;
 
   const connectedIds = new Set<string>();
@@ -123,6 +128,7 @@ export function buildWorkspaceGraphEdges(
         nodeIds,
         plugin,
         workspaceRoot,
+        workspacePackages,
       });
     }
   }

--- a/packages/extension/src/extension/pipeline/graph/nodes.ts
+++ b/packages/extension/src/extension/pipeline/graph/nodes.ts
@@ -8,6 +8,11 @@ import { DEFAULT_NODE_COLOR } from '../../../shared/fileColors';
 import type { IGraphNode } from '../../../shared/graph/contracts';
 import { DEFAULT_PACKAGE_NODE_COLOR } from '../../../shared/fileColors';
 import {
+  getWorkspacePackageLabel,
+  getWorkspacePackageRootFromNodeId,
+  isWorkspacePackageNodeId,
+} from '../../../shared/graphControls/packages/workspace';
+import {
   getExternalPackageLabelFromNodeId,
   isExternalPackageNodeId,
 } from './packageSpecifiers/nodeId';
@@ -35,6 +40,19 @@ export function buildWorkspaceGraphNodes(
 
   for (const filePath of nodeIds) {
     if (!showOrphans && !connectedIds.has(filePath)) {
+      continue;
+    }
+
+    if (isWorkspacePackageNodeId(filePath)) {
+      nodes.push({
+        id: filePath,
+        label: getWorkspacePackageLabel(getWorkspacePackageRootFromNodeId(filePath)),
+        color: DEFAULT_PACKAGE_NODE_COLOR,
+        nodeType: 'package',
+        shape2D: 'hexagon',
+        shape3D: 'cube',
+        accessCount: 0,
+      });
       continue;
     }
 

--- a/packages/extension/src/extension/pipeline/graph/packageSpecifiers/nodeId.ts
+++ b/packages/extension/src/extension/pipeline/graph/packageSpecifiers/nodeId.ts
@@ -1,4 +1,5 @@
 import { getExternalPackageName } from './name';
+import { isWorkspacePackageNodeId } from '../../../../shared/graphControls/packages/workspace';
 
 export const PACKAGE_NODE_ID_PREFIX = 'pkg:';
 
@@ -8,7 +9,7 @@ export function getExternalPackageNodeId(specifier: string): string | null {
 }
 
 export function isExternalPackageNodeId(nodeId: string): boolean {
-  return nodeId.startsWith(PACKAGE_NODE_ID_PREFIX);
+  return nodeId.startsWith(PACKAGE_NODE_ID_PREFIX) && !isWorkspacePackageNodeId(nodeId);
 }
 
 export function getExternalPackageLabelFromNodeId(nodeId: string): string {

--- a/packages/extension/src/extension/pipeline/graph/workspacePackages/registry.ts
+++ b/packages/extension/src/extension/pipeline/graph/workspacePackages/registry.ts
@@ -1,0 +1,56 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getWorkspacePackageNodeId } from '../../../../shared/graphControls/packages/workspace';
+import {
+  getWorkspacePackageRootFromManifest,
+  isWorkspacePackageManifestPath,
+} from '../../../../shared/graphControls/packages/roots';
+
+export interface WorkspacePackageInfo {
+  name: string;
+  nodeId: string;
+  rootPath: string;
+}
+
+export type WorkspacePackageRegistry = ReadonlyMap<string, WorkspacePackageInfo>;
+
+function readPackageName(manifestPath: string): string | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as unknown;
+    if (
+      typeof parsed !== 'object'
+      || parsed === null
+      || Array.isArray(parsed)
+      || typeof (parsed as { name?: unknown }).name !== 'string'
+    ) {
+      return null;
+    }
+
+    return (parsed as { name: string }).name;
+  } catch {
+    return null;
+  }
+}
+
+export function buildWorkspacePackageRegistry(
+  filePaths: Iterable<string>,
+  workspaceRoot: string,
+): WorkspacePackageRegistry {
+  const registry = new Map<string, WorkspacePackageInfo>();
+
+  for (const filePath of [...filePaths].filter(isWorkspacePackageManifestPath).sort()) {
+    const name = readPackageName(path.join(workspaceRoot, filePath));
+    if (!name || registry.has(name)) {
+      continue;
+    }
+
+    const rootPath = getWorkspacePackageRootFromManifest(filePath);
+    registry.set(name, {
+      name,
+      nodeId: getWorkspacePackageNodeId(rootPath),
+      rootPath,
+    });
+  }
+
+  return registry;
+}

--- a/packages/extension/src/shared/graphControls/packages/edges.ts
+++ b/packages/extension/src/shared/graphControls/packages/edges.ts
@@ -1,6 +1,6 @@
 import type { IGraphData } from '../../graph/contracts';
 import { STRUCTURAL_NESTS_EDGE_KIND } from '../defaults/definitions';
-import { getNearestWorkspacePackageRoot } from './roots';
+import { getWorkspacePackageRootFromManifest, isWorkspacePackageManifestPath } from './roots';
 import { getWorkspacePackageNodeId, isFileNode } from './workspace';
 
 export function buildWorkspacePackageEdges(
@@ -14,8 +14,12 @@ export function buildWorkspacePackageEdges(
       continue;
     }
 
-    const packageRoot = getNearestWorkspacePackageRoot(node.id, packageRoots);
-    if (!packageRoot) {
+    if (!isWorkspacePackageManifestPath(node.id)) {
+      continue;
+    }
+
+    const packageRoot = getWorkspacePackageRootFromManifest(node.id);
+    if (!packageRoots.has(packageRoot)) {
       continue;
     }
 

--- a/packages/extension/src/shared/graphControls/packages/nodes.ts
+++ b/packages/extension/src/shared/graphControls/packages/nodes.ts
@@ -1,12 +1,4 @@
-import { getWorkspacePackageNodeId } from './workspace';
-
-function getWorkspacePackageLabel(rootPath: string): string {
-  if (rootPath === '.') {
-    return 'workspace';
-  }
-
-  return rootPath.split('/').pop() ?? rootPath;
-}
+import { getWorkspacePackageLabel, getWorkspacePackageNodeId } from './workspace';
 
 export function createWorkspacePackageNodes(
   packageRoots: ReadonlySet<string>,

--- a/packages/extension/src/shared/graphControls/packages/roots.ts
+++ b/packages/extension/src/shared/graphControls/packages/roots.ts
@@ -1,11 +1,11 @@
 import type { IGraphData } from '../../graph/contracts';
 import { isFileNode } from './workspace';
 
-function isPackageManifestPath(nodeId: string): boolean {
+export function isWorkspacePackageManifestPath(nodeId: string): boolean {
   return nodeId === 'package.json' || nodeId.endsWith('/package.json');
 }
 
-function getWorkspacePackageRootFromManifest(nodeId: string): string {
+export function getWorkspacePackageRootFromManifest(nodeId: string): string {
   return nodeId === 'package.json'
     ? '.'
     : nodeId.slice(0, -'/package.json'.length);
@@ -39,7 +39,7 @@ export function collectWorkspacePackageRoots(
   const packageRoots = new Set<string>();
 
   for (const node of nodes) {
-    if (!isFileNode(node) || !isPackageManifestPath(node.id)) {
+    if (!isFileNode(node) || !isWorkspacePackageManifestPath(node.id)) {
       continue;
     }
 

--- a/packages/extension/src/shared/graphControls/packages/workspace.ts
+++ b/packages/extension/src/shared/graphControls/packages/workspace.ts
@@ -9,3 +9,21 @@ export function isFileNode(node: IGraphData['nodes'][number]): boolean {
 export function getWorkspacePackageNodeId(rootPath: string): string {
   return `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}${rootPath}`;
 }
+
+export function isWorkspacePackageNodeId(nodeId: string): boolean {
+  return nodeId.startsWith(WORKSPACE_PACKAGE_NODE_ID_PREFIX);
+}
+
+export function getWorkspacePackageRootFromNodeId(nodeId: string): string {
+  return isWorkspacePackageNodeId(nodeId)
+    ? nodeId.slice(WORKSPACE_PACKAGE_NODE_ID_PREFIX.length)
+    : nodeId;
+}
+
+export function getWorkspacePackageLabel(rootPath: string): string {
+  if (rootPath === '.') {
+    return 'workspace';
+  }
+
+  return rootPath.split('/').pop() ?? rootPath;
+}

--- a/packages/extension/src/webview/graphControls/filtering.ts
+++ b/packages/extension/src/webview/graphControls/filtering.ts
@@ -37,7 +37,12 @@ export function applyGraphControls({
     workspacePackageRoots,
   } = buildStructuralGraphNodes(getFileNodes(baseNodes), nodeVisibility, nodeColors);
 
-  const nodes = [...visibleBaseNodes, ...folderNodes, ...packageNodes];
+  const visibleBaseNodeIds = new Set(visibleBaseNodes.map(node => node.id));
+  const nodes = [
+    ...visibleBaseNodes,
+    ...folderNodes,
+    ...packageNodes.filter(node => !visibleBaseNodeIds.has(node.id)),
+  ];
   const visibleNodeIds = new Set(nodes.map((node) => node.id));
   const visibleFileNodes = getFileNodes(visibleBaseNodes);
   const semanticEdges = filterSemanticEdges(graphData.edges, visibleNodeIds, edgeVisibility);

--- a/packages/extension/tests/extension/pipeline/examplesWorkspace.test.ts
+++ b/packages/extension/tests/extension/pipeline/examplesWorkspace.test.ts
@@ -82,8 +82,8 @@ describe('WorkspacePipeline examples workspace', { timeout: 30000 }, () => {
       'example-markdown/notes/Home.md->example-markdown/src/commented.ts#reference:static',
       'example-markdown/src/commented.ts->example-markdown/notes/Architecture.md#reference:static',
       'example-typescript/packages/app/src/index.ts->example-typescript/packages/app/src/utils.ts#import',
-      'example-typescript/packages/app/src/index.ts->example-typescript/packages/shared/src/types.ts#import',
-      'example-typescript/packages/app/src/index.ts->example-typescript/packages/shared/src/types.ts#type-import',
+      'example-typescript/packages/app/src/index.ts->pkg:workspace:example-typescript/packages/shared#import',
+      'example-typescript/packages/app/src/index.ts->pkg:workspace:example-typescript/packages/shared#type-import',
       'example-typescript/packages/app/src/utils.ts->example-typescript/packages/feature-depth/src/deep.ts#import',
     ];
 
@@ -102,6 +102,7 @@ describe('WorkspacePipeline examples workspace', { timeout: 30000 }, () => {
         'example-typescript/packages/app/src/utils.ts',
         'example-typescript/packages/feature-depth/src/deep.ts',
         'example-typescript/packages/feature-depth/src/leaf.ts',
+        'example-typescript/packages/shared/package.json',
         'example-typescript/packages/shared/src/types.ts',
       ]),
     );

--- a/packages/extension/tests/extension/pipeline/graph/data.test.ts
+++ b/packages/extension/tests/extension/pipeline/graph/data.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { IProjectedConnection, IPlugin } from '../../../../src/core/plugins/types/contracts';
 import { DEFAULT_NODE_COLOR } from '../../../../src/shared/fileColors';
@@ -297,6 +300,91 @@ describe('pipeline/graph/data', () => {
             pluginId: 'codegraphy.typescript',
             sourceId: 'es6-import',
             label: 'ES6 import',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('targets local workspace package nodes for unresolved imports whose package name is discovered locally', () => {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraphy-local-package-'));
+    fs.mkdirSync(path.join(workspaceRoot, 'packages/shared'), { recursive: true });
+    fs.writeFileSync(
+      path.join(workspaceRoot, 'packages/shared/package.json'),
+      JSON.stringify({ name: '@scope/shared' }),
+      'utf8',
+    );
+
+    const graph = (() => {
+      try {
+        return buildWorkspaceGraphData({
+          cacheFiles: {
+            'packages/app/src/index.ts': { size: 10 },
+            'packages/shared/package.json': { size: 20 },
+          },
+          disabledPlugins: new Set(),
+          fileConnections: new Map<string, IProjectedConnection[]>([
+            ['packages/app/src/index.ts', [
+              { specifier: '@scope/shared', resolvedPath: null, kind: 'type-import', sourceId: 'type-import' },
+            ]],
+            ['packages/shared/package.json', []],
+            ['packages/shared/src/types.ts', []],
+          ]),
+          showOrphans: true,
+          visitCounts: {},
+          workspaceRoot,
+          getPluginForFile: () => createPlugin('codegraphy.typescript'),
+        });
+      } finally {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+      }
+    })();
+
+    expect(graph.nodes).toEqual([
+      {
+        id: 'packages/app/src/index.ts',
+        label: 'index.ts',
+        color: DEFAULT_NODE_COLOR,
+        fileSize: 10,
+        accessCount: 0,
+      },
+      {
+        id: 'pkg:workspace:packages/shared',
+        label: 'shared',
+        color: '#F59E0B',
+        nodeType: 'package',
+        shape2D: 'hexagon',
+        shape3D: 'cube',
+        fileSize: undefined,
+        accessCount: 0,
+      },
+      {
+        id: 'packages/shared/package.json',
+        label: 'package.json',
+        color: DEFAULT_NODE_COLOR,
+        fileSize: 20,
+        accessCount: 0,
+      },
+      {
+        id: 'packages/shared/src/types.ts',
+        label: 'types.ts',
+        color: DEFAULT_NODE_COLOR,
+        fileSize: undefined,
+        accessCount: 0,
+      },
+    ]);
+    expect(graph.edges).toEqual([
+      {
+        id: 'packages/app/src/index.ts->pkg:workspace:packages/shared#type-import',
+        from: 'packages/app/src/index.ts',
+        to: 'pkg:workspace:packages/shared',
+        kind: 'type-import',
+        sources: [
+          {
+            id: 'codegraphy.typescript:type-import',
+            pluginId: 'codegraphy.typescript',
+            sourceId: 'type-import',
+            label: 'type-import',
           },
         ],
       },

--- a/packages/extension/tests/extension/pipeline/graph/edgeTargets.test.ts
+++ b/packages/extension/tests/extension/pipeline/graph/edgeTargets.test.ts
@@ -93,4 +93,29 @@ describe('pipeline/graph/edgeTargets', () => {
       ),
     ).toBe('pkg:@scope/pkg');
   });
+
+  it('returns local workspace package node ids for unresolved imports that match discovered package names', () => {
+    const connection: IProjectedConnection = {
+      kind: 'type-import',
+      resolvedPath: null,
+      sourceId: 'type-import',
+      specifier: '@scope/pkg/subpath',
+    };
+
+    expect(
+      getConnectionTargetId(
+        createPlugin('codegraphy.anything'),
+        connection,
+        new Map(),
+        '/workspace',
+        new Map([
+          ['@scope/pkg', {
+            name: '@scope/pkg',
+            nodeId: 'pkg:workspace:packages/pkg',
+            rootPath: 'packages/pkg',
+          }],
+        ]),
+      ),
+    ).toBe('pkg:workspace:packages/pkg');
+  });
 });

--- a/packages/extension/tests/extension/pipeline/graph/packageSpecifiers/nodeId.test.ts
+++ b/packages/extension/tests/extension/pipeline/graph/packageSpecifiers/nodeId.test.ts
@@ -15,6 +15,7 @@ describe('pipeline/graph/packageSpecifiers/nodeId', () => {
   it('recognizes and labels external package node ids', () => {
     expect(isExternalPackageNodeId('pkg:react')).toBe(true);
     expect(isExternalPackageNodeId('src/app.ts')).toBe(false);
+    expect(isExternalPackageNodeId('pkg:workspace:packages/shared')).toBe(false);
     expect(getExternalPackageLabelFromNodeId('pkg:@scope/pkg')).toBe('@scope/pkg');
   });
 });

--- a/packages/extension/tests/extension/pipeline/graph/workspacePackages/registry.test.ts
+++ b/packages/extension/tests/extension/pipeline/graph/workspacePackages/registry.test.ts
@@ -1,0 +1,59 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildWorkspacePackageRegistry } from '../../../../../src/extension/pipeline/graph/workspacePackages/registry';
+
+function createWorkspaceRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'codegraphy-package-registry-'));
+}
+
+function writePackageJson(workspaceRoot: string, relativePath: string, name: string): void {
+  const packageJsonPath = path.join(workspaceRoot, relativePath);
+  fs.mkdirSync(path.dirname(packageJsonPath), { recursive: true });
+  fs.writeFileSync(packageJsonPath, JSON.stringify({ name }), 'utf8');
+}
+
+describe('pipeline/graph/workspacePackages/registry', () => {
+  it('indexes discovered package manifests by package name', () => {
+    const workspaceRoot = createWorkspaceRoot();
+    try {
+      writePackageJson(workspaceRoot, 'packages/shared/package.json', '@scope/shared');
+
+      expect(
+        buildWorkspacePackageRegistry([
+          'packages/shared/package.json',
+          'packages/shared/src/types.ts',
+        ], workspaceRoot),
+      ).toEqual(new Map([
+        ['@scope/shared', {
+          name: '@scope/shared',
+          nodeId: 'pkg:workspace:packages/shared',
+          rootPath: 'packages/shared',
+        }],
+      ]));
+    } finally {
+      fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('skips missing, malformed, and unnamed package manifests', () => {
+    const workspaceRoot = createWorkspaceRoot();
+    try {
+      fs.mkdirSync(path.join(workspaceRoot, 'packages/malformed'), { recursive: true });
+      fs.writeFileSync(path.join(workspaceRoot, 'packages/malformed/package.json'), '{"name":', 'utf8');
+      fs.mkdirSync(path.join(workspaceRoot, 'packages/unnamed'), { recursive: true });
+      fs.writeFileSync(path.join(workspaceRoot, 'packages/unnamed/package.json'), '{}', 'utf8');
+
+      expect(
+        buildWorkspacePackageRegistry([
+          'packages/malformed/package.json',
+          'packages/missing/package.json',
+          'packages/unnamed/package.json',
+        ], workspaceRoot),
+      ).toEqual(new Map());
+    } finally {
+      fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/extension/tests/shared/graphControls/packages.test.ts
+++ b/packages/extension/tests/shared/graphControls/packages.test.ts
@@ -37,7 +37,7 @@ describe('shared/graphControls/packages', () => {
     ]);
   });
 
-  it('builds nests edges from the nearest workspace package to each visible file', () => {
+  it('builds nests edges from workspace package nodes to their package manifests', () => {
     expect(buildWorkspacePackageEdges(
       new Set(['.', 'packages/extension']),
       [
@@ -58,20 +58,6 @@ describe('shared/graphControls/packages', () => {
         id: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension->packages/extension/package.json#codegraphy:nests`,
         from: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension`,
         to: 'packages/extension/package.json',
-        kind: 'codegraphy:nests',
-        sources: [],
-      },
-      {
-        id: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension->packages/extension/src/index.ts#codegraphy:nests`,
-        from: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension`,
-        to: 'packages/extension/src/index.ts',
-        kind: 'codegraphy:nests',
-        sources: [],
-      },
-      {
-        id: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}.->packages/plugin-api/src/api.ts#codegraphy:nests`,
-        from: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}.`,
-        to: 'packages/plugin-api/src/api.ts',
         kind: 'codegraphy:nests',
         sources: [],
       },

--- a/packages/extension/tests/shared/graphControls/packages/edges.test.ts
+++ b/packages/extension/tests/shared/graphControls/packages/edges.test.ts
@@ -3,7 +3,7 @@ import { WORKSPACE_PACKAGE_NODE_ID_PREFIX } from '../../../../src/shared/graphCo
 import { buildWorkspacePackageEdges } from '../../../../src/shared/graphControls/packages/edges';
 
 describe('shared/graphControls/packages/edges', () => {
-  it('builds nests edges from the nearest workspace package to each visible file', () => {
+  it('builds nests edges from workspace package nodes to their package manifests', () => {
     expect(buildWorkspacePackageEdges(
       new Set(['.', 'packages/extension']),
       [
@@ -27,36 +27,23 @@ describe('shared/graphControls/packages/edges', () => {
         kind: 'codegraphy:nests',
         sources: [],
       },
-      {
-        id: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension->packages/extension/src/index.ts#codegraphy:nests`,
-        from: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension`,
-        to: 'packages/extension/src/index.ts',
-        kind: 'codegraphy:nests',
-        sources: [],
-      },
-      {
-        id: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}.->packages/plugin-api/src/api.ts#codegraphy:nests`,
-        from: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}.`,
-        to: 'packages/plugin-api/src/api.ts',
-        kind: 'codegraphy:nests',
-        sources: [],
-      },
     ]);
   });
 
-  it('skips non-file nodes and files that do not resolve to a workspace package root', () => {
+  it('skips non-file nodes and source files inside package roots', () => {
     expect(buildWorkspacePackageEdges(
       new Set(['packages/extension']),
       [
         { id: 'packages/extension', label: 'packages/extension', color: '#111111', nodeType: 'folder' },
         { id: 'packages/plugin-api/src/api.ts', label: 'api.ts', color: '#222222', nodeType: 'file' },
+        { id: 'packages/extension/package.json', label: 'package.json', color: '#444444', nodeType: 'file' },
         { id: 'packages/extension/src/index.ts', label: 'index.ts', color: '#333333', nodeType: 'file' },
       ],
     )).toEqual([
       {
-        id: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension->packages/extension/src/index.ts#codegraphy:nests`,
+        id: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension->packages/extension/package.json#codegraphy:nests`,
         from: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension`,
-        to: 'packages/extension/src/index.ts',
+        to: 'packages/extension/package.json',
         kind: 'codegraphy:nests',
         sources: [],
       },

--- a/packages/extension/tests/shared/graphControls/packages/workspace.test.ts
+++ b/packages/extension/tests/shared/graphControls/packages/workspace.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getWorkspacePackageLabel,
   getWorkspacePackageNodeId,
+  getWorkspacePackageRootFromNodeId,
+  isWorkspacePackageNodeId,
   isFileNode,
   WORKSPACE_PACKAGE_NODE_ID_PREFIX,
 } from '../../../../src/shared/graphControls/packages/workspace';
@@ -34,5 +37,16 @@ describe('shared/graphControls/packages/workspace', () => {
     expect(getWorkspacePackageNodeId('packages/extension')).toBe(
       `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension`,
     );
+  });
+
+  it('reads workspace package ids back to roots and labels', () => {
+    const nodeId = `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/plugin-api`;
+
+    expect(isWorkspacePackageNodeId(nodeId)).toBe(true);
+    expect(isWorkspacePackageNodeId('pkg:react')).toBe(false);
+    expect(getWorkspacePackageRootFromNodeId(nodeId)).toBe('packages/plugin-api');
+    expect(getWorkspacePackageRootFromNodeId('src/app.ts')).toBe('src/app.ts');
+    expect(getWorkspacePackageLabel('.')).toBe('workspace');
+    expect(getWorkspacePackageLabel('packages/plugin-api')).toBe('plugin-api');
   });
 });

--- a/packages/extension/tests/webview/graphControls/filtering/structures.test.ts
+++ b/packages/extension/tests/webview/graphControls/filtering/structures.test.ts
@@ -159,7 +159,7 @@ describe('webview/graphControls/filtering/structures', () => {
 
     expect(packageOnly.every(edge => edge.kind === STRUCTURAL_NESTS_EDGE_KIND)).toBe(true);
     expect(packageOnly.some(edge => edge.from === `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}.` && edge.to === 'package.json')).toBe(true);
-    expect(packageOnly.some(edge => edge.from === `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}.` && edge.to === 'packages/extension/src/index.ts')).toBe(true);
+    expect(packageOnly.some(edge => edge.from === `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}.` && edge.to === 'packages/extension/src/index.ts')).toBe(false);
     expect(packageOnly.some(edge => edge.from === '(root)' || edge.from === 'packages')).toBe(false);
   });
 });

--- a/packages/extension/tests/webview/graphSurface/controls.test.ts
+++ b/packages/extension/tests/webview/graphSurface/controls.test.ts
@@ -125,13 +125,6 @@ describe('webview/graphSurface/controls', () => {
             kind: STRUCTURAL_NESTS_EDGE_KIND,
             sources: [],
           },
-          {
-            id: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension->packages/extension/src/index.ts#${STRUCTURAL_NESTS_EDGE_KIND}`,
-            from: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension`,
-            to: 'packages/extension/src/index.ts',
-            kind: STRUCTURAL_NESTS_EDGE_KIND,
-            sources: [],
-          },
         ],
       },
       edgeDecorations: {
@@ -141,11 +134,43 @@ describe('webview/graphSurface/controls', () => {
         [`${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension->packages/extension/package.json#${STRUCTURAL_NESTS_EDGE_KIND}`]: {
           color: '#222222',
         },
-        [`${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/extension->packages/extension/src/index.ts#${STRUCTURAL_NESTS_EDGE_KIND}`]: {
-          color: '#222222',
-        },
       },
     });
+  });
+
+  it('does not duplicate workspace package nodes already present in graph data', () => {
+    const packageGraphData: IGraphData = {
+      nodes: [
+        { id: 'packages/shared/package.json', label: 'package.json', color: '#111111', nodeType: 'file' },
+        {
+          id: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/shared`,
+          label: 'shared',
+          color: '#111111',
+          nodeType: 'package',
+        },
+      ],
+      edges: [
+        {
+          id: `packages/app/src/index.ts->${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/shared#import`,
+          from: 'packages/app/src/index.ts',
+          to: `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/shared`,
+          kind: 'import',
+          sources: [],
+        },
+      ],
+    };
+
+    const result = applyGraphControls({
+      graphData: packageGraphData,
+      nodeColors: { file: '#111111', package: '#F59E0B' },
+      nodeVisibility: { file: true, folder: false, package: true },
+      edgeVisibility: { [STRUCTURAL_NESTS_EDGE_KIND]: true, import: true },
+      edgeColors: {},
+    });
+
+    expect(
+      result.graphData?.nodes.filter(node => node.id === `${WORKSPACE_PACKAGE_NODE_ID_PREFIX}packages/shared`),
+    ).toHaveLength(1);
   });
 
   it('returns null when no graph data is available', () => {


### PR DESCRIPTION
## Summary

- Discover local workspace packages from scanned `package.json` files and register their package names against existing workspace package node IDs.
- Route unresolved bare imports that match a local package name to the workspace package node instead of creating a separate external package node.
- Keep package structural edges on Option B for now: package nodes connect to their `package.json` manifest, not every file in the package.
- Update the TypeScript example so `packages/app` imports from `@codegraphy/example-shared`, making the monorepo package-node behavior easy to test.

## Why

Type-only imports such as `import type { IPlugin } from '@codegraphy-vscode/plugin-api'` can be local monorepo package imports even when their specifier is a bare package name. The previous package-node behavior treated those as external packages, so the graph could show a separate package node instead of connecting through the local package node.

## Validation

- `pnpm --filter @codegraphy/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/graph tests/shared/graphControls/packages tests/shared/graphControls/packages.test.ts tests/webview/graphControls/filtering/structures.test.ts tests/webview/graphSurface/controls.test.ts tests/extension/pipeline/examplesWorkspace.test.ts`
- `pnpm --filter @codegraphy/extension typecheck`
- `pnpm --filter @codegraphy/extension lint`
- `pnpm run test`