### PR TITLE
Fix timeline history analysis parity

### DIFF
--- a/.changeset/timeline-history-parity.md
+++ b/.changeset/timeline-history-parity.md
@@ -2,4 +2,4 @@
 "@codegraphy/extension": patch
 ---
 
-Fix timeline history playback so commit graphs stop pulling in unsupported files from old diffs, resolve plugin file lookups against each commit instead of the current workspace, and allow third-party plugins to contribute timeline edges from commit-local state.
+Fix timeline history playback so commit graphs stop pulling in unsupported files from old diffs, resolve plugin file lookups against each commit instead of the current workspace, refresh Material legend groups when you jump between commits, and allow third-party plugins to contribute timeline edges from commit-local state. Timeline commits with no graphable files now show a commit-specific empty state instead of the generic “open a folder” message.

--- a/.changeset/timeline-history-parity.md
+++ b/.changeset/timeline-history-parity.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy/extension": patch
+---
+
+Fix timeline history playback so commit graphs stop pulling in unsupported files from old diffs and resolve tree-sitter file links against each commit instead of the current workspace.

--- a/.changeset/timeline-history-parity.md
+++ b/.changeset/timeline-history-parity.md
@@ -2,4 +2,4 @@
 "@codegraphy/extension": patch
 ---
 
-Fix timeline history playback so commit graphs stop pulling in unsupported files from old diffs and resolve tree-sitter file links against each commit instead of the current workspace.
+Fix timeline history playback so commit graphs stop pulling in unsupported files from old diffs, resolve plugin file lookups against each commit instead of the current workspace, and allow third-party plugins to contribute timeline edges from commit-local state.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -55,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -25,6 +25,7 @@ The current plugin API supports more than file analysis:
 - per-file analysis objects with symbols, relations, node types, and edge types
 - `analyzeFile(...)` is the required analysis path for plugins that contribute code analysis
 - `onFilesChanged(...)` is the incremental save hook for plugins that maintain cross-file indexes
+- analysis hooks receive an optional `context` object; use `context.fileSystem` for timeline-safe repo reads
 - graph queries backed by the projected repo-local index and current graph state
 - commands, exporters, toolbar actions, and the compatibility `registerView(...)` hook for optional future graph transforms
 - context menu items, commands, and exporters
@@ -32,6 +33,8 @@ The current plugin API supports more than file analysis:
 - Tier 2 webview slots such as `toolbar`, `node-details`, `tooltip`, `timeline-panel`, `graph-overlay`
 
 Core now owns the default explorer-style file and folder theming through Material Icon Theme. The built-in TypeScript, Python, C#, and Markdown plugins are intentionally minimal now: they mostly contribute ecosystem defaults, filters, and optional semantic enrichment instead of baseline file coloring.
+
+For timeline compatibility, third-party plugins should avoid reading the live workspace directly during analysis. Use the plugin hook `context` instead so the same plugin can resolve files from either the current workspace or a historical commit snapshot.
 
 ## Packaging model
 

--- a/docs/TIMELINE.md
+++ b/docs/TIMELINE.md
@@ -18,6 +18,8 @@ Indexing analyzes the main branch's commit history (up to 500 commits) and cache
 
 Timeline state is stored under `.codegraphy/` alongside the live repo index and repo-local settings.
 
+Plugin analysis runs during timeline indexing too. Plugins that use the public analysis-hook `context.fileSystem` read files from the selected commit, so third-party plugins can contribute nodes and edges to historical snapshots without depending on the current `HEAD` workspace state.
+
 ## Controls
 
 | Control | Action |

--- a/docs/plugin-api/LIFECYCLE.md
+++ b/docs/plugin-api/LIFECYCLE.md
@@ -161,12 +161,12 @@ onUnload() {
 
 These hooks are called multiple times during the plugin's lifetime:
 
-### onPreAnalyze(files, workspaceRoot)
+### onPreAnalyze(files, workspaceRoot, context?)
 
 Called before each analysis pass with the full list of discovered files. Use this to build workspace-wide indexes needed for cross-file resolution.
 
 ```typescript
-onPreAnalyze(files, workspaceRoot) {
+onPreAnalyze(files, workspaceRoot, context) {
   // Build a lookup map, parse config files, etc.
   this.fileIndex = new Map();
   for (const f of files) {
@@ -177,14 +177,16 @@ onPreAnalyze(files, workspaceRoot) {
 
 **Example:** The GDScript plugin uses this to build a `class_name` map so `extends Player` resolves to the correct file. The Markdown plugin builds a file index for wikilink resolution.
 
-### onFilesChanged(files, workspaceRoot)
+`context?.mode === 'timeline'` means this pre-analysis run is being built from git history, not the live workspace.
+
+### onFilesChanged(files, workspaceRoot, context?)
 
 Called before an incremental save-driven refresh when CodeGraphy already has a warmed repo index.
 
 Use this when your plugin keeps cross-file state that can be updated from a small changed-file set. Return additional workspace-relative file paths when those dependents also need re-analysis.
 
 ```typescript
-async onFilesChanged(files, workspaceRoot) {
+async onFilesChanged(files, workspaceRoot, context) {
   let requiresDependents = false;
 
   for (const file of files) {
@@ -205,7 +207,7 @@ Behavior:
 - if your plugin only implements `onPreAnalyze(...)` and not `onFilesChanged(...)`, CodeGraphy falls back to a full refresh for safety
 - if `onFilesChanged(...)` throws, CodeGraphy also falls back to a full refresh
 
-### analyzeFile(filePath, content, workspaceRoot)
+### analyzeFile(filePath, content, workspaceRoot, context?)
 
 Called for each file after the core has prepared the file payload. Plugins return a per-file analysis object containing any mix of:
 
@@ -225,7 +227,7 @@ Use plain plugin-local `sourceId` values in plugin output, like `import`, `refer
 - merged graph provenance later: `id: 'acme.plugin:reference'`
 
 ```typescript
-async analyzeFile(filePath, content, workspaceRoot) {
+async analyzeFile(filePath, content, workspaceRoot, context) {
   return {
     filePath,
     nodeTypes: [
@@ -282,6 +284,8 @@ async analyzeFile(filePath, content, workspaceRoot) {
   };
 }
 ```
+
+When plugin behavior depends on the repo state outside the current file, use `context.fileSystem` instead of raw Node `fs`. In timeline mode the host resolves those reads against the selected commit.
 
 Path contract:
 

--- a/docs/plugin-api/TYPES.md
+++ b/docs/plugin-api/TYPES.md
@@ -58,10 +58,23 @@ Key points:
 - `webviewApiVersion?: string` and `webviewContributions?: { scripts?: string[]; styles?: string[] }` support Tier 2.
 - `sources?: IConnectionSource[]` declares the plugin’s relation provenance/source families.
 - `fileColors?: Record<string, string | IPluginFileColorDefinition>` lets plugins provide default color/shape/imagePath styling by pattern.
-- `analyzeFile(filePath, content, workspaceRoot)` is the plugin analysis hook for returning relations, symbols, and contributed node or edge types.
+- `analyzeFile(filePath, content, workspaceRoot, context?)` is the plugin analysis hook for returning relations, symbols, and contributed node or edge types.
 - core builds the base file result first, then plugin results are merged on top in plugin order.
 - `contributeNodeTypes()` and `contributeEdgeTypes()` let plugins register new graph controls and defaults.
 - Optional hooks: `initialize`, `onLoad`, `onWorkspaceReady`, `onWebviewReady`, `onPreAnalyze`, `onFilesChanged`, `onPostAnalyze`, `onGraphRebuild`, `onUnload`.
+
+### `IPluginAnalysisContext`
+
+- `mode: 'workspace' | 'timeline'`
+- `commitSha?: string` is present during timeline replay
+- `fileSystem` is a host-backed adapter with:
+  - `exists(filePath)`
+  - `isFile(filePath)`
+  - `isDirectory(filePath)`
+  - `listDirectory(filePath)`
+  - `readTextFile(filePath)`
+
+Use this instead of raw Node `fs` when your plugin needs sibling files, config files, or repo-local state. During timeline indexing the adapter reads the selected commit, not `HEAD`.
 
 ### Merge Rules
 

--- a/packages/extension/src/core/plugins/context/workspace.ts
+++ b/packages/extension/src/core/plugins/context/workspace.ts
@@ -1,0 +1,103 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type {
+  IPluginAnalysisContext,
+  IPluginAnalysisFileSystem,
+} from '../types/contracts';
+
+function isWithinWorkspace(workspaceRoot: string, filePath: string): boolean {
+  const relativePath = path.relative(workspaceRoot, filePath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+async function statIfPresent(filePath: string): Promise<Awaited<ReturnType<typeof fs.stat>> | null> {
+  try {
+    return await fs.stat(filePath);
+  } catch {
+    return null;
+  }
+}
+
+async function existsWithinWorkspace(
+  workspaceRoot: string,
+  filePath: string,
+): Promise<boolean> {
+  if (!isWithinWorkspace(workspaceRoot, filePath)) {
+    return false;
+  }
+
+  return (await statIfPresent(filePath)) !== null;
+}
+
+async function isDirectoryWithinWorkspace(
+  workspaceRoot: string,
+  filePath: string,
+): Promise<boolean> {
+  if (!isWithinWorkspace(workspaceRoot, filePath)) {
+    return false;
+  }
+
+  return (await statIfPresent(filePath))?.isDirectory() ?? false;
+}
+
+async function isFileWithinWorkspace(
+  workspaceRoot: string,
+  filePath: string,
+): Promise<boolean> {
+  if (!isWithinWorkspace(workspaceRoot, filePath)) {
+    return false;
+  }
+
+  return (await statIfPresent(filePath))?.isFile() ?? false;
+}
+
+async function listDirectoryWithinWorkspace(
+  workspaceRoot: string,
+  filePath: string,
+): Promise<string[] | null> {
+  if (!isWithinWorkspace(workspaceRoot, filePath)) {
+    return null;
+  }
+
+  try {
+    return await fs.readdir(filePath);
+  } catch {
+    return null;
+  }
+}
+
+async function readTextFileWithinWorkspace(
+  workspaceRoot: string,
+  filePath: string,
+): Promise<string | null> {
+  if (!isWithinWorkspace(workspaceRoot, filePath)) {
+    return null;
+  }
+
+  try {
+    return await fs.readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function createWorkspaceAnalysisFileSystem(
+  workspaceRoot: string,
+): IPluginAnalysisFileSystem {
+  return {
+    exists: (filePath) => existsWithinWorkspace(workspaceRoot, filePath),
+    isDirectory: (filePath) => isDirectoryWithinWorkspace(workspaceRoot, filePath),
+    isFile: (filePath) => isFileWithinWorkspace(workspaceRoot, filePath),
+    listDirectory: (filePath) => listDirectoryWithinWorkspace(workspaceRoot, filePath),
+    readTextFile: (filePath) => readTextFileWithinWorkspace(workspaceRoot, filePath),
+  };
+}
+
+export function createWorkspacePluginAnalysisContext(
+  workspaceRoot: string,
+): IPluginAnalysisContext {
+  return {
+    mode: 'workspace',
+    fileSystem: createWorkspaceAnalysisFileSystem(workspaceRoot),
+  };
+}

--- a/packages/extension/src/core/plugins/lifecycle/notify/analysis.ts
+++ b/packages/extension/src/core/plugins/lifecycle/notify/analysis.ts
@@ -1,5 +1,7 @@
 import type { IGraphData } from '../../../../shared/graph/contracts';
 import type { ILifecyclePluginInfo } from '../contracts';
+import type { IPluginAnalysisContext } from '../../types/contracts';
+import { createWorkspacePluginAnalysisContext } from '../../context/workspace';
 
 type AnalyzeFile = {
   absolutePath: string;
@@ -15,6 +17,7 @@ export async function notifyPreAnalyze(
   plugins: Map<string, ILifecyclePluginInfo>,
   files: AnalyzeFile[],
   workspaceRoot: string,
+  analysisContext: IPluginAnalysisContext = createWorkspacePluginAnalysisContext(workspaceRoot),
 ): Promise<void> {
   for (const info of plugins.values()) {
     if (!info.plugin.onPreAnalyze) {
@@ -22,7 +25,7 @@ export async function notifyPreAnalyze(
     }
 
     try {
-      await info.plugin.onPreAnalyze(files, workspaceRoot);
+      await info.plugin.onPreAnalyze(files, workspaceRoot, analysisContext);
     } catch (error) {
       logLifecycleError('onPreAnalyze', info.plugin.id, error);
     }

--- a/packages/extension/src/core/plugins/lifecycle/notify/filesChanged.ts
+++ b/packages/extension/src/core/plugins/lifecycle/notify/filesChanged.ts
@@ -1,4 +1,6 @@
 import type { ILifecyclePluginInfo } from '../contracts';
+import type { IPluginAnalysisContext } from '../../types/contracts';
+import { createWorkspacePluginAnalysisContext } from '../../context/workspace';
 
 type AnalyzeFile = {
   absolutePath: string;
@@ -44,6 +46,7 @@ export async function notifyFilesChanged(
   plugins: Map<string, ILifecyclePluginInfo>,
   files: AnalyzeFile[],
   workspaceRoot: string,
+  analysisContext: IPluginAnalysisContext = createWorkspacePluginAnalysisContext(workspaceRoot),
 ): Promise<IPluginFilesChangedResult> {
   const additionalFilePaths = new Set<string>();
   let requiresFullRefresh = false;
@@ -62,7 +65,11 @@ export async function notifyFilesChanged(
     }
 
     try {
-      const nextPaths = await info.plugin.onFilesChanged(pluginFiles, workspaceRoot);
+      const nextPaths = await info.plugin.onFilesChanged(
+        pluginFiles,
+        workspaceRoot,
+        analysisContext,
+      );
       collectAdditionalFilePaths(nextPaths, additionalFilePaths);
     } catch (error) {
       console.error(`[CodeGraphy] Error in onFilesChanged for ${info.plugin.id}:`, error);

--- a/packages/extension/src/core/plugins/registry/runtime/state/collection.ts
+++ b/packages/extension/src/core/plugins/registry/runtime/state/collection.ts
@@ -1,6 +1,7 @@
 import type {
   IFileAnalysisResult,
   IPlugin,
+  IPluginAnalysisContext,
   IPluginEdgeType,
   IPluginInfo,
   IPluginNodeType,
@@ -38,6 +39,7 @@ export abstract class PluginRegistryCollection extends PluginRegistryState {
     filePath: string,
     content: string,
     workspaceRoot: string,
+    analysisContext?: IPluginAnalysisContext,
   ): Promise<IProjectedConnection[]> {
     return analyzeFile(
       filePath,
@@ -46,6 +48,7 @@ export abstract class PluginRegistryCollection extends PluginRegistryState {
       this._plugins,
       this._extensionMap,
       this._coreAnalyzeFileResult,
+      analysisContext,
     );
   }
 
@@ -53,6 +56,7 @@ export abstract class PluginRegistryCollection extends PluginRegistryState {
     filePath: string,
     content: string,
     workspaceRoot: string,
+    analysisContext?: IPluginAnalysisContext,
   ): Promise<IFileAnalysisResult | null> {
     return analyzeFileResult(
       filePath,
@@ -61,6 +65,7 @@ export abstract class PluginRegistryCollection extends PluginRegistryState {
       this._plugins,
       this._extensionMap,
       this._coreAnalyzeFileResult,
+      analysisContext,
     );
   }
 

--- a/packages/extension/src/core/plugins/registry/runtime/state/lifecycle.ts
+++ b/packages/extension/src/core/plugins/registry/runtime/state/lifecycle.ts
@@ -1,4 +1,5 @@
 import type { IGraphData } from '../../../../../shared/graph/contracts';
+import type { IPluginAnalysisContext } from '../../../types/contracts';
 import {
   initializeAll as lifecycleInitializeAll,
   initializePlugin as lifecycleInitializePlugin,
@@ -44,15 +45,17 @@ export abstract class PluginRegistryLifecycle extends PluginRegistryCollection {
   async notifyPreAnalyze(
     files: Array<{ absolutePath: string; relativePath: string; content: string }>,
     workspaceRoot: string,
+    analysisContext?: IPluginAnalysisContext,
   ): Promise<void> {
-    await lifecycleNotifyPreAnalyze(this._plugins, files, workspaceRoot);
+    await lifecycleNotifyPreAnalyze(this._plugins, files, workspaceRoot, analysisContext);
   }
 
   async notifyFilesChanged(
     files: Array<{ absolutePath: string; relativePath: string; content: string }>,
     workspaceRoot: string,
+    analysisContext?: IPluginAnalysisContext,
   ): Promise<{ additionalFilePaths: string[]; requiresFullRefresh: boolean }> {
-    return lifecycleNotifyFilesChanged(this._plugins, files, workspaceRoot);
+    return lifecycleNotifyFilesChanged(this._plugins, files, workspaceRoot, analysisContext);
   }
 
   notifyPostAnalyze(graph: IGraphData): void {

--- a/packages/extension/src/core/plugins/routing/router/analyze.ts
+++ b/packages/extension/src/core/plugins/routing/router/analyze.ts
@@ -1,4 +1,8 @@
-import type { IFileAnalysisResult, IProjectedConnection } from '../../types/contracts';
+import type {
+  IFileAnalysisResult,
+  IPluginAnalysisContext,
+  IProjectedConnection,
+} from '../../types/contracts';
 import { getPluginsForFile, type IRoutablePluginInfo } from './lookups';
 import {
   createEmptyFileAnalysisResult,
@@ -8,6 +12,7 @@ import {
   toProjectedConnectionsFromFileAnalysis,
   withPluginProvenance,
 } from './results/project';
+import { createWorkspacePluginAnalysisContext } from '../../context/workspace';
 
 export type CoreFileAnalysisResultProvider = (
   filePath: string,
@@ -25,6 +30,7 @@ export async function analyzeFile(
   plugins: Map<string, IRoutablePluginInfo>,
   extensionMap: Map<string, string[]>,
   coreAnalyzeFileResult?: CoreFileAnalysisResultProvider,
+  analysisContext?: IPluginAnalysisContext,
 ): Promise<IProjectedConnection[]> {
   const analysis = await analyzeFileResult(
     filePath,
@@ -33,6 +39,7 @@ export async function analyzeFile(
     plugins,
     extensionMap,
     coreAnalyzeFileResult,
+    analysisContext,
   );
   return analysis ? toProjectedConnectionsFromFileAnalysis(analysis) : [];
 }
@@ -44,6 +51,7 @@ export async function analyzeFileResult(
   plugins: Map<string, IRoutablePluginInfo>,
   extensionMap: Map<string, string[]>,
   coreAnalyzeFileResult?: CoreFileAnalysisResultProvider,
+  analysisContext: IPluginAnalysisContext = createWorkspacePluginAnalysisContext(workspaceRoot),
 ): Promise<IFileAnalysisResult | null> {
   const matchingPlugins = getPluginsForFile(filePath, plugins, extensionMap);
   const coreResult = await coreAnalyzeFileResult?.(filePath, content, workspaceRoot) ?? null;
@@ -66,7 +74,7 @@ export async function analyzeFileResult(
     try {
       const pluginResult = withPluginProvenance(
         plugin,
-        await plugin.analyzeFile(filePath, content, workspaceRoot),
+        await plugin.analyzeFile(filePath, content, workspaceRoot, analysisContext),
       );
 
       mergedResult = mergeFileAnalysisResults(mergedResult, pluginResult);

--- a/packages/extension/src/core/plugins/types/contracts.ts
+++ b/packages/extension/src/core/plugins/types/contracts.ts
@@ -24,6 +24,8 @@ export type {
   IGraphEdgeSource,
   IGraphNode,
   IPlugin,
+  IPluginAnalysisContext,
+  IPluginAnalysisFileSystem,
   IPluginEdgeType,
   IPluginFileColorDefinition,
   IPluginNodeType,

--- a/packages/extension/src/extension/gitHistory/analysisContext.ts
+++ b/packages/extension/src/extension/gitHistory/analysisContext.ts
@@ -1,0 +1,79 @@
+import * as path from 'node:path';
+import type { IPluginAnalysisContext } from '../../core/plugins/types/contracts';
+import {
+  buildGitHistoryDirectoryEntries,
+  normalizeGitHistoryPath,
+  toRelativeGitHistoryDirectoryPath,
+  toRelativeGitHistoryFilePath,
+} from './pathIndex';
+
+export interface CreateGitHistoryAnalysisContextOptions {
+  allFiles: readonly string[];
+  getFileAtCommit: (
+    sha: string,
+    filePath: string,
+    signal: AbortSignal,
+  ) => Promise<string>;
+  sha: string;
+  signal: AbortSignal;
+  workspaceRoot: string;
+}
+
+export function createGitHistoryAnalysisContext(
+  options: CreateGitHistoryAnalysisContextOptions,
+): IPluginAnalysisContext {
+  const files = new Set(options.allFiles.map(normalizeGitHistoryPath));
+  const directories = buildGitHistoryDirectoryEntries(options.allFiles);
+  const textFileCache = new Map<string, Promise<string | null>>();
+
+  const isFile = (absolutePath: string): boolean => {
+    const relativePath = toRelativeGitHistoryFilePath(absolutePath, options.workspaceRoot);
+    return relativePath !== null && files.has(relativePath);
+  };
+
+  const isDirectory = (absolutePath: string): boolean => {
+    const relativePath = toRelativeGitHistoryDirectoryPath(absolutePath, options.workspaceRoot);
+    return relativePath !== null && directories.has(relativePath);
+  };
+
+  return {
+    mode: 'timeline',
+    commitSha: options.sha,
+    fileSystem: {
+      async exists(filePath) {
+        return isFile(filePath) || isDirectory(filePath);
+      },
+      async isDirectory(filePath) {
+        return isDirectory(filePath);
+      },
+      async isFile(filePath) {
+        return isFile(filePath);
+      },
+      async listDirectory(filePath) {
+        const relativePath = toRelativeGitHistoryDirectoryPath(filePath, options.workspaceRoot);
+        return relativePath === null ? null : directories.get(relativePath) ?? null;
+      },
+      async readTextFile(filePath) {
+        if (!isFile(filePath)) {
+          return null;
+        }
+
+        const cached = textFileCache.get(filePath);
+        if (cached) {
+          return cached;
+        }
+
+        const relativePath = normalizeGitHistoryPath(
+          path.relative(options.workspaceRoot, filePath),
+        );
+        const contentPromise = options.getFileAtCommit(
+          options.sha,
+          relativePath,
+          options.signal,
+        ).catch(() => null);
+        textFileCache.set(filePath, contentPromise);
+        return contentPromise;
+      },
+    },
+  };
+}

--- a/packages/extension/src/extension/gitHistory/analyzer.ts
+++ b/packages/extension/src/extension/gitHistory/analyzer.ts
@@ -186,6 +186,11 @@ export class GitHistoryAnalyzer {
         sha,
         signal
       ),
+      commitFiles: await getCommitTreeFiles(
+        (args, abortSignal) => this._execGit(args, abortSignal),
+        sha,
+        signal,
+      ),
       getFileAtCommit: (commitSha, filePath, abortSignal) =>
         this._getFileAtCommit(commitSha, filePath, abortSignal),
       previousGraph,

--- a/packages/extension/src/extension/gitHistory/cache/stateKeys.ts
+++ b/packages/extension/src/extension/gitHistory/cache/stateKeys.ts
@@ -1,4 +1,4 @@
 export const COMMITS_STATE_KEY = 'codegraphy.timelineCommits';
 export const CACHE_VERSION_KEY = 'codegraphy.timelineCacheVersion';
 export const PLUGIN_SIGNATURE_KEY = 'codegraphy.timelinePluginSignature';
-export const CACHE_VERSION = '1.2.0';
+export const CACHE_VERSION = '1.3.0';

--- a/packages/extension/src/extension/gitHistory/commitPathHost.ts
+++ b/packages/extension/src/extension/gitHistory/commitPathHost.ts
@@ -1,5 +1,11 @@
 import * as path from 'node:path';
 import type { TreeSitterPathHost } from '../pipeline/plugins/treesitter/runtime/pathHost';
+import {
+  buildGitHistoryDirectoryEntries,
+  normalizeGitHistoryPath,
+  toRelativeGitHistoryDirectoryPath,
+  toRelativeGitHistoryFilePath,
+} from './pathIndex';
 
 export interface CreateGitHistoryCommitPathHostOptions {
   allFiles: readonly string[];
@@ -11,71 +17,6 @@ export interface CreateGitHistoryCommitPathHostOptions {
   sha: string;
   signal: AbortSignal;
   workspaceRoot: string;
-}
-
-function normalizeRelativePath(relativePath: string): string {
-  return relativePath.split(path.sep).join('/');
-}
-
-function toRelativeFilePath(absolutePath: string, workspaceRoot: string): string | null {
-  const relativePath = path.relative(workspaceRoot, absolutePath);
-  if (relativePath === '') {
-    return null;
-  }
-
-  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-    return null;
-  }
-
-  return normalizeRelativePath(relativePath);
-}
-
-function toRelativeDirectoryPath(absolutePath: string, workspaceRoot: string): string | null {
-  const relativePath = path.relative(workspaceRoot, absolutePath);
-  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-    return null;
-  }
-
-  return relativePath === '' ? '' : normalizeRelativePath(relativePath);
-}
-
-function buildDirectoryEntries(
-  allFiles: readonly string[],
-): Map<string, string[]> {
-  const directoryEntries = new Map<string, Set<string>>();
-
-  const addEntry = (directoryPath: string, entryName: string) => {
-    const entries = directoryEntries.get(directoryPath);
-    if (entries) {
-      entries.add(entryName);
-      return;
-    }
-
-    directoryEntries.set(directoryPath, new Set([entryName]));
-  };
-
-  for (const relativeFilePath of allFiles) {
-    const segments = normalizeRelativePath(relativeFilePath).split('/');
-    let currentDirectory = '';
-
-    for (let index = 0; index < segments.length; index += 1) {
-      addEntry(currentDirectory, segments[index]);
-
-      if (index === segments.length - 1) {
-        break;
-      }
-
-      currentDirectory = currentDirectory
-        ? `${currentDirectory}/${segments[index]}`
-        : segments[index];
-    }
-  }
-
-  return new Map(
-    Array.from(directoryEntries.entries(), ([directoryPath, entries]) => {
-      return [directoryPath, Array.from(entries).sort()];
-    }),
-  );
 }
 
 async function buildPrefetchedTextFiles(
@@ -98,15 +39,15 @@ async function buildPrefetchedTextFiles(
 export async function createGitHistoryCommitPathHost(
   options: CreateGitHistoryCommitPathHostOptions,
 ): Promise<TreeSitterPathHost> {
-  const files = new Set(options.allFiles.map(normalizeRelativePath));
-  const directories = buildDirectoryEntries(options.allFiles);
+  const files = new Set(options.allFiles.map(normalizeGitHistoryPath));
+  const directories = buildGitHistoryDirectoryEntries(options.allFiles);
   const textFiles = await buildPrefetchedTextFiles(options);
   const isFile = (absolutePath: string): boolean => {
-    const relativePath = toRelativeFilePath(absolutePath, options.workspaceRoot);
+    const relativePath = toRelativeGitHistoryFilePath(absolutePath, options.workspaceRoot);
     return relativePath !== null && files.has(relativePath);
   };
   const isDirectory = (absolutePath: string): boolean => {
-    const relativePath = toRelativeDirectoryPath(absolutePath, options.workspaceRoot);
+    const relativePath = toRelativeGitHistoryDirectoryPath(absolutePath, options.workspaceRoot);
     return relativePath !== null && directories.has(relativePath);
   };
 
@@ -117,7 +58,7 @@ export async function createGitHistoryCommitPathHost(
     isDirectory,
     isFile,
     listDirectory(absolutePath) {
-      const relativePath = toRelativeDirectoryPath(absolutePath, options.workspaceRoot);
+      const relativePath = toRelativeGitHistoryDirectoryPath(absolutePath, options.workspaceRoot);
       return relativePath === null ? null : directories.get(relativePath) ?? null;
     },
     readTextFile(absolutePath) {

--- a/packages/extension/src/extension/gitHistory/commitPathHost.ts
+++ b/packages/extension/src/extension/gitHistory/commitPathHost.ts
@@ -1,0 +1,127 @@
+import * as path from 'node:path';
+import type { TreeSitterPathHost } from '../pipeline/plugins/treesitter/runtime/pathHost';
+
+export interface CreateGitHistoryCommitPathHostOptions {
+  allFiles: readonly string[];
+  getFileAtCommit: (
+    sha: string,
+    filePath: string,
+    signal: AbortSignal,
+  ) => Promise<string>;
+  sha: string;
+  signal: AbortSignal;
+  workspaceRoot: string;
+}
+
+function normalizeRelativePath(relativePath: string): string {
+  return relativePath.split(path.sep).join('/');
+}
+
+function toRelativeFilePath(absolutePath: string, workspaceRoot: string): string | null {
+  const relativePath = path.relative(workspaceRoot, absolutePath);
+  if (relativePath === '') {
+    return null;
+  }
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return normalizeRelativePath(relativePath);
+}
+
+function toRelativeDirectoryPath(absolutePath: string, workspaceRoot: string): string | null {
+  const relativePath = path.relative(workspaceRoot, absolutePath);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return relativePath === '' ? '' : normalizeRelativePath(relativePath);
+}
+
+function buildDirectoryEntries(
+  allFiles: readonly string[],
+): Map<string, string[]> {
+  const directoryEntries = new Map<string, Set<string>>();
+
+  const addEntry = (directoryPath: string, entryName: string) => {
+    const entries = directoryEntries.get(directoryPath);
+    if (entries) {
+      entries.add(entryName);
+      return;
+    }
+
+    directoryEntries.set(directoryPath, new Set([entryName]));
+  };
+
+  for (const relativeFilePath of allFiles) {
+    const segments = normalizeRelativePath(relativeFilePath).split('/');
+    let currentDirectory = '';
+
+    for (let index = 0; index < segments.length; index += 1) {
+      addEntry(currentDirectory, segments[index]);
+
+      if (index === segments.length - 1) {
+        break;
+      }
+
+      currentDirectory = currentDirectory
+        ? `${currentDirectory}/${segments[index]}`
+        : segments[index];
+    }
+  }
+
+  return new Map(
+    Array.from(directoryEntries.entries(), ([directoryPath, entries]) => {
+      return [directoryPath, Array.from(entries).sort()];
+    }),
+  );
+}
+
+async function buildPrefetchedTextFiles(
+  options: CreateGitHistoryCommitPathHostOptions,
+): Promise<Map<string, string>> {
+  const textFiles = new Map<string, string>();
+  const candidateFiles = options.allFiles.filter((filePath) => path.basename(filePath) === 'go.mod');
+
+  for (const relativeFilePath of candidateFiles) {
+    const absolutePath = path.join(options.workspaceRoot, relativeFilePath);
+    textFiles.set(
+      absolutePath,
+      await options.getFileAtCommit(options.sha, relativeFilePath, options.signal),
+    );
+  }
+
+  return textFiles;
+}
+
+export async function createGitHistoryCommitPathHost(
+  options: CreateGitHistoryCommitPathHostOptions,
+): Promise<TreeSitterPathHost> {
+  const files = new Set(options.allFiles.map(normalizeRelativePath));
+  const directories = buildDirectoryEntries(options.allFiles);
+  const textFiles = await buildPrefetchedTextFiles(options);
+  const isFile = (absolutePath: string): boolean => {
+    const relativePath = toRelativeFilePath(absolutePath, options.workspaceRoot);
+    return relativePath !== null && files.has(relativePath);
+  };
+  const isDirectory = (absolutePath: string): boolean => {
+    const relativePath = toRelativeDirectoryPath(absolutePath, options.workspaceRoot);
+    return relativePath !== null && directories.has(relativePath);
+  };
+
+  return {
+    exists(absolutePath) {
+      return isFile(absolutePath) || isDirectory(absolutePath);
+    },
+    isDirectory,
+    isFile,
+    listDirectory(absolutePath) {
+      const relativePath = toRelativeDirectoryPath(absolutePath, options.workspaceRoot);
+      return relativePath === null ? null : directories.get(relativePath) ?? null;
+    },
+    readTextFile(absolutePath) {
+      return textFiles.get(absolutePath) ?? null;
+    },
+  };
+}

--- a/packages/extension/src/extension/gitHistory/commits/list.ts
+++ b/packages/extension/src/extension/gitHistory/commits/list.ts
@@ -43,6 +43,8 @@ export async function getCommitList(
       '--format=%H|%at|%s|%an|%P',
       '-n',
       String(maxCommits),
+      '--',
+      '.',
     ],
     signal
   );

--- a/packages/extension/src/extension/gitHistory/diff/analysis.ts
+++ b/packages/extension/src/extension/gitHistory/diff/analysis.ts
@@ -1,5 +1,6 @@
 import type { IFileAnalysisResult } from '../../../core/plugins/types/contracts';
 import type { IGraphData } from '../../../shared/graph/contracts';
+import { createGitHistoryCommitPathHost } from '../commitPathHost';
 import { addGitHistoryGraphFile, modifyGitHistoryGraphFile } from './changes';
 import {
   createDiffGraphSnapshot,
@@ -20,6 +21,7 @@ interface DiffGraphRegistry {
 
 export interface AnalyzeDiffCommitGraphOptions {
   diffOutput: string;
+  commitFiles: readonly string[];
   getFileAtCommit: (
     sha: string,
     filePath: string,
@@ -38,6 +40,7 @@ export async function analyzeDiffCommitGraph(
 ): Promise<IGraphData> {
   const {
     diffOutput,
+    commitFiles,
     getFileAtCommit,
     previousGraph,
     registry,
@@ -49,6 +52,16 @@ export async function analyzeDiffCommitGraph(
 
   const { edgeSet, edges, nodeMap, nodes } = createDiffGraphSnapshot(previousGraph);
   const lines = diffOutput.trim().split('\n').filter(Boolean);
+  const trackedFiles = new Set(commitFiles.filter((filePath) => {
+    return !shouldExclude(filePath) && registry.supportsFile(filePath);
+  }));
+  const pathHost = await createGitHistoryCommitPathHost({
+    allFiles: commitFiles,
+    getFileAtCommit,
+    sha,
+    signal,
+    workspaceRoot,
+  });
 
   for (const line of lines) {
     if (signal.aborted) {
@@ -63,6 +76,11 @@ export async function analyzeDiffCommitGraph(
     if (status.startsWith('R')) {
       const oldPath = parts[1];
       const newPath = parts[2];
+      if (!trackedFiles.has(newPath)) {
+        deleteGitHistoryGraphFile(oldPath, nodes, edges, nodeMap, edgeSet);
+        continue;
+      }
+
       renameGitHistoryGraphFile(oldPath, newPath, edges, nodeMap, edgeSet);
       await reanalyzeGraphFile({
         edgeSet,
@@ -75,12 +93,13 @@ export async function analyzeDiffCommitGraph(
         sha,
         signal,
         workspaceRoot,
+        pathHost,
       });
       continue;
     }
 
     if (status === 'A') {
-      if (shouldExclude(parts[1])) {
+      if (!trackedFiles.has(parts[1])) {
         continue;
       }
 
@@ -95,11 +114,17 @@ export async function analyzeDiffCommitGraph(
         sha,
         signal,
         workspaceRoot,
+        pathHost,
       });
       continue;
     }
 
     if (status === 'M') {
+      if (!trackedFiles.has(parts[1])) {
+        deleteGitHistoryGraphFile(parts[1], nodes, edges, nodeMap, edgeSet);
+        continue;
+      }
+
       await modifyGitHistoryGraphFile({
         edgeSet,
         edges,
@@ -111,6 +136,7 @@ export async function analyzeDiffCommitGraph(
         sha,
         signal,
         workspaceRoot,
+        pathHost,
       });
       continue;
     }

--- a/packages/extension/src/extension/gitHistory/diff/analysis.ts
+++ b/packages/extension/src/extension/gitHistory/diff/analysis.ts
@@ -1,6 +1,7 @@
 import type { IFileAnalysisResult } from '../../../core/plugins/types/contracts';
 import type { IGraphData } from '../../../shared/graph/contracts';
 import { createGitHistoryCommitPathHost } from '../commitPathHost';
+import { preAnalyzeGitHistoryPlugins } from '../preAnalyze';
 import { addGitHistoryGraphFile, modifyGitHistoryGraphFile } from './changes';
 import {
   createDiffGraphSnapshot,
@@ -16,6 +17,14 @@ interface DiffGraphRegistry {
     workspaceRoot: string,
   ): Promise<IFileAnalysisResult | null>;
   getPluginForFile?(absolutePath: string): { id: string } | undefined;
+  notifyPreAnalyze(
+    files: Array<{
+      absolutePath: string;
+      relativePath: string;
+      content: string;
+    }>,
+    workspaceRoot: string,
+  ): Promise<void>;
   supportsFile(filePath: string): boolean;
 }
 
@@ -34,6 +43,27 @@ export interface AnalyzeDiffCommitGraphOptions {
   signal: AbortSignal;
   workspaceRoot: string;
 }
+
+interface DiffAnalysisContext {
+  edgeSet: Set<string>;
+  edges: IGraphData['edges'];
+  getFileAtCommit: AnalyzeDiffCommitGraphOptions['getFileAtCommit'];
+  nodeMap: Map<string, IGraphData['nodes'][number]>;
+  nodes: IGraphData['nodes'];
+  pathHost: Awaited<ReturnType<typeof createGitHistoryCommitPathHost>>;
+  registry: DiffGraphRegistry;
+  sha: string;
+  signal: AbortSignal;
+  trackedFiles: Set<string>;
+  workspaceRoot: string;
+}
+
+type ParsedDiffLine =
+  | { kind: 'add'; filePath: string }
+  | { kind: 'delete'; filePath: string }
+  | { kind: 'modify'; filePath: string }
+  | { kind: 'rename'; oldPath: string; newPath: string }
+  | { kind: 'ignore' };
 
 export async function analyzeDiffCommitGraph(
   options: AnalyzeDiffCommitGraphOptions,
@@ -55,6 +85,14 @@ export async function analyzeDiffCommitGraph(
   const trackedFiles = new Set(commitFiles.filter((filePath) => {
     return !shouldExclude(filePath) && registry.supportsFile(filePath);
   }));
+  await preAnalyzeGitHistoryPlugins({
+    allFiles: commitFiles.filter((filePath) => !shouldExclude(filePath)),
+    getFileAtCommit,
+    registry,
+    sha,
+    signal,
+    workspaceRoot,
+  });
   const pathHost = await createGitHistoryCommitPathHost({
     allFiles: commitFiles,
     getFileAtCommit,
@@ -62,88 +100,23 @@ export async function analyzeDiffCommitGraph(
     signal,
     workspaceRoot,
   });
+  const context: DiffAnalysisContext = {
+    edgeSet,
+    edges,
+    getFileAtCommit,
+    nodeMap,
+    nodes,
+    pathHost,
+    registry,
+    sha,
+    signal,
+    trackedFiles,
+    workspaceRoot,
+  };
 
   for (const line of lines) {
-    if (signal.aborted) {
-      const error = new Error('Indexing aborted');
-      error.name = 'AbortError';
-      throw error;
-    }
-
-    const parts = line.split('\t');
-    const status = parts[0];
-
-    if (status.startsWith('R')) {
-      const oldPath = parts[1];
-      const newPath = parts[2];
-      if (!trackedFiles.has(newPath)) {
-        deleteGitHistoryGraphFile(oldPath, nodes, edges, nodeMap, edgeSet);
-        continue;
-      }
-
-      renameGitHistoryGraphFile(oldPath, newPath, edges, nodeMap, edgeSet);
-      await reanalyzeGraphFile({
-        edgeSet,
-        edges,
-        filePath: newPath,
-        getFileAtCommit,
-        nodeMap,
-        nodes,
-        registry,
-        sha,
-        signal,
-        workspaceRoot,
-        pathHost,
-      });
-      continue;
-    }
-
-    if (status === 'A') {
-      if (!trackedFiles.has(parts[1])) {
-        continue;
-      }
-
-      await addGitHistoryGraphFile({
-        edgeSet,
-        edges,
-        filePath: parts[1],
-        getFileAtCommit,
-        nodeMap,
-        nodes,
-        registry,
-        sha,
-        signal,
-        workspaceRoot,
-        pathHost,
-      });
-      continue;
-    }
-
-    if (status === 'M') {
-      if (!trackedFiles.has(parts[1])) {
-        deleteGitHistoryGraphFile(parts[1], nodes, edges, nodeMap, edgeSet);
-        continue;
-      }
-
-      await modifyGitHistoryGraphFile({
-        edgeSet,
-        edges,
-        filePath: parts[1],
-        getFileAtCommit,
-        nodeMap,
-        nodes,
-        registry,
-        sha,
-        signal,
-        workspaceRoot,
-        pathHost,
-      });
-      continue;
-    }
-
-    if (status === 'D') {
-      deleteGitHistoryGraphFile(parts[1], nodes, edges, nodeMap, edgeSet);
-    }
+    assertDiffAnalysisActive(signal);
+    await handleDiffLine(parseDiffLine(line), context);
   }
 
   return {
@@ -151,3 +124,155 @@ export async function analyzeDiffCommitGraph(
     edges: filterDanglingDiffGraphEdges(nodes, edges),
   };
 }
+
+async function handleDiffLine(
+  diffLine: ParsedDiffLine,
+  context: DiffAnalysisContext,
+): Promise<void> {
+  switch (diffLine.kind) {
+    case 'rename':
+      await handleRename(diffLine.oldPath, diffLine.newPath, context);
+      return;
+    case 'add':
+      await handleAddition(diffLine.filePath, context);
+      return;
+    case 'modify':
+      await handleModification(diffLine.filePath, context);
+      return;
+    case 'delete':
+      deleteTrackedFile(diffLine.filePath, context);
+      return;
+    case 'ignore':
+      return;
+  }
+}
+
+async function handleRename(
+  oldPath: string,
+  newPath: string,
+  context: DiffAnalysisContext,
+): Promise<void> {
+  if (!context.trackedFiles.has(newPath)) {
+    deleteTrackedFile(oldPath, context);
+    return;
+  }
+
+  renameGitHistoryGraphFile(
+    oldPath,
+    newPath,
+    context.edges,
+    context.nodeMap,
+    context.edgeSet,
+  );
+  await reanalyzeTrackedFile(newPath, context);
+}
+
+async function handleAddition(
+  filePath: string,
+  context: DiffAnalysisContext,
+): Promise<void> {
+  if (!context.trackedFiles.has(filePath)) {
+    return;
+  }
+
+  await addGitHistoryGraphFile(buildTrackedFileOptions(filePath, context));
+}
+
+async function handleModification(
+  filePath: string,
+  context: DiffAnalysisContext,
+): Promise<void> {
+  if (!context.trackedFiles.has(filePath)) {
+    deleteTrackedFile(filePath, context);
+    return;
+  }
+
+  await modifyGitHistoryGraphFile(buildTrackedFileOptions(filePath, context));
+}
+
+function deleteTrackedFile(filePath: string, context: DiffAnalysisContext): void {
+  deleteGitHistoryGraphFile(
+    filePath,
+    context.nodes,
+    context.edges,
+    context.nodeMap,
+    context.edgeSet,
+  );
+}
+
+async function reanalyzeTrackedFile(
+  filePath: string,
+  context: DiffAnalysisContext,
+): Promise<void> {
+  await reanalyzeGraphFile(buildTrackedFileOptions(filePath, context));
+}
+
+function buildTrackedFileOptions(filePath: string, context: DiffAnalysisContext) {
+  return {
+    edgeSet: context.edgeSet,
+    edges: context.edges,
+    filePath,
+    getFileAtCommit: context.getFileAtCommit,
+    nodeMap: context.nodeMap,
+    nodes: context.nodes,
+    registry: context.registry,
+    sha: context.sha,
+    signal: context.signal,
+    workspaceRoot: context.workspaceRoot,
+    pathHost: context.pathHost,
+  };
+}
+
+function parseDiffLine(line: string): ParsedDiffLine {
+  const [status, firstPath, secondPath] = line.split('\t');
+
+  return parseRenameDiffLine(status, firstPath, secondPath)
+    ?? parseSinglePathDiffLine(status, firstPath)
+    ?? { kind: 'ignore' };
+}
+
+function assertDiffAnalysisActive(signal: AbortSignal): void {
+  if (!signal.aborted) {
+    return;
+  }
+
+  const error = new Error('Indexing aborted');
+  error.name = 'AbortError';
+  throw error;
+}
+
+function parseRenameDiffLine(
+  status: string,
+  oldPath?: string,
+  newPath?: string,
+): ParsedDiffLine | null {
+  if (!status.startsWith('R') || !oldPath || !newPath) {
+    return null;
+  }
+
+  return {
+    kind: 'rename',
+    oldPath,
+    newPath,
+  };
+}
+
+function parseSinglePathDiffLine(
+  status: string,
+  filePath?: string,
+): ParsedDiffLine | null {
+  if (!filePath) {
+    return null;
+  }
+
+  return singlePathDiffFactories[status]?.(filePath) ?? null;
+}
+
+const singlePathDiffFactories: Record<
+  string,
+  (filePath: string) => Extract<ParsedDiffLine, { filePath: string }>
+> = {
+  'A': (filePath) => ({ kind: 'add', filePath }),
+  'D': (filePath) => ({ kind: 'delete', filePath }),
+  'M': (filePath) => ({ kind: 'modify', filePath }),
+};

--- a/packages/extension/src/extension/gitHistory/diff/analysis.ts
+++ b/packages/extension/src/extension/gitHistory/diff/analysis.ts
@@ -1,5 +1,9 @@
-import type { IFileAnalysisResult } from '../../../core/plugins/types/contracts';
+import type {
+  IFileAnalysisResult,
+  IPluginAnalysisContext,
+} from '../../../core/plugins/types/contracts';
 import type { IGraphData } from '../../../shared/graph/contracts';
+import { createGitHistoryAnalysisContext } from '../analysisContext';
 import { createGitHistoryCommitPathHost } from '../commitPathHost';
 import { preAnalyzeGitHistoryPlugins } from '../preAnalyze';
 import { addGitHistoryGraphFile, modifyGitHistoryGraphFile } from './changes';
@@ -15,6 +19,7 @@ interface DiffGraphRegistry {
     absolutePath: string,
     content: string,
     workspaceRoot: string,
+    context?: IPluginAnalysisContext,
   ): Promise<IFileAnalysisResult | null>;
   getPluginForFile?(absolutePath: string): { id: string } | undefined;
   notifyPreAnalyze(
@@ -24,6 +29,7 @@ interface DiffGraphRegistry {
       content: string;
     }>,
     workspaceRoot: string,
+    context: IPluginAnalysisContext,
   ): Promise<void>;
   supportsFile(filePath: string): boolean;
 }
@@ -45,6 +51,7 @@ export interface AnalyzeDiffCommitGraphOptions {
 }
 
 interface DiffAnalysisContext {
+  analysisContext: IPluginAnalysisContext;
   edgeSet: Set<string>;
   edges: IGraphData['edges'];
   getFileAtCommit: AnalyzeDiffCommitGraphOptions['getFileAtCommit'];
@@ -85,6 +92,13 @@ export async function analyzeDiffCommitGraph(
   const trackedFiles = new Set(commitFiles.filter((filePath) => {
     return !shouldExclude(filePath) && registry.supportsFile(filePath);
   }));
+  const analysisContext = createGitHistoryAnalysisContext({
+    allFiles: commitFiles,
+    getFileAtCommit,
+    sha,
+    signal,
+    workspaceRoot,
+  });
   await preAnalyzeGitHistoryPlugins({
     allFiles: commitFiles.filter((filePath) => !shouldExclude(filePath)),
     getFileAtCommit,
@@ -92,7 +106,7 @@ export async function analyzeDiffCommitGraph(
     sha,
     signal,
     workspaceRoot,
-  });
+  }, analysisContext);
   const pathHost = await createGitHistoryCommitPathHost({
     allFiles: commitFiles,
     getFileAtCommit,
@@ -101,6 +115,7 @@ export async function analyzeDiffCommitGraph(
     workspaceRoot,
   });
   const context: DiffAnalysisContext = {
+    analysisContext,
     edgeSet,
     edges,
     getFileAtCommit,
@@ -220,6 +235,7 @@ function buildTrackedFileOptions(filePath: string, context: DiffAnalysisContext)
     signal: context.signal,
     workspaceRoot: context.workspaceRoot,
     pathHost: context.pathHost,
+    analysisContext: context.analysisContext,
   };
 }
 

--- a/packages/extension/src/extension/gitHistory/diff/changes.ts
+++ b/packages/extension/src/extension/gitHistory/diff/changes.ts
@@ -1,4 +1,7 @@
-import type { IFileAnalysisResult } from '../../../core/plugins/types/contracts';
+import type {
+  IFileAnalysisResult,
+  IPluginAnalysisContext,
+} from '../../../core/plugins/types/contracts';
 import type { IGraphEdge, IGraphNode } from '../../../shared/graph/contracts';
 import type { TreeSitterPathHost } from '../../pipeline/plugins/treesitter/runtime/pathHost';
 import { reanalyzeGraphFile, removeOutgoingGitHistoryEdges } from '../reanalyzeGraphFile';
@@ -8,6 +11,7 @@ interface DiffGraphChangeRegistry {
     absolutePath: string,
     content: string,
     workspaceRoot: string,
+    context?: IPluginAnalysisContext,
   ): Promise<IFileAnalysisResult | null>;
   getPluginForFile?(absolutePath: string): { id: string } | undefined;
   supportsFile(filePath: string): boolean;
@@ -29,6 +33,7 @@ interface DiffGraphChangeOptions {
   signal: AbortSignal;
   workspaceRoot: string;
   pathHost?: TreeSitterPathHost;
+  analysisContext?: IPluginAnalysisContext;
 }
 
 export async function addGitHistoryGraphFile(
@@ -46,6 +51,7 @@ export async function addGitHistoryGraphFile(
     signal,
     workspaceRoot,
     pathHost,
+    analysisContext,
   } = options;
 
   if (!registry.supportsFile(filePath)) {
@@ -64,6 +70,7 @@ export async function addGitHistoryGraphFile(
     signal,
     workspaceRoot,
     pathHost,
+    analysisContext,
   });
 }
 
@@ -82,6 +89,7 @@ export async function modifyGitHistoryGraphFile(
     signal,
     workspaceRoot,
     pathHost,
+    analysisContext,
   } = options;
 
   if (!registry.supportsFile(filePath)) {
@@ -102,5 +110,6 @@ export async function modifyGitHistoryGraphFile(
     signal,
     workspaceRoot,
     pathHost,
+    analysisContext,
   });
 }

--- a/packages/extension/src/extension/gitHistory/diff/changes.ts
+++ b/packages/extension/src/extension/gitHistory/diff/changes.ts
@@ -1,6 +1,6 @@
 import type { IFileAnalysisResult } from '../../../core/plugins/types/contracts';
 import type { IGraphEdge, IGraphNode } from '../../../shared/graph/contracts';
-import { createGitHistoryNode } from '../fullCommitAnalysis';
+import type { TreeSitterPathHost } from '../../pipeline/plugins/treesitter/runtime/pathHost';
 import { reanalyzeGraphFile, removeOutgoingGitHistoryEdges } from '../reanalyzeGraphFile';
 
 interface DiffGraphChangeRegistry {
@@ -28,20 +28,7 @@ interface DiffGraphChangeOptions {
   sha: string;
   signal: AbortSignal;
   workspaceRoot: string;
-}
-
-function addGitHistoryNodeIfMissing(
-  filePath: string,
-  nodeMap: Map<string, IGraphNode>,
-  nodes: IGraphNode[],
-): void {
-  if (nodeMap.has(filePath)) {
-    return;
-  }
-
-  const node = createGitHistoryNode(filePath);
-  nodes.push(node);
-  nodeMap.set(filePath, node);
+  pathHost?: TreeSitterPathHost;
 }
 
 export async function addGitHistoryGraphFile(
@@ -58,10 +45,10 @@ export async function addGitHistoryGraphFile(
     sha,
     signal,
     workspaceRoot,
+    pathHost,
   } = options;
 
   if (!registry.supportsFile(filePath)) {
-    addGitHistoryNodeIfMissing(filePath, nodeMap, nodes);
     return;
   }
 
@@ -76,6 +63,7 @@ export async function addGitHistoryGraphFile(
     sha,
     signal,
     workspaceRoot,
+    pathHost,
   });
 }
 
@@ -93,6 +81,7 @@ export async function modifyGitHistoryGraphFile(
     sha,
     signal,
     workspaceRoot,
+    pathHost,
   } = options;
 
   if (!registry.supportsFile(filePath)) {
@@ -112,5 +101,6 @@ export async function modifyGitHistoryGraphFile(
     sha,
     signal,
     workspaceRoot,
+    pathHost,
   });
 }

--- a/packages/extension/src/extension/gitHistory/diff/state.ts
+++ b/packages/extension/src/extension/gitHistory/diff/state.ts
@@ -48,7 +48,8 @@ export function renameGitHistoryGraphFile(
     nodeMap.set(newPath, node);
   }
 
-  for (const edge of edges) {
+  for (let index = edges.length - 1; index >= 0; index--) {
+    const edge = edges[index];
     let changed = false;
     const previousId = edge.id;
 
@@ -67,7 +68,34 @@ export function renameGitHistoryGraphFile(
     }
 
     edgeSet.delete(previousId);
-    edge.id = replaceGraphEdgeIdEndpoints(edge, edge.from, edge.to);
+    const nextId = replaceGraphEdgeIdEndpoints(edge, edge.from, edge.to);
+    const duplicateIndex = edges.findIndex((candidate, candidateIndex) => {
+      return candidateIndex !== index && candidate.id === nextId;
+    });
+
+    if (duplicateIndex >= 0) {
+      mergeGitHistoryEdgeSources(edges[duplicateIndex], edge);
+      edges.splice(index, 1);
+      continue;
+    }
+
+    edge.id = nextId;
     edgeSet.add(edge.id);
   }
+}
+
+function mergeGitHistoryEdgeSources(targetEdge: IGraphEdge, sourceEdge: IGraphEdge): void {
+  const mergedSources = [...targetEdge.sources];
+  const seenSourceIds = new Set(mergedSources.map((source) => source.id));
+
+  for (const source of sourceEdge.sources) {
+    if (seenSourceIds.has(source.id)) {
+      continue;
+    }
+
+    seenSourceIds.add(source.id);
+    mergedSources.push(source);
+  }
+
+  targetEdge.sources = mergedSources;
 }

--- a/packages/extension/src/extension/gitHistory/files.ts
+++ b/packages/extension/src/extension/gitHistory/files.ts
@@ -24,7 +24,7 @@ export async function getDiffNameStatus(
     throw createAbortError();
   }
 
-  return execGit(['diff', '--name-status', '-M', parentSha, sha, '--', '.'], signal);
+  return execGit(['diff', '--name-status', '-M', '--relative', parentSha, sha, '--', '.'], signal);
 }
 
 export async function getFileAtCommit(
@@ -34,7 +34,7 @@ export async function getFileAtCommit(
   signal: AbortSignal
 ): Promise<string> {
   try {
-    return await execGit(['show', `${sha}:${filePath}`], signal);
+    return await execGit(['show', `${sha}:./${filePath}`], signal);
   } catch {
     return '';
   }

--- a/packages/extension/src/extension/gitHistory/files.ts
+++ b/packages/extension/src/extension/gitHistory/files.ts
@@ -10,7 +10,7 @@ export async function getCommitTreeFiles(
     throw createAbortError();
   }
 
-  const output = await execGit(['ls-tree', '-r', '--name-only', sha], signal);
+  const output = await execGit(['ls-tree', '-r', '--name-only', sha, '--', '.'], signal);
   return output.trim().split('\n').filter(Boolean);
 }
 
@@ -24,7 +24,7 @@ export async function getDiffNameStatus(
     throw createAbortError();
   }
 
-  return execGit(['diff', '--name-status', '-M', parentSha, sha], signal);
+  return execGit(['diff', '--name-status', '-M', parentSha, sha, '--', '.'], signal);
 }
 
 export async function getFileAtCommit(

--- a/packages/extension/src/extension/gitHistory/fullCommitAnalysis.ts
+++ b/packages/extension/src/extension/gitHistory/fullCommitAnalysis.ts
@@ -4,6 +4,7 @@ import { getFileColor } from '../../shared/fileColors';
 import type { IGraphData, IGraphEdge, IGraphNode } from '../../shared/graph/contracts';
 import { createGitHistoryCommitPathHost } from './commitPathHost';
 import { appendGitHistoryAnalysisEdges } from './graphConnections';
+import { preAnalyzeGitHistoryPlugins } from './preAnalyze';
 import { withTreeSitterPathHost } from '../pipeline/plugins/treesitter/runtime/pathHost';
 
 interface FullCommitAnalysisRegistry {
@@ -13,6 +14,14 @@ interface FullCommitAnalysisRegistry {
     workspaceRoot: string,
   ): Promise<IFileAnalysisResult | null>;
   getPluginForFile?(absolutePath: string): { id: string } | undefined;
+  notifyPreAnalyze(
+    files: Array<{
+      absolutePath: string;
+      relativePath: string;
+      content: string;
+    }>,
+    workspaceRoot: string,
+  ): Promise<void>;
 }
 
 export interface AnalyzeFullCommitGraphOptions {
@@ -65,6 +74,14 @@ export async function analyzeFullCommitGraph(
   const edges: IGraphEdge[] = [];
   const nodeIds = new Set<string>();
   const edgeSet = new Set<string>();
+  await preAnalyzeGitHistoryPlugins({
+    allFiles: allFiles.filter((filePath) => !shouldExclude(filePath)),
+    getFileAtCommit,
+    registry,
+    sha,
+    signal,
+    workspaceRoot,
+  });
   const pathHost = await createGitHistoryCommitPathHost({
     allFiles,
     getFileAtCommit,

--- a/packages/extension/src/extension/gitHistory/fullCommitAnalysis.ts
+++ b/packages/extension/src/extension/gitHistory/fullCommitAnalysis.ts
@@ -1,8 +1,12 @@
 import * as path from 'path';
-import type { IFileAnalysisResult } from '../../core/plugins/types/contracts';
+import type {
+  IFileAnalysisResult,
+  IPluginAnalysisContext,
+} from '../../core/plugins/types/contracts';
 import { getFileColor } from '../../shared/fileColors';
 import type { IGraphData, IGraphEdge, IGraphNode } from '../../shared/graph/contracts';
 import { createGitHistoryCommitPathHost } from './commitPathHost';
+import { createGitHistoryAnalysisContext } from './analysisContext';
 import { appendGitHistoryAnalysisEdges } from './graphConnections';
 import { preAnalyzeGitHistoryPlugins } from './preAnalyze';
 import { withTreeSitterPathHost } from '../pipeline/plugins/treesitter/runtime/pathHost';
@@ -12,6 +16,7 @@ interface FullCommitAnalysisRegistry {
     absolutePath: string,
     content: string,
     workspaceRoot: string,
+    context?: IPluginAnalysisContext,
   ): Promise<IFileAnalysisResult | null>;
   getPluginForFile?(absolutePath: string): { id: string } | undefined;
   notifyPreAnalyze(
@@ -21,6 +26,7 @@ interface FullCommitAnalysisRegistry {
       content: string;
     }>,
     workspaceRoot: string,
+    context: IPluginAnalysisContext,
   ): Promise<void>;
 }
 
@@ -74,6 +80,13 @@ export async function analyzeFullCommitGraph(
   const edges: IGraphEdge[] = [];
   const nodeIds = new Set<string>();
   const edgeSet = new Set<string>();
+  const analysisContext = createGitHistoryAnalysisContext({
+    allFiles,
+    getFileAtCommit,
+    sha,
+    signal,
+    workspaceRoot,
+  });
   await preAnalyzeGitHistoryPlugins({
     allFiles: allFiles.filter((filePath) => !shouldExclude(filePath)),
     getFileAtCommit,
@@ -81,7 +94,7 @@ export async function analyzeFullCommitGraph(
     sha,
     signal,
     workspaceRoot,
-  });
+  }, analysisContext);
   const pathHost = await createGitHistoryCommitPathHost({
     allFiles,
     getFileAtCommit,
@@ -101,7 +114,7 @@ export async function analyzeFullCommitGraph(
     const absolutePath = path.join(workspaceRoot, filePath);
     const analysis = await withTreeSitterPathHost(
       pathHost,
-      () => registry.analyzeFileResult(absolutePath, content, workspaceRoot),
+      () => registry.analyzeFileResult(absolutePath, content, workspaceRoot, analysisContext),
     );
     const plugin = registry.getPluginForFile?.(absolutePath);
 

--- a/packages/extension/src/extension/gitHistory/fullCommitAnalysis.ts
+++ b/packages/extension/src/extension/gitHistory/fullCommitAnalysis.ts
@@ -2,7 +2,9 @@ import * as path from 'path';
 import type { IFileAnalysisResult } from '../../core/plugins/types/contracts';
 import { getFileColor } from '../../shared/fileColors';
 import type { IGraphData, IGraphEdge, IGraphNode } from '../../shared/graph/contracts';
+import { createGitHistoryCommitPathHost } from './commitPathHost';
 import { appendGitHistoryAnalysisEdges } from './graphConnections';
+import { withTreeSitterPathHost } from '../pipeline/plugins/treesitter/runtime/pathHost';
 
 interface FullCommitAnalysisRegistry {
   analyzeFileResult(
@@ -63,6 +65,13 @@ export async function analyzeFullCommitGraph(
   const edges: IGraphEdge[] = [];
   const nodeIds = new Set<string>();
   const edgeSet = new Set<string>();
+  const pathHost = await createGitHistoryCommitPathHost({
+    allFiles,
+    getFileAtCommit,
+    sha,
+    signal,
+    workspaceRoot,
+  });
 
   for (const filePath of files) {
     if (signal.aborted) {
@@ -73,7 +82,10 @@ export async function analyzeFullCommitGraph(
 
     const content = await getFileAtCommit(sha, filePath, signal);
     const absolutePath = path.join(workspaceRoot, filePath);
-    const analysis = await registry.analyzeFileResult(absolutePath, content, workspaceRoot);
+    const analysis = await withTreeSitterPathHost(
+      pathHost,
+      () => registry.analyzeFileResult(absolutePath, content, workspaceRoot),
+    );
     const plugin = registry.getPluginForFile?.(absolutePath);
 
     if (!nodeIds.has(filePath)) {

--- a/packages/extension/src/extension/gitHistory/indexer.ts
+++ b/packages/extension/src/extension/gitHistory/indexer.ts
@@ -36,9 +36,9 @@ async function indexFirstCommit(
   onProgress: IndexGitHistoryOptions['onProgress'],
   signal: AbortSignal,
 ): Promise<{ firstGraphableCommitIndex: number; previousGraphData: IGraphData }> {
-  onProgress('Indexing commits', 1, total);
   const previousGraphData = await dependencies.analyzeFullCommit(firstCommit.sha, signal);
   await dependencies.writeCachedGraphData(firstCommit.sha, previousGraphData);
+  onProgress('Indexing commits', 1, total);
 
   return {
     firstGraphableCommitIndex: previousGraphData.nodes.length > 0 ? 0 : -1,
@@ -78,7 +78,6 @@ export async function indexGitHistory(
     }
 
     const commit = commits[index];
-    onProgress('Indexing commits', index + 1, total);
     previousGraphData = await dependencies.analyzeDiffCommit(
       commit.sha,
       commits[index - 1].sha,
@@ -86,6 +85,7 @@ export async function indexGitHistory(
       signal
     );
     await dependencies.writeCachedGraphData(commit.sha, previousGraphData);
+    onProgress('Indexing commits', index + 1, total);
 
     if (firstGraphableCommitIndex < 0 && previousGraphData.nodes.length > 0) {
       firstGraphableCommitIndex = index;
@@ -94,6 +94,7 @@ export async function indexGitHistory(
 
   const cachedCommits = getCachedTimelineCommits(commits, firstGraphableCommitIndex);
 
+  onProgress('Finalizing timeline cache', total, total);
   await dependencies.persistCachedCommitState(cachedCommits);
   return cachedCommits;
 }

--- a/packages/extension/src/extension/gitHistory/pathIndex.ts
+++ b/packages/extension/src/extension/gitHistory/pathIndex.ts
@@ -1,0 +1,72 @@
+import * as path from 'node:path';
+
+export function normalizeGitHistoryPath(relativePath: string): string {
+  return relativePath.split(path.sep).join('/');
+}
+
+export function toRelativeGitHistoryFilePath(
+  absolutePath: string,
+  workspaceRoot: string,
+): string | null {
+  const relativePath = path.relative(workspaceRoot, absolutePath);
+  if (relativePath === '') {
+    return null;
+  }
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return normalizeGitHistoryPath(relativePath);
+}
+
+export function toRelativeGitHistoryDirectoryPath(
+  absolutePath: string,
+  workspaceRoot: string,
+): string | null {
+  const relativePath = path.relative(workspaceRoot, absolutePath);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  return relativePath === '' ? '' : normalizeGitHistoryPath(relativePath);
+}
+
+export function buildGitHistoryDirectoryEntries(
+  allFiles: readonly string[],
+): Map<string, string[]> {
+  const directoryEntries = new Map<string, Set<string>>();
+
+  const addEntry = (directoryPath: string, entryName: string) => {
+    const entries = directoryEntries.get(directoryPath);
+    if (entries) {
+      entries.add(entryName);
+      return;
+    }
+
+    directoryEntries.set(directoryPath, new Set([entryName]));
+  };
+
+  for (const relativeFilePath of allFiles) {
+    const segments = normalizeGitHistoryPath(relativeFilePath).split('/');
+    let currentDirectory = '';
+
+    for (let index = 0; index < segments.length; index += 1) {
+      addEntry(currentDirectory, segments[index]);
+
+      if (index === segments.length - 1) {
+        break;
+      }
+
+      currentDirectory = currentDirectory
+        ? `${currentDirectory}/${segments[index]}`
+        : segments[index];
+    }
+  }
+
+  return new Map(
+    Array.from(directoryEntries.entries(), ([directoryPath, entries]) => {
+      return [directoryPath, Array.from(entries).sort()];
+    }),
+  );
+}

--- a/packages/extension/src/extension/gitHistory/preAnalyze.ts
+++ b/packages/extension/src/extension/gitHistory/preAnalyze.ts
@@ -1,0 +1,61 @@
+import * as path from 'path';
+
+interface GitHistoryPreAnalyzeRegistry {
+  notifyPreAnalyze(
+    files: Array<{
+      absolutePath: string;
+      relativePath: string;
+      content: string;
+    }>,
+    workspaceRoot: string,
+  ): Promise<void>;
+}
+
+export interface PreAnalyzeGitHistoryOptions {
+  allFiles: readonly string[];
+  getFileAtCommit: (
+    sha: string,
+    filePath: string,
+    signal: AbortSignal,
+  ) => Promise<string>;
+  registry: GitHistoryPreAnalyzeRegistry;
+  sha: string;
+  signal: AbortSignal;
+  workspaceRoot: string;
+}
+
+export async function preAnalyzeGitHistoryPlugins(
+  options: PreAnalyzeGitHistoryOptions,
+): Promise<void> {
+  const {
+    allFiles,
+    getFileAtCommit,
+    registry,
+    sha,
+    signal,
+    workspaceRoot,
+  } = options;
+
+  const files = await Promise.all(allFiles.map(async (relativePath) => {
+    throwIfGitHistoryPreAnalyzeAborted(signal);
+
+    return {
+      absolutePath: path.join(workspaceRoot, relativePath),
+      relativePath,
+      content: await getFileAtCommit(sha, relativePath, signal),
+    };
+  }));
+
+  throwIfGitHistoryPreAnalyzeAborted(signal);
+  await registry.notifyPreAnalyze(files, workspaceRoot);
+}
+
+function throwIfGitHistoryPreAnalyzeAborted(signal: AbortSignal): void {
+  if (!signal.aborted) {
+    return;
+  }
+
+  const error = new Error('Indexing aborted');
+  error.name = 'AbortError';
+  throw error;
+}

--- a/packages/extension/src/extension/gitHistory/preAnalyze.ts
+++ b/packages/extension/src/extension/gitHistory/preAnalyze.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import type { IPluginAnalysisContext } from '../../core/plugins/types/contracts';
 
 interface GitHistoryPreAnalyzeRegistry {
   notifyPreAnalyze(
@@ -8,6 +9,7 @@ interface GitHistoryPreAnalyzeRegistry {
       content: string;
     }>,
     workspaceRoot: string,
+    context: IPluginAnalysisContext,
   ): Promise<void>;
 }
 
@@ -26,6 +28,7 @@ export interface PreAnalyzeGitHistoryOptions {
 
 export async function preAnalyzeGitHistoryPlugins(
   options: PreAnalyzeGitHistoryOptions,
+  context: IPluginAnalysisContext,
 ): Promise<void> {
   const {
     allFiles,
@@ -47,7 +50,7 @@ export async function preAnalyzeGitHistoryPlugins(
   }));
 
   throwIfGitHistoryPreAnalyzeAborted(signal);
-  await registry.notifyPreAnalyze(files, workspaceRoot);
+  await registry.notifyPreAnalyze(files, workspaceRoot, context);
 }
 
 function throwIfGitHistoryPreAnalyzeAborted(signal: AbortSignal): void {

--- a/packages/extension/src/extension/gitHistory/reanalyzeGraphFile.ts
+++ b/packages/extension/src/extension/gitHistory/reanalyzeGraphFile.ts
@@ -1,6 +1,8 @@
 import * as path from 'path';
 import type { IFileAnalysisResult } from '../../core/plugins/types/contracts';
 import type { IGraphEdge, IGraphNode } from '../../shared/graph/contracts';
+import type { TreeSitterPathHost } from '../pipeline/plugins/treesitter/runtime/pathHost';
+import { withTreeSitterPathHost } from '../pipeline/plugins/treesitter/runtime/pathHost';
 import { appendGitHistoryAnalysisEdges } from './graphConnections';
 import { createGitHistoryNode } from './fullCommitAnalysis';
 
@@ -29,6 +31,7 @@ export interface ReanalyzeGraphFileOptions {
   sha: string;
   signal: AbortSignal;
   workspaceRoot: string;
+  pathHost?: TreeSitterPathHost;
 }
 
 export async function reanalyzeGraphFile(
@@ -45,6 +48,7 @@ export async function reanalyzeGraphFile(
     sha,
     signal,
     workspaceRoot,
+    pathHost,
   } = options;
 
   if (!registry.supportsFile(filePath)) {
@@ -53,7 +57,10 @@ export async function reanalyzeGraphFile(
 
   const content = await getFileAtCommit(sha, filePath, signal);
   const absolutePath = path.join(workspaceRoot, filePath);
-  const analysis = await registry.analyzeFileResult(absolutePath, content, workspaceRoot);
+  const analysis = await withTreeSitterPathHost(
+    pathHost,
+    () => registry.analyzeFileResult(absolutePath, content, workspaceRoot),
+  );
   const plugin = registry.getPluginForFile?.(absolutePath);
 
   if (!nodeMap.has(filePath)) {

--- a/packages/extension/src/extension/gitHistory/reanalyzeGraphFile.ts
+++ b/packages/extension/src/extension/gitHistory/reanalyzeGraphFile.ts
@@ -1,5 +1,8 @@
 import * as path from 'path';
-import type { IFileAnalysisResult } from '../../core/plugins/types/contracts';
+import type {
+  IFileAnalysisResult,
+  IPluginAnalysisContext,
+} from '../../core/plugins/types/contracts';
 import type { IGraphEdge, IGraphNode } from '../../shared/graph/contracts';
 import type { TreeSitterPathHost } from '../pipeline/plugins/treesitter/runtime/pathHost';
 import { withTreeSitterPathHost } from '../pipeline/plugins/treesitter/runtime/pathHost';
@@ -11,6 +14,7 @@ interface ReanalyzeGraphFileRegistry {
     absolutePath: string,
     content: string,
     workspaceRoot: string,
+    context?: IPluginAnalysisContext,
   ): Promise<IFileAnalysisResult | null>;
   getPluginForFile?(absolutePath: string): { id: string } | undefined;
   supportsFile(filePath: string): boolean;
@@ -32,6 +36,7 @@ export interface ReanalyzeGraphFileOptions {
   signal: AbortSignal;
   workspaceRoot: string;
   pathHost?: TreeSitterPathHost;
+  analysisContext?: IPluginAnalysisContext;
 }
 
 export async function reanalyzeGraphFile(
@@ -49,6 +54,7 @@ export async function reanalyzeGraphFile(
     signal,
     workspaceRoot,
     pathHost,
+    analysisContext,
   } = options;
 
   if (!registry.supportsFile(filePath)) {
@@ -59,7 +65,7 @@ export async function reanalyzeGraphFile(
   const absolutePath = path.join(workspaceRoot, filePath);
   const analysis = await withTreeSitterPathHost(
     pathHost,
-    () => registry.analyzeFileResult(absolutePath, content, workspaceRoot),
+    () => registry.analyzeFileResult(absolutePath, content, workspaceRoot, analysisContext),
   );
   const plugin = registry.getPluginForFile?.(absolutePath);
 

--- a/packages/extension/src/extension/graphView/timeline/indexing/result.ts
+++ b/packages/extension/src/extension/graphView/timeline/indexing/result.ts
@@ -19,6 +19,7 @@ export async function applyGraphViewTimelineIndexResult(
 ): Promise<void> {
   if (commits.length === 0) {
     handlers.showInformationMessage('No commits found to index');
+    handlers.sendMessage({ type: 'CACHE_INVALIDATED' });
     return;
   }
 

--- a/packages/extension/src/extension/graphView/timeline/indexing/run.ts
+++ b/packages/extension/src/extension/graphView/timeline/indexing/run.ts
@@ -48,7 +48,10 @@ export async function runGraphViewTimelineIndex(
       jumpToCommit: sha => handlers.jumpToCommit(sha),
     });
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') return;
+    if (error instanceof Error && error.name === 'AbortError') {
+      handlers.sendMessage({ type: 'CACHE_INVALIDATED' });
+      return;
+    }
     handlers.logError('[CodeGraphy] Indexing failed:', error);
     handlers.showErrorMessage(`Timeline indexing failed: ${handlers.toErrorMessage(error)}`);
     handlers.sendMessage({ type: 'CACHE_INVALIDATED' });

--- a/packages/extension/src/extension/graphView/timeline/provider/contracts.ts
+++ b/packages/extension/src/extension/graphView/timeline/provider/contracts.ts
@@ -31,6 +31,8 @@ export interface GraphViewProviderTimelineSource {
   _disabledPlugins: Set<string>;
   _rawGraphData: IGraphData;
   _graphData: IGraphData;
+  _computeMergedGroups?(): void;
+  _sendGroupsUpdated?(): void;
   _applyViewTransform?(): void;
   _sendMessage(message: ExtensionToWebviewMessage): void;
 }

--- a/packages/extension/src/extension/graphView/timeline/provider/indexing.ts
+++ b/packages/extension/src/extension/graphView/timeline/provider/indexing.ts
@@ -83,6 +83,8 @@ export async function resetGraphViewProviderTimeline(
     | '_disabledPlugins'
     | '_rawGraphData'
     | '_graphData'
+    | '_computeMergedGroups'
+    | '_sendGroupsUpdated'
     | '_applyViewTransform'
     | '_sendMessage'
   >,
@@ -102,6 +104,8 @@ export async function resetGraphViewProviderTimeline(
 
     if (graphData.nodes.length > 0) {
       applyTimelineCommitGraph(source, commit.sha, graphData);
+      source._computeMergedGroups?.();
+      source._sendGroupsUpdated?.();
       return;
     }
   }

--- a/packages/extension/src/extension/graphView/timeline/provider/jump.ts
+++ b/packages/extension/src/extension/graphView/timeline/provider/jump.ts
@@ -12,6 +12,8 @@ export async function jumpGraphViewProviderToCommit(
     | '_disabledPlugins'
     | '_rawGraphData'
     | '_graphData'
+    | '_computeMergedGroups'
+    | '_sendGroupsUpdated'
     | '_applyViewTransform'
     | '_sendMessage'
   >,
@@ -25,4 +27,6 @@ export async function jumpGraphViewProviderToCommit(
 
   const graphData = await buildTimelineCommitGraphData(source, sha, dependencies);
   applyTimelineCommitGraph(source, sha, graphData);
+  source._computeMergedGroups?.();
+  source._sendGroupsUpdated?.();
 }

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyze/existingFile.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/analyze/existingFile.ts
@@ -1,8 +1,8 @@
-import * as fs from 'node:fs';
+import { treeSitterPathIsFile } from '../pathHost';
 
 export function findExistingFile(candidates: readonly string[]): string | null {
   for (const candidatePath of candidates) {
-    if (fs.existsSync(candidatePath) && fs.statSync(candidatePath).isFile()) {
+    if (treeSitterPathIsFile(candidatePath)) {
       return candidatePath;
     }
   }

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/pathHost.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/pathHost.ts
@@ -1,0 +1,72 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import * as fs from 'node:fs';
+
+export interface TreeSitterPathHost {
+  exists(absolutePath: string): boolean;
+  isDirectory(absolutePath: string): boolean;
+  isFile(absolutePath: string): boolean;
+  listDirectory(absolutePath: string): readonly string[] | null;
+  readTextFile(absolutePath: string): string | null;
+}
+
+const treeSitterPathHostStorage = new AsyncLocalStorage<TreeSitterPathHost>();
+
+function getTreeSitterPathHost(): TreeSitterPathHost | undefined {
+  return treeSitterPathHostStorage.getStore();
+}
+
+export function withTreeSitterPathHost<T>(
+  pathHost: TreeSitterPathHost | undefined,
+  callback: () => T,
+): T {
+  if (!pathHost) {
+    return callback();
+  }
+
+  return treeSitterPathHostStorage.run(pathHost, callback);
+}
+
+export function treeSitterPathExists(absolutePath: string): boolean {
+  const pathHost = getTreeSitterPathHost();
+  return pathHost ? pathHost.exists(absolutePath) : fs.existsSync(absolutePath);
+}
+
+export function treeSitterPathIsFile(absolutePath: string): boolean {
+  const pathHost = getTreeSitterPathHost();
+  return pathHost
+    ? pathHost.isFile(absolutePath)
+    : fs.existsSync(absolutePath) && fs.statSync(absolutePath).isFile();
+}
+
+export function treeSitterPathIsDirectory(absolutePath: string): boolean {
+  const pathHost = getTreeSitterPathHost();
+  return pathHost
+    ? pathHost.isDirectory(absolutePath)
+    : fs.existsSync(absolutePath) && fs.statSync(absolutePath).isDirectory();
+}
+
+export function treeSitterReadDirectory(absolutePath: string): readonly string[] {
+  const pathHost = getTreeSitterPathHost();
+  if (pathHost) {
+    return pathHost.listDirectory(absolutePath) ?? [];
+  }
+
+  try {
+    return fs.readdirSync(absolutePath);
+  } catch {
+    return [];
+  }
+}
+
+export function treeSitterReadTextFile(absolutePath: string): string | null {
+  const pathHost = getTreeSitterPathHost();
+  if (pathHost) {
+    return pathHost.readTextFile(absolutePath);
+  }
+
+  try {
+    return fs.readFileSync(absolutePath, 'utf8');
+  } catch {
+    return null;
+  }
+}

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/projectRoots/go/module.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/projectRoots/go/module.ts
@@ -1,24 +1,15 @@
-import * as fs from 'node:fs';
 import * as path from 'node:path';
-
-const goModuleNameCache = new Map<string, string | null>();
+import { treeSitterReadTextFile } from '../../pathHost';
 
 export function readGoModuleName(projectRoot: string): string | null {
-  if (goModuleNameCache.has(projectRoot)) {
-    return goModuleNameCache.get(projectRoot) ?? null;
-  }
-
   const goModPath = path.join(projectRoot, 'go.mod');
-  let moduleName: string | null = null;
-
-  if (fs.existsSync(goModPath)) {
-    const content = fs.readFileSync(goModPath, 'utf8');
-    const match = content.match(/^module\s+(.+)$/mu);
-    moduleName = match?.[1]?.trim() ?? null;
+  const content = treeSitterReadTextFile(goModPath);
+  if (!content) {
+    return null;
   }
 
-  goModuleNameCache.set(projectRoot, moduleName);
-  return moduleName;
+  const match = content.match(/^module\s+(.+)$/mu);
+  return match?.[1]?.trim() ?? null;
 }
 
 export function resolveGoPackageDirectory(

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/projectRoots/go/packagePath.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/projectRoots/go/packagePath.ts
@@ -1,21 +1,25 @@
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { resolveGoPackageDirectory } from './module';
+import {
+  treeSitterPathIsDirectory,
+  treeSitterPathIsFile,
+  treeSitterReadDirectory,
+} from '../../pathHost';
 import { findNearestProjectRoot } from '../search';
 
 function resolveGoDirectFilePath(packageDirectoryPath: string): string | null {
   const directFilePath = `${packageDirectoryPath}.go`;
-  return fs.existsSync(directFilePath) && fs.statSync(directFilePath).isFile()
+  return treeSitterPathIsFile(directFilePath)
     ? directFilePath
     : null;
 }
 
 function listGoPackageFiles(packageDirectoryPath: string): string[] {
-  if (!fs.existsSync(packageDirectoryPath) || !fs.statSync(packageDirectoryPath).isDirectory()) {
+  if (!treeSitterPathIsDirectory(packageDirectoryPath)) {
     return [];
   }
 
-  return fs.readdirSync(packageDirectoryPath)
+  return treeSitterReadDirectory(packageDirectoryPath)
     .filter((entry) => entry.endsWith('.go') && !entry.endsWith('_test.go'))
     .sort();
 }

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/projectRoots/java.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/projectRoots/java.ts
@@ -1,5 +1,5 @@
-import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { treeSitterPathIsFile } from '../pathHost';
 
 export function resolveJavaSourceRoot(
   filePath: string,
@@ -42,7 +42,7 @@ export function resolveJavaTypePath(
   }
 
   const candidatePath = path.join(sourceRoot, ...typeName.split('.')) + '.java';
-  return fs.existsSync(candidatePath) && fs.statSync(candidatePath).isFile()
+  return treeSitterPathIsFile(candidatePath)
     ? candidatePath
     : null;
 }

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/projectRoots/search.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/projectRoots/search.ts
@@ -1,5 +1,5 @@
-import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { treeSitterPathExists } from '../pathHost';
 import { shouldStopProjectRootWalk } from './workspaceBounds';
 
 export function findNearestProjectRoot(
@@ -12,7 +12,7 @@ export function findNearestProjectRoot(
 
   while (true) {
     for (const marker of markers) {
-      if (fs.existsSync(path.join(currentPath, marker))) {
+      if (treeSitterPathExists(path.join(currentPath, marker))) {
         return currentPath;
       }
     }

--- a/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/resolve.ts
+++ b/packages/extension/src/extension/pipeline/plugins/treesitter/runtime/resolve.ts
@@ -1,5 +1,5 @@
-import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { findExistingFile } from './analyze/existingFile';
 
 const IMPORT_RESOLUTION_EXTENSIONS = [
   '',
@@ -14,21 +14,10 @@ const IMPORT_RESOLUTION_EXTENSIONS = [
 ] as const;
 
 function findExistingPath(basePath: string): string | null {
-  for (const extension of IMPORT_RESOLUTION_EXTENSIONS) {
-    const candidatePath = `${basePath}${extension}`;
-    if (fs.existsSync(candidatePath) && fs.statSync(candidatePath).isFile()) {
-      return candidatePath;
-    }
-  }
-
-  for (const extension of IMPORT_RESOLUTION_EXTENSIONS.slice(1)) {
-    const candidatePath = path.join(basePath, `index${extension}`);
-    if (fs.existsSync(candidatePath) && fs.statSync(candidatePath).isFile()) {
-      return candidatePath;
-    }
-  }
-
-  return null;
+  return findExistingFile([
+    ...IMPORT_RESOLUTION_EXTENSIONS.map((extension) => `${basePath}${extension}`),
+    ...IMPORT_RESOLUTION_EXTENSIONS.slice(1).map((extension) => path.join(basePath, `index${extension}`)),
+  ]);
 }
 
 export function resolveTreeSitterImportPath(

--- a/packages/extension/src/webview/app/graph/surface.tsx
+++ b/packages/extension/src/webview/app/graph/surface.tsx
@@ -12,6 +12,7 @@ export interface GraphSurfaceProps {
   coloredData: IGraphData | null | undefined;
   showOrphans: boolean;
   depthMode: boolean;
+  timelineActive: boolean;
   theme: GraphComponentProps['theme'];
   nodeDecorations: GraphComponentProps['nodeDecorations'];
   edgeDecorations: GraphComponentProps['edgeDecorations'];
@@ -25,6 +26,7 @@ export function GraphSurface({
   coloredData,
   showOrphans,
   depthMode,
+  timelineActive,
   theme,
   nodeDecorations,
   edgeDecorations,
@@ -33,7 +35,12 @@ export function GraphSurface({
   onAddLegendRequested,
 }: GraphSurfaceProps): React.ReactElement {
   if (graphData.nodes.length === 0) {
-    return <EmptyState hint={getNoDataHint(graphData, showOrphans, depthMode)} fullScreen={false} />;
+    return (
+      <EmptyState
+        hint={getNoDataHint(graphData, showOrphans, depthMode, timelineActive)}
+        fullScreen={false}
+      />
+    );
   }
 
   return (

--- a/packages/extension/src/webview/app/shell/messages.ts
+++ b/packages/extension/src/webview/app/shell/messages.ts
@@ -11,6 +11,7 @@ export function getNoDataHint(
   graphData: IGraphData | null,
   showOrphans: boolean,
   depthMode = false,
+  timelineActive = false,
 ): string {
   if (graphData && !showOrphans) {
     return 'All files are hidden. Try enabling "Show Orphans" in Settings → Filters.';
@@ -18,6 +19,10 @@ export function getNoDataHint(
 
   if (graphData && depthMode) {
     return 'No nodes match the current depth focus. Try changing the focused file or disabling depth mode.';
+  }
+
+  if (graphData && timelineActive) {
+    return 'No graphable files exist in this commit. Try another point in the timeline.';
   }
 
   return 'Open a folder to visualize its structure.';

--- a/packages/extension/src/webview/app/shell/view.tsx
+++ b/packages/extension/src/webview/app/shell/view.tsx
@@ -34,6 +34,7 @@ export default function App(): React.ReactElement {
     disabledCustomFilterPatterns,
     disabledPluginFilterPatterns,
     showOrphans,
+    timelineActive,
     activePanel,
     depthMode,
     nodeColors,
@@ -108,7 +109,7 @@ export default function App(): React.ReactElement {
   if (isLoading) return <LoadingState />;
 
   if (!graphData) {
-    return <EmptyState hint={getNoDataHint(graphData, showOrphans, depthMode)} />;
+    return <EmptyState hint={getNoDataHint(graphData, showOrphans, depthMode, timelineActive)} />;
   }
 
   const displayGraphData = coloredData || graphData;
@@ -166,6 +167,7 @@ export default function App(): React.ReactElement {
           coloredData={coloredData}
           showOrphans={showOrphans}
           depthMode={depthMode}
+          timelineActive={timelineActive}
           theme={theme}
           nodeDecorations={nodeDecorations}
           edgeDecorations={graphEdgeDecorations}

--- a/packages/extension/src/webview/components/timeline/view/Status.tsx
+++ b/packages/extension/src/webview/components/timeline/view/Status.tsx
@@ -72,11 +72,11 @@ export default function Status({
         variant="outline"
         size="sm"
         onClick={onIndexRepo}
-        title="Index repository git history"
+        title="Index Git history"
         disabled={!canIndexRepo}
       >
         <MdiIcon path={mdiClockOutline} size={16} className="mr-1" />
-        Index Repo
+        Index Git History
       </Button>
     </div>
   );

--- a/packages/extension/tests/core/plugins/context/workspace.test.ts
+++ b/packages/extension/tests/core/plugins/context/workspace.test.ts
@@ -1,0 +1,55 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createWorkspacePluginAnalysisContext } from '../../../../src/core/plugins/context/workspace';
+
+describe('createWorkspacePluginAnalysisContext', () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraphy-workspace-context-'));
+    fs.mkdirSync(path.join(workspaceRoot, 'src', 'nested'), { recursive: true });
+    fs.writeFileSync(path.join(workspaceRoot, 'src', 'app.ts'), 'export const app = true;\n');
+    fs.writeFileSync(path.join(workspaceRoot, 'src', 'nested', 'value.ts'), 'export const value = 1;\n');
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('reads files and directories inside the workspace and rejects paths outside it', async () => {
+    const context = createWorkspacePluginAnalysisContext(workspaceRoot);
+    const filePath = path.join(workspaceRoot, 'src', 'app.ts');
+    const directoryPath = path.join(workspaceRoot, 'src');
+    const missingPath = path.join(workspaceRoot, 'missing.ts');
+    const outsidePath = path.join(path.dirname(workspaceRoot), 'outside.ts');
+
+    expect(context.mode).toBe('workspace');
+    await expect(context.fileSystem.exists(workspaceRoot)).resolves.toBe(true);
+    await expect(context.fileSystem.exists(filePath)).resolves.toBe(true);
+    await expect(context.fileSystem.exists(directoryPath)).resolves.toBe(true);
+    await expect(context.fileSystem.exists(missingPath)).resolves.toBe(false);
+    await expect(context.fileSystem.exists(outsidePath)).resolves.toBe(false);
+
+    await expect(context.fileSystem.isDirectory(workspaceRoot)).resolves.toBe(true);
+    await expect(context.fileSystem.isDirectory(directoryPath)).resolves.toBe(true);
+    await expect(context.fileSystem.isDirectory(filePath)).resolves.toBe(false);
+    await expect(context.fileSystem.isDirectory(outsidePath)).resolves.toBe(false);
+
+    await expect(context.fileSystem.isFile(filePath)).resolves.toBe(true);
+    await expect(context.fileSystem.isFile(directoryPath)).resolves.toBe(false);
+    await expect(context.fileSystem.isFile(missingPath)).resolves.toBe(false);
+    await expect(context.fileSystem.isFile(outsidePath)).resolves.toBe(false);
+
+    await expect(context.fileSystem.listDirectory(workspaceRoot)).resolves.toEqual(['src']);
+    await expect(context.fileSystem.listDirectory(directoryPath)).resolves.toEqual(['app.ts', 'nested']);
+    await expect(context.fileSystem.listDirectory(filePath)).resolves.toBeNull();
+    await expect(context.fileSystem.listDirectory(outsidePath)).resolves.toBeNull();
+
+    await expect(context.fileSystem.readTextFile(filePath)).resolves.toBe('export const app = true;\n');
+    await expect(context.fileSystem.readTextFile(directoryPath)).resolves.toBeNull();
+    await expect(context.fileSystem.readTextFile(missingPath)).resolves.toBeNull();
+    await expect(context.fileSystem.readTextFile(outsidePath)).resolves.toBeNull();
+  });
+});

--- a/packages/extension/tests/core/plugins/lifecycle/notify/analysis.test.ts
+++ b/packages/extension/tests/core/plugins/lifecycle/notify/analysis.test.ts
@@ -21,6 +21,32 @@ function makePlugin(overrides: Partial<IPlugin> = {}): IPlugin {
 }
 
 describe('plugin lifecycle notify/analysis', () => {
+  it('passes the analysis context to pre-analysis hooks', async () => {
+    const onPreAnalyze = vi.fn().mockResolvedValue(undefined);
+    const plugin = makePlugin({ onPreAnalyze });
+    const files = [{ absolutePath: '/ws/a.ts', relativePath: 'a.ts', content: '' }];
+    const context = {
+      mode: 'timeline',
+      commitSha: 'abc123',
+      fileSystem: {
+        exists: vi.fn(),
+        isDirectory: vi.fn(),
+        isFile: vi.fn(),
+        listDirectory: vi.fn(),
+        readTextFile: vi.fn(),
+      },
+    };
+
+    await (notifyPreAnalyze as unknown as (...args: unknown[]) => Promise<void>)(
+      new Map([[plugin.id, { plugin }]]),
+      files,
+      '/ws',
+      context,
+    );
+
+    expect(onPreAnalyze).toHaveBeenCalledWith(files, '/ws', context);
+  });
+
   it('calls onPreAnalyze with the shared files payload', async () => {
     const onPreAnalyze = vi.fn().mockResolvedValue(undefined);
     const plugin = makePlugin({ onPreAnalyze });
@@ -28,7 +54,11 @@ describe('plugin lifecycle notify/analysis', () => {
 
     await notifyPreAnalyze(new Map([[plugin.id, { plugin }]]), files, '/ws');
 
-    expect(onPreAnalyze).toHaveBeenCalledWith(files, '/ws');
+    expect(onPreAnalyze).toHaveBeenCalledWith(
+      files,
+      '/ws',
+      expect.objectContaining({ mode: 'workspace' }),
+    );
   });
 
   it('calls post-analysis hooks when they are present', () => {

--- a/packages/extension/tests/core/plugins/lifecycle/notify/filesChanged.test.ts
+++ b/packages/extension/tests/core/plugins/lifecycle/notify/filesChanged.test.ts
@@ -15,6 +15,31 @@ function makePlugin(overrides: Partial<IPlugin> = {}): IPlugin {
 }
 
 describe('plugin lifecycle notify/filesChanged', () => {
+  it('passes the analysis context to change hooks', async () => {
+    const onFilesChanged = vi.fn().mockResolvedValue(undefined);
+    const plugin = makePlugin({ onFilesChanged });
+    const files = [{ absolutePath: '/ws/a.ts', relativePath: 'a.ts', content: '' }];
+    const context = {
+      mode: 'workspace',
+      fileSystem: {
+        exists: vi.fn(),
+        isDirectory: vi.fn(),
+        isFile: vi.fn(),
+        listDirectory: vi.fn(),
+        readTextFile: vi.fn(),
+      },
+    };
+
+    await (notifyFilesChanged as unknown as (...args: unknown[]) => Promise<unknown>)(
+      new Map([[plugin.id, { plugin }]]),
+      files,
+      '/ws',
+      context,
+    );
+
+    expect(onFilesChanged).toHaveBeenCalledWith(files, '/ws', context);
+  });
+
   it('deduplicates additional file paths returned by matching plugins', async () => {
     const onFilesChanged = vi.fn().mockResolvedValue(['src/a.ts', 'src/a.ts', '', 42]);
     const plugin = makePlugin({ onFilesChanged });
@@ -63,8 +88,16 @@ describe('plugin lifecycle notify/filesChanged', () => {
       additionalFilePaths: [],
       requiresFullRefresh: false,
     });
-    expect(wildcardPlugin.onFilesChanged).toHaveBeenCalledWith(files, '/ws');
-    expect(caseInsensitivePlugin.onFilesChanged).toHaveBeenCalledWith(files, '/ws');
+    expect(wildcardPlugin.onFilesChanged).toHaveBeenCalledWith(
+      files,
+      '/ws',
+      expect.objectContaining({ mode: 'workspace' }),
+    );
+    expect(caseInsensitivePlugin.onFilesChanged).toHaveBeenCalledWith(
+      files,
+      '/ws',
+      expect.objectContaining({ mode: 'workspace' }),
+    );
     expect(ignoredPlugin.onFilesChanged).not.toHaveBeenCalled();
   });
 
@@ -125,6 +158,10 @@ describe('plugin lifecycle notify/filesChanged', () => {
       '[CodeGraphy] Error in onFilesChanged for broken-plugin:',
       expect.any(Error),
     );
-    expect(healthyPlugin.onFilesChanged).toHaveBeenCalledWith(files, '/ws');
+    expect(healthyPlugin.onFilesChanged).toHaveBeenCalledWith(
+      files,
+      '/ws',
+      expect.objectContaining({ mode: 'workspace' }),
+    );
   });
 });

--- a/packages/extension/tests/core/plugins/lifecycle/pluginLifecycle.test.ts
+++ b/packages/extension/tests/core/plugins/lifecycle/pluginLifecycle.test.ts
@@ -129,7 +129,11 @@ describe('pluginLifecycle', () => {
 
       await notifyPreAnalyze(plugins, files, '/ws');
 
-      expect(onPreAnalyze).toHaveBeenCalledWith(files, '/ws');
+      expect(onPreAnalyze).toHaveBeenCalledWith(
+        files,
+        '/ws',
+        expect.objectContaining({ mode: 'workspace' }),
+      );
     });
   });
 
@@ -144,7 +148,11 @@ describe('pluginLifecycle', () => {
         additionalFilePaths: ['src/dependency.ts'],
         requiresFullRefresh: false,
       });
-      expect(onFilesChanged).toHaveBeenCalledWith(files, '/ws');
+      expect(onFilesChanged).toHaveBeenCalledWith(
+        files,
+        '/ws',
+        expect.objectContaining({ mode: 'workspace' }),
+      );
     });
 
     it('requests a full refresh when a matching plugin still only supports pre-analysis hooks', async () => {

--- a/packages/extension/tests/core/plugins/registry/pluginRegistry.analysis.test.ts
+++ b/packages/extension/tests/core/plugins/registry/pluginRegistry.analysis.test.ts
@@ -41,7 +41,8 @@ describe('PluginRegistry analysis', () => {
     expect(plugin.analyzeFile).toHaveBeenCalledWith(
       '/src/app.ts',
       'content',
-      '/workspace'
+      '/workspace',
+      expect.objectContaining({ mode: 'workspace' }),
     );
     expect(result).toEqual([
       {
@@ -130,7 +131,12 @@ describe('PluginRegistry analysis', () => {
 
     const result = await registry.analyzeFileResult('/src/app.ts', 'content', '/workspace');
 
-    expect(plugin.analyzeFile).toHaveBeenCalledWith('/src/app.ts', 'content', '/workspace');
+    expect(plugin.analyzeFile).toHaveBeenCalledWith(
+      '/src/app.ts',
+      'content',
+      '/workspace',
+      expect.objectContaining({ mode: 'workspace' }),
+    );
     expect(result).toEqual({
       edgeTypes: [],
       filePath: '/src/app.ts',

--- a/packages/extension/tests/core/plugins/registry/v2.test.ts
+++ b/packages/extension/tests/core/plugins/registry/v2.test.ts
@@ -249,7 +249,11 @@ describe('PluginRegistry v2', () => {
       registry.notifyWebviewReady();
 
       expect(plugin.onWorkspaceReady).toHaveBeenCalledWith(graph);
-      expect(plugin.onPreAnalyze).toHaveBeenCalledWith(files, '/workspace');
+      expect(plugin.onPreAnalyze).toHaveBeenCalledWith(
+        files,
+        '/workspace',
+        expect.objectContaining({ mode: 'workspace' }),
+      );
       expect(plugin.onPostAnalyze).toHaveBeenCalledWith(graph);
       expect(plugin.onGraphRebuild).toHaveBeenCalledWith(graph);
       expect(plugin.onWebviewReady).toHaveBeenCalledOnce();

--- a/packages/extension/tests/core/plugins/routing/analyze.test.ts
+++ b/packages/extension/tests/core/plugins/routing/analyze.test.ts
@@ -36,6 +36,41 @@ function makePlugin(id: string, extensions: string[], result: object): IPlugin {
 }
 
 describe('routing/analyze', () => {
+  it('passes the analysis context through to matching plugins', async () => {
+    const active = makePlugin('active', ['.ts'], {
+      filePath: 'src/app.ts',
+      relations: [],
+    });
+    const { pluginsMap, extensionMap } = buildMaps([active]);
+    const context = {
+      mode: 'workspace',
+      fileSystem: {
+        exists: vi.fn(),
+        isDirectory: vi.fn(),
+        isFile: vi.fn(),
+        listDirectory: vi.fn(),
+        readTextFile: vi.fn(),
+      },
+    };
+
+    await (analyzeFileResult as unknown as (...args: unknown[]) => Promise<unknown>)(
+      'src/app.ts',
+      'content',
+      '/ws',
+      pluginsMap,
+      extensionMap,
+      undefined,
+      context,
+    );
+
+    expect(active.analyzeFile).toHaveBeenCalledWith(
+      'src/app.ts',
+      'content',
+      '/ws',
+      context,
+    );
+  });
+
   it('projects analyzed file results into graph connections', async () => {
     const active = makePlugin('active', ['.ts'], {
       filePath: 'src/app.ts',

--- a/packages/extension/tests/extension/gitHistory/analysisContext.test.ts
+++ b/packages/extension/tests/extension/gitHistory/analysisContext.test.ts
@@ -1,0 +1,96 @@
+import * as path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { createGitHistoryAnalysisContext } from '../../../src/extension/gitHistory/analysisContext';
+
+describe('createGitHistoryAnalysisContext', () => {
+  it('resolves commit-local files and directories and caches file reads', async () => {
+    const getFileAtCommit = vi.fn(async (sha: string, filePath: string) => {
+      return `${sha}:${filePath}`;
+    });
+    const context = createGitHistoryAnalysisContext({
+      allFiles: ['src/app.ts', 'src/lib/util.ts', 'README.md'],
+      getFileAtCommit,
+      sha: 'abc123',
+      signal: new AbortController().signal,
+      workspaceRoot: '/workspace',
+    });
+
+    expect(context.mode).toBe('timeline');
+    expect(context.commitSha).toBe('abc123');
+
+    const rootPath = '/workspace';
+    const srcDirectory = path.join(rootPath, 'src');
+    const libDirectory = path.join(rootPath, 'src', 'lib');
+    const appFile = path.join(rootPath, 'src', 'app.ts');
+    const utilFile = path.join(rootPath, 'src', 'lib', 'util.ts');
+    const readmeFile = path.join(rootPath, 'README.md');
+    const missingPath = path.join(rootPath, 'missing.ts');
+    const outsidePath = '/outside/app.ts';
+
+    await expect(context.fileSystem.exists(rootPath)).resolves.toBe(true);
+    await expect(context.fileSystem.exists(srcDirectory)).resolves.toBe(true);
+    await expect(context.fileSystem.exists(appFile)).resolves.toBe(true);
+    await expect(context.fileSystem.exists(missingPath)).resolves.toBe(false);
+    await expect(context.fileSystem.exists(outsidePath)).resolves.toBe(false);
+
+    await expect(context.fileSystem.isDirectory(rootPath)).resolves.toBe(true);
+    await expect(context.fileSystem.isDirectory(srcDirectory)).resolves.toBe(true);
+    await expect(context.fileSystem.isDirectory(libDirectory)).resolves.toBe(true);
+    await expect(context.fileSystem.isDirectory(appFile)).resolves.toBe(false);
+
+    await expect(context.fileSystem.isFile(appFile)).resolves.toBe(true);
+    await expect(context.fileSystem.isFile(utilFile)).resolves.toBe(true);
+    await expect(context.fileSystem.isFile(srcDirectory)).resolves.toBe(false);
+    await expect(context.fileSystem.isFile(outsidePath)).resolves.toBe(false);
+
+    await expect(context.fileSystem.listDirectory(rootPath)).resolves.toEqual(['README.md', 'src']);
+    await expect(context.fileSystem.listDirectory(srcDirectory)).resolves.toEqual(['app.ts', 'lib']);
+    await expect(context.fileSystem.listDirectory(libDirectory)).resolves.toEqual(['util.ts']);
+    await expect(context.fileSystem.listDirectory(outsidePath)).resolves.toBeNull();
+
+    await expect(context.fileSystem.readTextFile(appFile)).resolves.toBe('abc123:src/app.ts');
+    await expect(context.fileSystem.readTextFile(appFile)).resolves.toBe('abc123:src/app.ts');
+    await expect(context.fileSystem.readTextFile(readmeFile)).resolves.toBe('abc123:README.md');
+    await expect(context.fileSystem.readTextFile(srcDirectory)).resolves.toBeNull();
+    await expect(context.fileSystem.readTextFile(missingPath)).resolves.toBeNull();
+    await expect(context.fileSystem.readTextFile(outsidePath)).resolves.toBeNull();
+
+    expect(getFileAtCommit).toHaveBeenCalledTimes(2);
+    expect(getFileAtCommit).toHaveBeenNthCalledWith(
+      1,
+      'abc123',
+      'src/app.ts',
+      expect.any(AbortSignal),
+    );
+    expect(getFileAtCommit).toHaveBeenNthCalledWith(
+      2,
+      'abc123',
+      'README.md',
+      expect.any(AbortSignal),
+    );
+  });
+
+  it('returns null when commit-local file reads fail', async () => {
+    const getFileAtCommit = vi.fn(async () => {
+      throw new Error('missing from commit');
+    });
+    const context = createGitHistoryAnalysisContext({
+      allFiles: ['src/app.ts'],
+      getFileAtCommit,
+      sha: 'deadbeef',
+      signal: new AbortController().signal,
+      workspaceRoot: '/workspace',
+    });
+    const filePath = '/workspace/src/app.ts';
+
+    await expect(context.fileSystem.readTextFile(filePath)).resolves.toBeNull();
+    await expect(context.fileSystem.readTextFile(filePath)).resolves.toBeNull();
+
+    expect(getFileAtCommit).toHaveBeenCalledTimes(1);
+    expect(getFileAtCommit).toHaveBeenCalledWith(
+      'deadbeef',
+      'src/app.ts',
+      expect.any(AbortSignal),
+    );
+  });
+});

--- a/packages/extension/tests/extension/gitHistory/analyzer.pluginContext.test.ts
+++ b/packages/extension/tests/extension/gitHistory/analyzer.pluginContext.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ExecFileOptions } from 'child_process';
+import * as path from 'node:path';
+import type { ExtensionContext } from 'vscode';
+
+vi.mock('vscode', () => ({
+  workspace: {
+    getConfiguration: vi.fn(),
+    onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+  Uri: {
+    joinPath: vi.fn((...args: unknown[]) => {
+      const parts = args.map((arg) => String((arg as { fsPath?: string }).fsPath ?? arg));
+      return { fsPath: parts.join('/') };
+    }),
+    file: vi.fn((filePath: string) => ({ fsPath: filePath, scheme: 'file' })),
+  },
+}));
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  default: { execFile: mockExecFile },
+  execFile: mockExecFile,
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: vi.fn(),
+      writeFile: vi.fn(),
+      readFile: vi.fn(),
+      rm: vi.fn(),
+      access: vi.fn(),
+    },
+  };
+});
+
+import * as fs from 'fs';
+import { GitHistoryAnalyzer } from '../../../src/extension/gitHistory/analyzer';
+import { createConfiguredRegistry } from '../../core/plugins/registry/pluginRegistry.testSupport';
+
+function createMockContext(): ExtensionContext & {
+  _stateStore: Map<string, unknown>;
+} {
+  const stateStore = new Map<string, unknown>();
+  return {
+    storageUri: { fsPath: '/tmp/test-storage' },
+    workspaceState: {
+      get: vi.fn(<T>(key: string): T | undefined => stateStore.get(key) as T | undefined),
+      update: vi.fn((key: string, value: unknown) => {
+        if (value === undefined) {
+          stateStore.delete(key);
+        } else {
+          stateStore.set(key, value);
+        }
+        return Promise.resolve();
+      }),
+    },
+    _stateStore: stateStore,
+  } as unknown as ExtensionContext & {
+    _stateStore: Map<string, unknown>;
+  };
+}
+
+function mockGitCommands(handlers: Array<{ match: string | RegExp; stdout: string }>) {
+  mockExecFile.mockImplementation(((
+    _cmd: string,
+    args: readonly string[],
+    _opts: ExecFileOptions,
+    cb?: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    const joined = [...args].join(' ');
+    for (const handler of handlers) {
+      const matches = typeof handler.match === 'string'
+        ? joined.includes(handler.match)
+        : handler.match.test(joined);
+      if (matches) {
+        cb?.(null, handler.stdout, '');
+        return undefined as never;
+      }
+    }
+
+    cb?.(null, '', '');
+    return undefined as never;
+  }) as never);
+}
+
+function readCachedGraph(callIndex: number) {
+  const call = vi.mocked(fs.promises.writeFile).mock.calls[callIndex];
+  return JSON.parse(call[1] as string) as {
+    nodes: Array<{ id: string }>;
+    edges: Array<{ from: string; to: string }>;
+  };
+}
+
+describe('GitHistoryAnalyzer plugin analysis context', () => {
+  const workspaceRoot = '/workspace';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lets plugins resolve timeline edges from commit-local files', async () => {
+    const registry = createConfiguredRegistry();
+    registry.register({
+      id: 'acme.timeline-plugin',
+      name: 'Timeline Plugin',
+      version: '1.0.0',
+      apiVersion: '^2.0.0',
+      supportedExtensions: ['.edge'],
+      analyzeFile: vi.fn(async (filePath: string, _content: string, _root: string, context?: {
+        mode?: string;
+        commitSha?: string;
+        fileSystem?: {
+          exists(filePath: string): Promise<boolean>;
+        };
+      }) => {
+        if (!filePath.endsWith('app.edge')) {
+          return { filePath, relations: [] };
+        }
+
+        const targetPath = path.join(path.dirname(filePath), 'target.edge');
+        if (!(await context?.fileSystem?.exists(targetPath))) {
+          return { filePath, relations: [] };
+        }
+
+        return {
+          filePath,
+          relations: [{
+            kind: 'reference' as const,
+            sourceId: 'timeline-edge',
+            fromFilePath: filePath,
+            toFilePath: targetPath,
+            specifier: './target.edge',
+          }],
+        };
+      }),
+    });
+    const analyzer = new GitHistoryAnalyzer(
+      createMockContext(),
+      registry,
+      workspaceRoot,
+    );
+
+    mockGitCommands([
+      { match: 'rev-parse --abbrev-ref HEAD', stdout: 'main\n' },
+      {
+        match: 'log',
+        stdout: [
+          'sha2|2|remove target|A|sha1',
+          'sha1|1|add target|A|',
+        ].join('\n'),
+      },
+      { match: /ls-tree -r --name-only sha1/, stdout: 'graph/app.edge\ngraph/target.edge\n' },
+      { match: /ls-tree -r --name-only sha2/, stdout: 'graph/app.edge\n' },
+      { match: /show sha1:graph\/app\.edge/, stdout: 'target.edge' },
+      { match: /show sha1:graph\/target\.edge/, stdout: 'hello' },
+      { match: /diff --name-status -M sha1 sha2/, stdout: 'D\tgraph/target.edge\nM\tgraph/app.edge\n' },
+      { match: /show sha2:graph\/app\.edge/, stdout: 'target.edge' },
+    ]);
+
+    await analyzer.indexHistory(vi.fn(), new AbortController().signal);
+
+    const firstGraph = readCachedGraph(0);
+    const secondGraph = readCachedGraph(1);
+
+    expect(firstGraph.edges).toContainEqual({
+      from: 'graph/app.edge',
+      to: 'graph/target.edge',
+      id: expect.stringContaining('graph/app.edge->graph/target.edge'),
+      kind: 'reference',
+      sources: expect.any(Array),
+    });
+    expect(secondGraph.edges).not.toContainEqual(
+      expect.objectContaining({
+        from: 'graph/app.edge',
+        to: 'graph/target.edge',
+      }),
+    );
+    const plugin = registry.get('acme.timeline-plugin')?.plugin;
+    if (!plugin?.analyzeFile) {
+      throw new Error('Expected timeline plugin analyzeFile hook to be registered');
+    }
+    const analyzeCalls = vi.mocked(plugin.analyzeFile).mock.calls;
+    expect(analyzeCalls).toContainEqual([
+      '/workspace/graph/app.edge',
+      'target.edge',
+      '/workspace',
+      expect.objectContaining({ mode: 'timeline', commitSha: 'sha1' }),
+    ]);
+    expect(analyzeCalls).toContainEqual([
+      '/workspace/graph/app.edge',
+      'target.edge',
+      '/workspace',
+      expect.objectContaining({ mode: 'timeline', commitSha: 'sha2' }),
+    ]);
+  });
+});

--- a/packages/extension/tests/extension/gitHistory/analyzer.pluginContext.test.ts
+++ b/packages/extension/tests/extension/gitHistory/analyzer.pluginContext.test.ts
@@ -159,10 +159,10 @@ describe('GitHistoryAnalyzer plugin analysis context', () => {
       },
       { match: /ls-tree -r --name-only sha1/, stdout: 'graph/app.edge\ngraph/target.edge\n' },
       { match: /ls-tree -r --name-only sha2/, stdout: 'graph/app.edge\n' },
-      { match: /show sha1:graph\/app\.edge/, stdout: 'target.edge' },
-      { match: /show sha1:graph\/target\.edge/, stdout: 'hello' },
-      { match: /diff --name-status -M sha1 sha2/, stdout: 'D\tgraph/target.edge\nM\tgraph/app.edge\n' },
-      { match: /show sha2:graph\/app\.edge/, stdout: 'target.edge' },
+      { match: /show sha1:\.\/graph\/app\.edge/, stdout: 'target.edge' },
+      { match: /show sha1:\.\/graph\/target\.edge/, stdout: 'hello' },
+      { match: /diff --name-status -M --relative sha1 sha2/, stdout: 'D\tgraph/target.edge\nM\tgraph/app.edge\n' },
+      { match: /show sha2:\.\/graph\/app\.edge/, stdout: 'target.edge' },
     ]);
 
     await analyzer.indexHistory(vi.fn(), new AbortController().signal);

--- a/packages/extension/tests/extension/gitHistory/analyzer.test.ts
+++ b/packages/extension/tests/extension/gitHistory/analyzer.test.ts
@@ -426,7 +426,8 @@ describe('GitHistoryAnalyzer', () => {
           match: 'log',
           stdout: 'sha2|2|second|A|sha1\nsha1|1|first|B|\n',
         },
-        { match: 'ls-tree', stdout: 'src/a.ts\n' },
+        { match: /ls-tree -r --name-only sha1/, stdout: 'src/a.ts\n' },
+        { match: /ls-tree -r --name-only sha2/, stdout: 'src/a.ts\nsrc/new.ts\n' },
         { match: /show sha1:/, stdout: '' },
         {
           match: /diff --name-status/,
@@ -557,7 +558,8 @@ describe('GitHistoryAnalyzer', () => {
           match: 'log',
           stdout: 'sha2|2|second|A|sha1\nsha1|1|first|B|\n',
         },
-        { match: 'ls-tree', stdout: 'src/old.ts\nsrc/main.ts\n' },
+        { match: /ls-tree -r --name-only sha1/, stdout: 'src/old.ts\nsrc/main.ts\n' },
+        { match: /ls-tree -r --name-only sha2/, stdout: 'src/new.ts\nsrc/main.ts\n' },
         { match: /show sha1:src\/old\.ts/, stdout: '' },
         { match: /show sha1:src\/main\.ts/, stdout: 'import "./old";' },
         {
@@ -685,7 +687,8 @@ describe('GitHistoryAnalyzer', () => {
           match: 'log',
           stdout: 'sha2|2|second|A|sha1\nsha1|1|first|B|\n',
         },
-        { match: 'ls-tree', stdout: 'src/a.ts\n' },
+        { match: /ls-tree -r --name-only sha1/, stdout: 'src/a.ts\n' },
+        { match: /ls-tree -r --name-only sha2/, stdout: 'src/a.ts\nsrc/b.ts\nassets/sprite.ts\n' },
         { match: /show sha1:/, stdout: '' },
         {
           match: /diff --name-status/,
@@ -816,7 +819,7 @@ describe('GitHistoryAnalyzer', () => {
     });
 
     it('should return true when correct cache version and plugin signature are stored', () => {
-      context._stateStore.set('codegraphy.timelineCacheVersion', '1.2.0');
+      context._stateStore.set('codegraphy.timelineCacheVersion', '1.3.0');
       context._stateStore.set(
         'codegraphy.timelinePluginSignature',
         'test.plugin@1.0.0',
@@ -829,7 +832,7 @@ describe('GitHistoryAnalyzer', () => {
         { plugin: { id: 'z.plugin', version: '2.0.0' } },
         { plugin: { id: 'a.plugin', version: '1.0.0' } },
       ]);
-      context._stateStore.set('codegraphy.timelineCacheVersion', '1.2.0');
+      context._stateStore.set('codegraphy.timelineCacheVersion', '1.3.0');
       context._stateStore.set(
         'codegraphy.timelinePluginSignature',
         'a.plugin@1.0.0|z.plugin@2.0.0',
@@ -844,7 +847,7 @@ describe('GitHistoryAnalyzer', () => {
     });
 
     it('should return false when plugin signature does not match the current registry', () => {
-      context._stateStore.set('codegraphy.timelineCacheVersion', '1.2.0');
+      context._stateStore.set('codegraphy.timelineCacheVersion', '1.3.0');
       context._stateStore.set(
         'codegraphy.timelinePluginSignature',
         'stale.plugin@1.0.0',
@@ -863,7 +866,7 @@ describe('GitHistoryAnalyzer', () => {
       const commits = [
         { sha: 'abc', timestamp: 1, message: 'init', author: 'A', parents: [] },
       ];
-      context._stateStore.set('codegraphy.timelineCacheVersion', '1.2.0');
+      context._stateStore.set('codegraphy.timelineCacheVersion', '1.3.0');
       context._stateStore.set(
         'codegraphy.timelinePluginSignature',
         'test.plugin@1.0.0',
@@ -881,7 +884,7 @@ describe('GitHistoryAnalyzer', () => {
         { plugin: { id: 'z.plugin', version: '2.0.0' } },
         { plugin: { id: 'a.plugin', version: '1.0.0' } },
       ]);
-      context._stateStore.set('codegraphy.timelineCacheVersion', '1.2.0');
+      context._stateStore.set('codegraphy.timelineCacheVersion', '1.3.0');
       context._stateStore.set(
         'codegraphy.timelinePluginSignature',
         'a.plugin@1.0.0|z.plugin@2.0.0',
@@ -895,7 +898,7 @@ describe('GitHistoryAnalyzer', () => {
       const commits = [
         { sha: 'abc', timestamp: 1, message: 'init', author: 'A', parents: [] },
       ];
-      context._stateStore.set('codegraphy.timelineCacheVersion', '1.2.0');
+      context._stateStore.set('codegraphy.timelineCacheVersion', '1.3.0');
       context._stateStore.set(
         'codegraphy.timelinePluginSignature',
         'stale.plugin@1.0.0',

--- a/packages/extension/tests/extension/gitHistory/analyzer.test.ts
+++ b/packages/extension/tests/extension/gitHistory/analyzer.test.ts
@@ -79,6 +79,7 @@ function createMockContext() {
  */
 function createMockRegistry() {
   return {
+    notifyPreAnalyze: vi.fn(async () => {}),
     analyzeFileResult: vi.fn(async (absolutePath: string): Promise<IFileAnalysisResult> => ({
       filePath: absolutePath,
       relations: [],
@@ -94,6 +95,7 @@ function createMockRegistry() {
       },
     ]),
   } as unknown as PluginRegistry & {
+    notifyPreAnalyze: Mock;
     analyzeFileResult: Mock;
     supportsFile: Mock;
     getSupportedExtensions: Mock;

--- a/packages/extension/tests/extension/gitHistory/analyzer.test.ts
+++ b/packages/extension/tests/extension/gitHistory/analyzer.test.ts
@@ -765,7 +765,7 @@ describe('GitHistoryAnalyzer', () => {
 
       const progress = vi.fn();
 
-      // Abort after the first commit finishes (progress reports current = 2 for the second)
+      // Abort after the second commit finishes caching (progress reports after each commit is cached)
       progress.mockImplementation((_phase: string, current: number) => {
         if (current === 2) {
           controller.abort();
@@ -776,8 +776,8 @@ describe('GitHistoryAnalyzer', () => {
         analyzer.indexHistory(progress, controller.signal)
       ).rejects.toThrow('Indexing aborted');
 
-      // The first commit should have been cached but the second should not
-      expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
+      // The first two commits should have been cached before the abort is observed
+      expect(fs.promises.writeFile).toHaveBeenCalledTimes(2);
       // Progress should have been called for commit 1 and commit 2 (where abort happened)
       expect(progress).toHaveBeenCalledWith('Indexing commits', 1, 3);
       expect(progress).toHaveBeenCalledWith('Indexing commits', 2, 3);

--- a/packages/extension/tests/extension/gitHistory/analyzer.workspaceSubtree.test.ts
+++ b/packages/extension/tests/extension/gitHistory/analyzer.workspaceSubtree.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ExecFileOptions } from 'child_process';
+import type { IFileAnalysisResult } from '../../../src/core/plugins/types/contracts';
+import type { PluginRegistry } from '../../../src/core/plugins/registry/manager';
+
+vi.mock('vscode', () => ({
+  workspace: {
+    getConfiguration: vi.fn(),
+    onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+  },
+  Uri: {
+    joinPath: vi.fn((...args: unknown[]) => {
+      const parts = args.map((arg) => String((arg as { fsPath?: string }).fsPath ?? arg));
+      return { fsPath: parts.join('/') };
+    }),
+    file: vi.fn((filePath: string) => ({ fsPath: filePath, scheme: 'file' })),
+  },
+}));
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  default: { execFile: mockExecFile },
+  execFile: mockExecFile,
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: vi.fn(),
+      writeFile: vi.fn(),
+      readFile: vi.fn(),
+      rm: vi.fn(),
+      access: vi.fn(),
+    },
+  };
+});
+
+import * as fs from 'fs';
+import { GitHistoryAnalyzer } from '../../../src/extension/gitHistory/analyzer';
+
+function createMockContext() {
+  const stateStore = new Map<string, unknown>();
+  return {
+    storageUri: { fsPath: '/tmp/test-storage' },
+    workspaceState: {
+      get: vi.fn(<T>(key: string): T | undefined => stateStore.get(key) as T | undefined),
+      update: vi.fn((key: string, value: unknown) => {
+        if (value === undefined) {
+          stateStore.delete(key);
+        } else {
+          stateStore.set(key, value);
+        }
+        return Promise.resolve();
+      }),
+    },
+  };
+}
+
+function createMockRegistry() {
+  return {
+    notifyPreAnalyze: vi.fn(async () => {}),
+    analyzeFileResult: vi.fn(async (absolutePath: string): Promise<IFileAnalysisResult> => ({
+      filePath: absolutePath,
+      relations: [],
+    })),
+    supportsFile: vi.fn((filePath: string) => filePath.endsWith('.py')),
+    getSupportedExtensions: vi.fn(() => ['.py']),
+    list: vi.fn(() => []),
+  } as unknown as PluginRegistry & {
+    notifyPreAnalyze: ReturnType<typeof vi.fn>;
+    analyzeFileResult: ReturnType<typeof vi.fn>;
+    supportsFile: ReturnType<typeof vi.fn>;
+    getSupportedExtensions: ReturnType<typeof vi.fn>;
+    list: ReturnType<typeof vi.fn>;
+  };
+}
+
+function mockGitCommands(handlers: Array<{ match: string | RegExp; stdout: string }>) {
+  mockExecFile.mockImplementation(((
+    _cmd: string,
+    args: readonly string[],
+    _opts: ExecFileOptions,
+    cb?: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    const joined = [...args].join(' ');
+    for (const handler of handlers) {
+      const matches = typeof handler.match === 'string'
+        ? joined.includes(handler.match)
+        : handler.match.test(joined);
+      if (matches) {
+        cb?.(null, handler.stdout, '');
+        return undefined as never;
+      }
+    }
+
+    cb?.(null, '', '');
+    return undefined as never;
+  }) as never);
+}
+
+describe('GitHistoryAnalyzer in a workspace subtree', () => {
+  const workspaceRoot = '/workspace/examples';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('indexes commits relative to the opened workspace instead of duplicating the repo prefix', async () => {
+    const context = createMockContext();
+    const registry = createMockRegistry();
+    const analyzer = new GitHistoryAnalyzer(context as never, registry, workspaceRoot);
+
+    mockGitCommands([
+      { match: 'rev-parse --abbrev-ref HEAD', stdout: 'main\n' },
+      {
+        match: 'log --first-parent main --format=%H|%at|%s|%an|%P -n 100 -- .',
+        stdout: [
+          'sha2|2|update subtree|A|sha1',
+          'sha1|1|init subtree|B|',
+        ].join('\n'),
+      },
+      {
+        match: 'ls-tree -r --name-only sha1 -- .',
+        stdout: [
+          '.gitignore',
+          'example-python/src/main.py',
+        ].join('\n'),
+      },
+      {
+        match: 'ls-tree -r --name-only sha2 -- .',
+        stdout: [
+          '.gitignore',
+          'example-python/src/main.py',
+        ].join('\n'),
+      },
+      { match: 'show sha1:.gitignore', stdout: '.codegraphy/\n' },
+      { match: 'show sha1:example-python/src/main.py', stdout: 'print("one")\n' },
+      { match: 'diff --name-status -M sha1 sha2 -- .', stdout: 'M\texample-python/src/main.py\n' },
+      { match: 'show sha2:example-python/src/main.py', stdout: 'print("two")\n' },
+    ]);
+
+    await analyzer.indexHistory(vi.fn(), new AbortController().signal, 100);
+
+    expect(registry.analyzeFileResult).toHaveBeenCalledWith(
+      '/workspace/examples/example-python/src/main.py',
+      'print("one")\n',
+      '/workspace/examples',
+      expect.anything(),
+    );
+    expect(registry.analyzeFileResult).not.toHaveBeenCalledWith(
+      '/workspace/examples/examples/example-python/src/main.py',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    const firstWrite = vi.mocked(fs.promises.writeFile).mock.calls[0];
+    const graph = JSON.parse(firstWrite[1] as string) as { nodes: Array<{ id: string }> };
+
+    expect(graph.nodes).toContainEqual(expect.objectContaining({
+      id: 'example-python/src/main.py',
+    }));
+    expect(graph.nodes).not.toContainEqual(expect.objectContaining({
+      id: 'examples/example-python/src/main.py',
+    }));
+  });
+});

--- a/packages/extension/tests/extension/gitHistory/analyzer.workspaceSubtree.test.ts
+++ b/packages/extension/tests/extension/gitHistory/analyzer.workspaceSubtree.test.ts
@@ -139,10 +139,10 @@ describe('GitHistoryAnalyzer in a workspace subtree', () => {
           'example-python/src/main.py',
         ].join('\n'),
       },
-      { match: 'show sha1:.gitignore', stdout: '.codegraphy/\n' },
-      { match: 'show sha1:example-python/src/main.py', stdout: 'print("one")\n' },
-      { match: 'diff --name-status -M sha1 sha2 -- .', stdout: 'M\texample-python/src/main.py\n' },
-      { match: 'show sha2:example-python/src/main.py', stdout: 'print("two")\n' },
+      { match: 'show sha1:./.gitignore', stdout: '.codegraphy/\n' },
+      { match: 'show sha1:./example-python/src/main.py', stdout: 'print("one")\n' },
+      { match: 'diff --name-status -M --relative sha1 sha2 -- .', stdout: 'M\texample-python/src/main.py\n' },
+      { match: 'show sha2:./example-python/src/main.py', stdout: 'print("two")\n' },
     ]);
 
     await analyzer.indexHistory(vi.fn(), new AbortController().signal, 100);

--- a/packages/extension/tests/extension/gitHistory/cache/state.test.ts
+++ b/packages/extension/tests/extension/gitHistory/cache/state.test.ts
@@ -6,6 +6,7 @@ import {
   persistCachedCommitState,
 } from '../../../../src/extension/gitHistory/cache/state';
 import type { CacheWorkspaceState } from '../../../../src/extension/gitHistory/cache/state';
+import { CACHE_VERSION } from '../../../../src/extension/gitHistory/cache/stateKeys';
 
 function createWorkspaceState(): CacheWorkspaceState & { store: Map<string, unknown> } {
   const store = new Map<string, unknown>();
@@ -36,7 +37,7 @@ describe('gitHistory/cache/state', () => {
     await persistCachedCommitState(workspaceState, commits, pluginSignature);
 
     expect(workspaceState.update).toHaveBeenCalledWith('codegraphy.timelineCommits', commits);
-    expect(workspaceState.update).toHaveBeenCalledWith('codegraphy.timelineCacheVersion', '1.2.0');
+    expect(workspaceState.update).toHaveBeenCalledWith('codegraphy.timelineCacheVersion', CACHE_VERSION);
     expect(workspaceState.update).toHaveBeenCalledWith(
       'codegraphy.timelinePluginSignature',
       pluginSignature,
@@ -58,7 +59,7 @@ describe('gitHistory/cache/state', () => {
 
     expect(hasCachedTimeline(workspaceState, pluginSignature)).toBe(false);
 
-    workspaceState.store.set('codegraphy.timelineCacheVersion', '1.2.0');
+    workspaceState.store.set('codegraphy.timelineCacheVersion', CACHE_VERSION);
     expect(hasCachedTimeline(workspaceState, pluginSignature)).toBe(false);
 
     workspaceState.store.set('codegraphy.timelinePluginSignature', pluginSignature);
@@ -67,7 +68,7 @@ describe('gitHistory/cache/state', () => {
     workspaceState.store.set('codegraphy.timelineCacheVersion', '0.9.0');
     expect(hasCachedTimeline(workspaceState, pluginSignature)).toBe(false);
 
-    workspaceState.store.set('codegraphy.timelineCacheVersion', '1.2.0');
+    workspaceState.store.set('codegraphy.timelineCacheVersion', CACHE_VERSION);
     workspaceState.store.set('codegraphy.timelinePluginSignature', 'codegraphy.markdown@0.9.0');
     expect(hasCachedTimeline(workspaceState, pluginSignature)).toBe(false);
   });
@@ -84,7 +85,7 @@ describe('gitHistory/cache/state', () => {
     workspaceState.store.set('codegraphy.timelinePluginSignature', pluginSignature);
     expect(getCachedCommitList(workspaceState, pluginSignature)).toBeNull();
 
-    workspaceState.store.set('codegraphy.timelineCacheVersion', '1.2.0');
+    workspaceState.store.set('codegraphy.timelineCacheVersion', CACHE_VERSION);
     workspaceState.store.set('codegraphy.timelinePluginSignature', 'codegraphy.markdown@0.9.0');
     expect(getCachedCommitList(workspaceState, pluginSignature)).toBeNull();
 

--- a/packages/extension/tests/extension/gitHistory/commitPathHost.test.ts
+++ b/packages/extension/tests/extension/gitHistory/commitPathHost.test.ts
@@ -1,0 +1,27 @@
+import * as path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { createGitHistoryCommitPathHost } from '../../../src/extension/gitHistory/commitPathHost';
+
+describe('gitHistory/commitPathHost', () => {
+  it('answers file, directory, and read requests from the commit tree snapshot', async () => {
+    const getFileAtCommit = vi.fn(async (_sha: string, filePath: string) => {
+      return filePath === 'go.mod' ? 'module github.com/acme/project\n' : '';
+    });
+    const workspaceRoot = '/virtual/workspace';
+    const host = await createGitHistoryCommitPathHost({
+      allFiles: ['go.mod', 'src/app.ts', 'src/lib/util.ts'],
+      getFileAtCommit,
+      sha: 'abc123',
+      signal: new AbortController().signal,
+      workspaceRoot,
+    });
+
+    expect(host.isFile(path.join(workspaceRoot, 'src/app.ts'))).toBe(true);
+    expect(host.isDirectory(path.join(workspaceRoot, 'src'))).toBe(true);
+    expect(host.exists(path.join(workspaceRoot, 'src/lib'))).toBe(true);
+    expect(host.listDirectory(path.join(workspaceRoot, 'src'))).toEqual(['app.ts', 'lib']);
+    expect(host.readTextFile(path.join(workspaceRoot, 'go.mod'))).toBe('module github.com/acme/project\n');
+    expect(host.readTextFile(path.join(workspaceRoot, 'src/app.ts'))).toBeNull();
+    expect(getFileAtCommit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/extension/tests/extension/gitHistory/commits/list.test.ts
+++ b/packages/extension/tests/extension/gitHistory/commits/list.test.ts
@@ -106,6 +106,8 @@ describe('gitHistory/commits/list', () => {
         '--format=%H|%at|%s|%an|%P',
         '-n',
         '2',
+        '--',
+        '.',
       ]);
       return 'sha-2|200|message-2|author-2|sha-1\nsha-1|100|message-1|author-1|';
     };

--- a/packages/extension/tests/extension/gitHistory/diff/analysis.test.ts
+++ b/packages/extension/tests/extension/gitHistory/diff/analysis.test.ts
@@ -39,6 +39,7 @@ describe('gitHistory/diff/analysis', () => {
         'D\tsrc/remove.ts',
         'X\tsrc/unknown.ts',
       ].join('\n'),
+      commitFiles: ['src/keep.ts', 'src/new.ts', 'src/add.ts', 'src/edit.ts'],
       getFileAtCommit: vi.fn(async () => ''),
       previousGraph: {
         nodes: [
@@ -98,6 +99,7 @@ describe('gitHistory/diff/analysis', () => {
     await expect(
       analyzeDiffCommitGraph({
         diffOutput: 'A\tsrc/add.ts',
+        commitFiles: ['src/add.ts'],
         getFileAtCommit: vi.fn(async () => ''),
         previousGraph: { nodes: [], edges: [] },
         registry: {

--- a/packages/extension/tests/extension/gitHistory/diff/analysis.test.ts
+++ b/packages/extension/tests/extension/gitHistory/diff/analysis.test.ts
@@ -52,6 +52,7 @@ describe('gitHistory/diff/analysis', () => {
         ],
       },
       registry: {
+        notifyPreAnalyze: vi.fn(async () => {}),
         analyzeFileResult: vi.fn(async (absolutePath: string) => ({ filePath: absolutePath, relations: [] })),
         supportsFile: vi.fn(() => true),
       },
@@ -103,6 +104,7 @@ describe('gitHistory/diff/analysis', () => {
         getFileAtCommit: vi.fn(async () => ''),
         previousGraph: { nodes: [], edges: [] },
         registry: {
+          notifyPreAnalyze: vi.fn(async () => {}),
           analyzeFileResult: vi.fn(async (absolutePath: string) => ({ filePath: absolutePath, relations: [] })),
           supportsFile: vi.fn(() => true),
         },

--- a/packages/extension/tests/extension/gitHistory/diff/changes.test.ts
+++ b/packages/extension/tests/extension/gitHistory/diff/changes.test.ts
@@ -76,6 +76,7 @@ describe('gitHistory/diff/changes', () => {
       '/workspace/src/a.ts',
       'import "./b";',
       '/workspace',
+      undefined,
     );
     expect(nodes).toEqual([{ id: 'src/a.ts', label: 'a.ts', color: '#93C5FD' }]);
     expect(edges).toEqual([
@@ -133,6 +134,7 @@ describe('gitHistory/diff/changes', () => {
       '/workspace/src/a.ts',
       'import "./c";',
       '/workspace',
+      undefined,
     );
     expect(nodes).toEqual([existingNode]);
     expect(nodeMap.get(existingNode.id)).toBe(existingNode);

--- a/packages/extension/tests/extension/gitHistory/diff/changes.test.ts
+++ b/packages/extension/tests/extension/gitHistory/diff/changes.test.ts
@@ -9,7 +9,7 @@ import {
 describe('gitHistory/diff/changes', () => {
   const emptyAnalysis = (filePath: string): IFileAnalysisResult => ({ filePath, relations: [] });
 
-  it('adds a node for unsupported files without reanalyzing them', async () => {
+  it('skips unsupported files instead of adding timeline-only nodes', async () => {
     const nodes: Array<{ id: string; label: string; color: string }> = [];
     const nodeMap = new Map();
     const registry = {
@@ -30,7 +30,7 @@ describe('gitHistory/diff/changes', () => {
       workspaceRoot: '/workspace',
     });
 
-    expect(nodes).toEqual([{ id: 'src/readme.md', label: 'readme.md', color: '#CBD5E1' }]);
+    expect(nodes).toEqual([]);
     expect(registry.analyzeFileResult).not.toHaveBeenCalled();
   });
 
@@ -148,7 +148,7 @@ describe('gitHistory/diff/changes', () => {
     expect(edgeSet).toEqual(new Set(['src/a.ts->src/c.ts#import:static']));
   });
 
-  it('does not duplicate unsupported nodes that already exist', async () => {
+  it('leaves existing unsupported nodes untouched during replay', async () => {
     const existingNode = { id: 'src/readme.md', label: 'readme.md', color: '#CBD5E1' };
     const nodes = [existingNode];
     const nodeMap = new Map([[existingNode.id, existingNode]]);

--- a/packages/extension/tests/extension/gitHistory/diff/replay.test.ts
+++ b/packages/extension/tests/extension/gitHistory/diff/replay.test.ts
@@ -19,6 +19,7 @@ describe('gitHistory/diff/replay', () => {
       }),
       previousGraph: { nodes: [], edges: [] },
       registry: {
+        notifyPreAnalyze: vi.fn(async () => {}),
         analyzeFileResult: vi.fn(async (absolutePath: string) => {
           if (!absolutePath.endsWith('a.ts')) {
             return { filePath: absolutePath, relations: [] };

--- a/packages/extension/tests/extension/gitHistory/diff/replay.test.ts
+++ b/packages/extension/tests/extension/gitHistory/diff/replay.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { analyzeDiffCommitGraph } from '../../../../src/extension/gitHistory/diff/analysis';
+import { resolveTreeSitterImportPath } from '../../../../src/extension/pipeline/plugins/treesitter/runtime/resolve';
+
+describe('gitHistory/diff/replay', () => {
+  it('allows files added in the same commit to connect even when the importer is processed first', async () => {
+    const result = await analyzeDiffCommitGraph({
+      diffOutput: [
+        'A\tsrc/a.ts',
+        'A\tsrc/b.ts',
+      ].join('\n'),
+      commitFiles: ['src/a.ts', 'src/b.ts'],
+      getFileAtCommit: vi.fn(async (_sha: string, filePath: string) => {
+        if (filePath === 'src/a.ts') {
+          return 'import "./b";';
+        }
+
+        return 'export const b = 1;';
+      }),
+      previousGraph: { nodes: [], edges: [] },
+      registry: {
+        analyzeFileResult: vi.fn(async (absolutePath: string) => {
+          if (!absolutePath.endsWith('a.ts')) {
+            return { filePath: absolutePath, relations: [] };
+          }
+
+          const resolvedPath = resolveTreeSitterImportPath(absolutePath, './b');
+          return {
+            filePath: absolutePath,
+            relations: resolvedPath
+              ? [{
+                  sourceId: 'import',
+                  specifier: './b',
+                  type: 'static' as const,
+                  resolvedPath,
+                  kind: 'import' as const,
+                  pluginId: 'ts',
+                  fromFilePath: absolutePath,
+                }]
+              : [],
+          };
+        }),
+        supportsFile: vi.fn(() => true),
+      },
+      sha: 'sha2',
+      shouldExclude: () => false,
+      signal: new AbortController().signal,
+      workspaceRoot: '/virtual/workspace',
+    });
+
+    expect(result.nodes.map((node) => node.id)).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(result.edges).toEqual([
+      {
+        id: 'src/a.ts->src/b.ts#import:static',
+        from: 'src/a.ts',
+        to: 'src/b.ts',
+        kind: 'import',
+        sources: [
+          {
+            id: 'ts:import',
+            pluginId: 'ts',
+            sourceId: 'import',
+            label: 'import',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/extension/tests/extension/gitHistory/diff/state.test.ts
+++ b/packages/extension/tests/extension/gitHistory/diff/state.test.ts
@@ -88,4 +88,39 @@ describe('gitHistory/diff/state', () => {
     ]);
     expect(edgeSet).toEqual(new Set(['src/c.ts->src/new.ts#import', 'src/new.ts->src/b.ts#import']));
   });
+
+  it('deduplicates renamed edges that collapse onto an existing edge id', () => {
+    const preservedEdge: IGraphEdge = {
+      id: 'src/new.ts->src/b.ts#import',
+      from: 'src/new.ts',
+      to: 'src/b.ts',
+      kind: 'import',
+      sources: [{ id: 'existing', pluginId: 'existing', sourceId: 'existing', label: 'existing' }],
+    };
+    const renamedEdge: IGraphEdge = {
+      id: 'src/old.ts->src/b.ts#import',
+      from: 'src/old.ts',
+      to: 'src/b.ts',
+      kind: 'import',
+      sources: [{ id: 'renamed', pluginId: 'renamed', sourceId: 'renamed', label: 'renamed' }],
+    };
+    const edges: IGraphEdge[] = [preservedEdge, renamedEdge];
+    const edgeSet = new Set(edges.map((edge) => edge.id));
+
+    renameGitHistoryGraphFile('src/old.ts', 'src/new.ts', edges, new Map(), edgeSet);
+
+    expect(edges).toEqual([
+      {
+        id: 'src/new.ts->src/b.ts#import',
+        from: 'src/new.ts',
+        to: 'src/b.ts',
+        kind: 'import',
+        sources: [
+          { id: 'existing', pluginId: 'existing', sourceId: 'existing', label: 'existing' },
+          { id: 'renamed', pluginId: 'renamed', sourceId: 'renamed', label: 'renamed' },
+        ],
+      },
+    ]);
+    expect(edgeSet).toEqual(new Set(['src/new.ts->src/b.ts#import']));
+  });
 });

--- a/packages/extension/tests/extension/gitHistory/examplesTimeline.test.ts
+++ b/packages/extension/tests/extension/gitHistory/examplesTimeline.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { createGDScriptPlugin } from '../../../../plugin-godot/src/plugin';
 import { GitHistoryAnalyzer } from '../../../src/extension/gitHistory/analyzer';
+import { getMaterialThemeDefaultGroups } from '../../../src/extension/graphView/groups/defaults/materialTheme/view';
 import { WorkspacePipeline } from '../../../src/extension/pipeline/service/lifecycleFacade';
 import type { IGraphData } from '../../../src/shared/graph/contracts';
 
@@ -132,6 +133,26 @@ describe('GitHistoryAnalyzer examples timeline', { timeout: 120000 }, () => {
     if (!hasEdgeCountChanges) {
       throw new Error(`Expected examples timeline edge counts to change, got ${JSON.stringify(edgeCounts)}`);
     }
+
+    const initialMaterialGroups = getMaterialThemeDefaultGroups(
+      graphs[0],
+      vscode.Uri.file(path.resolve(examplesRoot, '..')),
+    );
+
+    expect(initialMaterialGroups).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'default:fileExtension:html',
+        pattern: '*.html',
+        pluginName: 'Material Icon Theme',
+        imageUrl: expect.stringMatching(/^data:image\/svg\+xml;base64,/),
+      }),
+      expect.objectContaining({
+        id: 'default:fileExtension:tsx',
+        pattern: '*.tsx',
+        pluginName: 'Material Icon Theme',
+        imageUrl: expect.stringMatching(/^data:image\/svg\+xml;base64,/),
+      }),
+    ]));
 
     const directFullAnalyzer = analyzer as unknown as {
       _analyzeFullCommit(sha: string, signal: AbortSignal): Promise<IGraphData>;

--- a/packages/extension/tests/extension/gitHistory/examplesTimeline.test.ts
+++ b/packages/extension/tests/extension/gitHistory/examplesTimeline.test.ts
@@ -1,0 +1,152 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { createGDScriptPlugin } from '../../../../plugin-godot/src/plugin';
+import { GitHistoryAnalyzer } from '../../../src/extension/gitHistory/analyzer';
+import { WorkspacePipeline } from '../../../src/extension/pipeline/service/lifecycleFacade';
+import type { IGraphData } from '../../../src/shared/graph/contracts';
+
+const examplesRoot = path.resolve(__dirname, '../../../../../examples');
+const tempStorageRoots: string[] = [];
+
+let workspaceFoldersValue:
+  | Array<{ uri: { fsPath: string; path: string }; name: string; index: number }>
+  | undefined;
+
+Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+  get: () => workspaceFoldersValue,
+  configurable: true,
+});
+
+function createContext(storageRoot: string) {
+  const stateStore = new Map<string, unknown>();
+
+  return {
+    subscriptions: [],
+    extensionUri: vscode.Uri.file('/test/extension'),
+    storageUri: vscode.Uri.file(storageRoot),
+    workspaceState: {
+      get: vi.fn(<T>(key: string): T | undefined => stateStore.get(key) as T | undefined),
+      update: vi.fn((key: string, value: unknown) => {
+        if (value === undefined) {
+          stateStore.delete(key);
+        } else {
+          stateStore.set(key, value);
+        }
+
+        return Promise.resolve();
+      }),
+    },
+  };
+}
+
+async function createStorageRoot(): Promise<string> {
+  const storageRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-timeline-examples-'));
+  tempStorageRoots.push(storageRoot);
+  return storageRoot;
+}
+
+function getNodeIds(graph: IGraphData): string[] {
+  return graph.nodes.map((node) => node.id).sort((left, right) => left.localeCompare(right));
+}
+
+function getEdgeIds(graph: IGraphData): string[] {
+  return graph.edges.map((edge) => edge.id).sort((left, right) => left.localeCompare(right));
+}
+
+function graphChanged(previousGraph: IGraphData, nextGraph: IGraphData): boolean {
+  return JSON.stringify({
+    nodes: getNodeIds(previousGraph),
+    edges: getEdgeIds(previousGraph),
+  }) !== JSON.stringify({
+    nodes: getNodeIds(nextGraph),
+    edges: getEdgeIds(nextGraph),
+  });
+}
+
+function getSampleCommitIndexes(count: number): number[] {
+  return [...new Set([
+    0,
+    Math.floor((count - 1) / 2),
+    count - 1,
+  ])];
+}
+
+afterAll(async () => {
+  await Promise.all(
+    tempStorageRoots.splice(0).map((storageRoot) =>
+      fs.rm(storageRoot, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe('GitHistoryAnalyzer examples timeline', { timeout: 120000 }, () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    workspaceFoldersValue = [
+      { uri: vscode.Uri.file(examplesRoot), name: 'examples', index: 0 },
+    ];
+  });
+
+  it('replays examples history with changing nodes and edges and matches direct full analysis for sampled commits', async () => {
+    const storageRoot = await createStorageRoot();
+    const context = createContext(storageRoot);
+    const pipeline = new WorkspacePipeline(context as unknown as vscode.ExtensionContext);
+
+    await pipeline.initialize();
+    pipeline.registry.register(createGDScriptPlugin());
+
+    const analyzer = new GitHistoryAnalyzer(
+      context as unknown as vscode.ExtensionContext,
+      pipeline.registry,
+      examplesRoot,
+    );
+
+    const commits = await analyzer.indexHistory(vi.fn(), new AbortController().signal, 100);
+    const graphs = await Promise.all(
+      commits.map(async (commit) => analyzer.getGraphDataForCommit(commit.sha)),
+    );
+    const nodeCounts = graphs.map((graph) => graph.nodes.length);
+    const edgeCounts = graphs.map((graph) => graph.edges.length);
+    const hasGraphEdges = graphs.some((graph) => graph.edges.length > 0);
+    const hasGraphChanges = graphs.some((graph, index) => index > 0 && graphChanged(graphs[index - 1], graph));
+    const hasNodeCountChanges = graphs.some(
+      (graph, index) => index > 0 && graph.nodes.length !== graphs[index - 1].nodes.length,
+    );
+    const hasEdgeCountChanges = graphs.some(
+      (graph, index) => index > 0 && graph.edges.length !== graphs[index - 1].edges.length,
+    );
+
+    expect(commits.length).toBeGreaterThan(1);
+    if (!hasGraphEdges) {
+      throw new Error(`Expected examples timeline to produce edges, got edge counts ${JSON.stringify(edgeCounts)}`);
+    }
+    if (!hasGraphChanges) {
+      throw new Error(`Expected examples timeline graph to change, got node counts ${JSON.stringify(nodeCounts)} and edge counts ${JSON.stringify(edgeCounts)}`);
+    }
+    if (!hasNodeCountChanges) {
+      throw new Error(`Expected examples timeline node counts to change, got ${JSON.stringify(nodeCounts)}`);
+    }
+    if (!hasEdgeCountChanges) {
+      throw new Error(`Expected examples timeline edge counts to change, got ${JSON.stringify(edgeCounts)}`);
+    }
+
+    const directFullAnalyzer = analyzer as unknown as {
+      _analyzeFullCommit(sha: string, signal: AbortSignal): Promise<IGraphData>;
+    };
+
+    for (const index of getSampleCommitIndexes(commits.length)) {
+      const commit = commits[index];
+      const replayedGraph = graphs[index];
+      const directGraph = await directFullAnalyzer._analyzeFullCommit(
+        commit.sha,
+        new AbortController().signal,
+      );
+
+      expect(getNodeIds(replayedGraph)).toEqual(getNodeIds(directGraph));
+      expect(getEdgeIds(replayedGraph)).toEqual(getEdgeIds(directGraph));
+    }
+  });
+});

--- a/packages/extension/tests/extension/gitHistory/files.test.ts
+++ b/packages/extension/tests/extension/gitHistory/files.test.ts
@@ -9,7 +9,7 @@ describe('gitHistory/files', () => {
       getCommitTreeFiles(execGit, 'abc123', new AbortController().signal)
     ).resolves.toEqual(['src/a.ts', 'src/b.ts']);
     expect(execGit).toHaveBeenCalledWith(
-      ['ls-tree', '-r', '--name-only', 'abc123'],
+      ['ls-tree', '-r', '--name-only', 'abc123', '--', '.'],
       expect.any(AbortSignal)
     );
   });
@@ -41,7 +41,7 @@ describe('gitHistory/files', () => {
     ).resolves.toBe('export const a = 1;');
 
     expect(execGit.mock.calls).toEqual([
-      [['diff', '--name-status', '-M', 'parent', 'child'], expect.any(AbortSignal)],
+      [['diff', '--name-status', '-M', 'parent', 'child', '--', '.'], expect.any(AbortSignal)],
       [['show', 'child:src/a.ts'], expect.any(AbortSignal)],
     ]);
   });

--- a/packages/extension/tests/extension/gitHistory/files.test.ts
+++ b/packages/extension/tests/extension/gitHistory/files.test.ts
@@ -41,8 +41,8 @@ describe('gitHistory/files', () => {
     ).resolves.toBe('export const a = 1;');
 
     expect(execGit.mock.calls).toEqual([
-      [['diff', '--name-status', '-M', 'parent', 'child', '--', '.'], expect.any(AbortSignal)],
-      [['show', 'child:src/a.ts'], expect.any(AbortSignal)],
+      [['diff', '--name-status', '-M', '--relative', 'parent', 'child', '--', '.'], expect.any(AbortSignal)],
+      [['show', 'child:./src/a.ts'], expect.any(AbortSignal)],
     ]);
   });
 

--- a/packages/extension/tests/extension/gitHistory/fullCommitAnalysis.test.ts
+++ b/packages/extension/tests/extension/gitHistory/fullCommitAnalysis.test.ts
@@ -102,6 +102,7 @@ describe('gitHistory/fullCommitAnalysis', () => {
         },
       ],
       '/workspace',
+      expect.objectContaining({ mode: 'timeline', commitSha: 'abc123' }),
     );
     expect(getFileAtCommit).toHaveBeenCalledTimes(5);
     expect(registry.analyzeFileResult).toHaveBeenCalledTimes(2);

--- a/packages/extension/tests/extension/gitHistory/fullCommitAnalysis.test.ts
+++ b/packages/extension/tests/extension/gitHistory/fullCommitAnalysis.test.ts
@@ -3,6 +3,7 @@ import {
   analyzeFullCommitGraph,
   createGitHistoryNode,
 } from '../../../src/extension/gitHistory/fullCommitAnalysis';
+import { resolveTreeSitterImportPath } from '../../../src/extension/pipeline/plugins/treesitter/runtime/resolve';
 
 describe('gitHistory/fullCommitAnalysis', () => {
   it('creates graph nodes from workspace-relative file paths', () => {
@@ -106,5 +107,66 @@ describe('gitHistory/fullCommitAnalysis', () => {
         workspaceRoot: '/workspace',
       })
     ).rejects.toMatchObject({ name: 'AbortError', message: 'Indexing aborted' });
+  });
+
+  it('resolves relative imports against the analyzed commit tree instead of the live workspace', async () => {
+    const getFileAtCommit = vi.fn(async (_sha: string, filePath: string) => {
+      if (filePath === 'src/a.ts') {
+        return 'import "./b";';
+      }
+
+      return 'export const b = 1;';
+    });
+    const registry = {
+      analyzeFileResult: vi.fn(async (absolutePath: string) => {
+        if (!absolutePath.endsWith('a.ts')) {
+          return { filePath: absolutePath, relations: [] };
+        }
+
+        const resolvedPath = resolveTreeSitterImportPath(absolutePath, './b');
+        return {
+          filePath: absolutePath,
+          relations: resolvedPath
+            ? [{
+                resolvedPath,
+                sourceId: 'import',
+                specifier: './b',
+                type: 'static' as const,
+                kind: 'import' as const,
+                pluginId: 'ts',
+                fromFilePath: absolutePath,
+              }]
+            : [],
+        };
+      }),
+    };
+
+    const result = await analyzeFullCommitGraph({
+      allFiles: ['src/a.ts', 'src/b.ts'],
+      getFileAtCommit,
+      registry,
+      sha: 'abc123',
+      shouldExclude: () => false,
+      signal: new AbortController().signal,
+      supportedExtensions: new Set(['.ts']),
+      workspaceRoot: '/virtual/workspace',
+    });
+
+    expect(result.edges).toEqual([
+      {
+        id: 'src/a.ts->src/b.ts#import:static',
+        from: 'src/a.ts',
+        to: 'src/b.ts',
+        kind: 'import',
+        sources: [
+          {
+            id: 'ts:import',
+            pluginId: 'ts',
+            sourceId: 'import',
+            label: 'import',
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/packages/extension/tests/extension/gitHistory/fullCommitAnalysis.test.ts
+++ b/packages/extension/tests/extension/gitHistory/fullCommitAnalysis.test.ts
@@ -23,6 +23,7 @@ describe('gitHistory/fullCommitAnalysis', () => {
       return 'export const value = 1;';
     });
     const registry = {
+      notifyPreAnalyze: vi.fn(async () => {}),
       analyzeFileResult: vi.fn(async (absolutePath: string) => {
         if (absolutePath.endsWith('a.ts')) {
           return {
@@ -82,7 +83,27 @@ describe('gitHistory/fullCommitAnalysis', () => {
         ],
       },
     ]);
-    expect(getFileAtCommit).toHaveBeenCalledTimes(2);
+    expect(registry.notifyPreAnalyze).toHaveBeenCalledWith(
+      [
+        {
+          absolutePath: '/workspace/src/a.ts',
+          relativePath: 'src/a.ts',
+          content: 'import "./b"; import "./missing";',
+        },
+        {
+          absolutePath: '/workspace/src/b.ts',
+          relativePath: 'src/b.ts',
+          content: 'export const value = 1;',
+        },
+        {
+          absolutePath: '/workspace/src/skip.js',
+          relativePath: 'src/skip.js',
+          content: 'export const value = 1;',
+        },
+      ],
+      '/workspace',
+    );
+    expect(getFileAtCommit).toHaveBeenCalledTimes(5);
     expect(registry.analyzeFileResult).toHaveBeenCalledTimes(2);
   });
 
@@ -98,6 +119,7 @@ describe('gitHistory/fullCommitAnalysis', () => {
         allFiles: ['src/a.ts', 'src/b.ts'],
         getFileAtCommit,
         registry: {
+          notifyPreAnalyze: vi.fn(async () => {}),
           analyzeFileResult: vi.fn(async (absolutePath: string) => ({ filePath: absolutePath, relations: [] })),
         },
         sha: 'abc123',
@@ -118,6 +140,7 @@ describe('gitHistory/fullCommitAnalysis', () => {
       return 'export const b = 1;';
     });
     const registry = {
+      notifyPreAnalyze: vi.fn(async () => {}),
       analyzeFileResult: vi.fn(async (absolutePath: string) => {
         if (!absolutePath.endsWith('a.ts')) {
           return { filePath: absolutePath, relations: [] };

--- a/packages/extension/tests/extension/gitHistory/indexer.test.ts
+++ b/packages/extension/tests/extension/gitHistory/indexer.test.ts
@@ -69,6 +69,7 @@ describe('gitHistory/indexer', () => {
     expect(dependencies.persistCachedCommitState).toHaveBeenCalledWith(commits);
     expect(onProgress).toHaveBeenCalledWith('Indexing commits', 1, 2);
     expect(onProgress).toHaveBeenCalledWith('Indexing commits', 2, 2);
+    expect(onProgress).toHaveBeenCalledWith('Finalizing timeline cache', 2, 2);
   });
 
   it('indexes a single commit without diff analysis', async () => {
@@ -96,8 +97,48 @@ describe('gitHistory/indexer', () => {
     expect(dependencies.writeCachedGraphData).toHaveBeenCalledOnce();
     expect(dependencies.writeCachedGraphData).toHaveBeenCalledWith('sha1', graphA);
     expect(dependencies.persistCachedCommitState).toHaveBeenCalledWith(commits);
-    expect(onProgress).toHaveBeenCalledOnce();
-    expect(onProgress).toHaveBeenCalledWith('Indexing commits', 1, 1);
+    expect(onProgress).toHaveBeenNthCalledWith(1, 'Indexing commits', 1, 1);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 'Finalizing timeline cache', 1, 1);
+  });
+
+  it('reports commit progress only after the commit graph has been cached', async () => {
+    const events: string[] = [];
+    const dependencies = {
+      analyzeDiffCommit: vi.fn(async () => {
+        events.push('analyze-diff');
+        return createGraph('b');
+      }),
+      analyzeFullCommit: vi.fn(async () => {
+        events.push('analyze-full');
+        return createGraph('a');
+      }),
+      getCommitList: vi.fn(async () => [createCommit('sha1'), createCommit('sha2', ['sha1'])]),
+      persistCachedCommitState: vi.fn(async () => {
+        events.push('persist');
+      }),
+      writeCachedGraphData: vi.fn(async (sha: string) => {
+        events.push(`write-${sha}`);
+      }),
+    };
+
+    await indexGitHistory({
+      dependencies,
+      onProgress: (phase, current, total) => {
+        events.push(`progress:${phase}:${current}/${total}`);
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(events).toEqual([
+      'analyze-full',
+      'write-sha1',
+      'progress:Indexing commits:1/2',
+      'analyze-diff',
+      'write-sha2',
+      'progress:Indexing commits:2/2',
+      'progress:Finalizing timeline cache:2/2',
+      'persist',
+    ]);
   });
 
   it('drops a single commit from the cached timeline when full analysis yields no nodes', async () => {

--- a/packages/extension/tests/extension/graphView/timeline/indexing/result.test.ts
+++ b/packages/extension/tests/extension/graphView/timeline/indexing/result.test.ts
@@ -18,7 +18,7 @@ describe('graph view timeline result', () => {
     });
 
     expect(showInformationMessage).toHaveBeenCalledWith('No commits found to index');
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith({ type: 'CACHE_INVALIDATED' });
     expect(jumpToCommit).not.toHaveBeenCalled();
   });
 

--- a/packages/extension/tests/extension/graphView/timeline/indexing/run.test.ts
+++ b/packages/extension/tests/extension/graphView/timeline/indexing/run.test.ts
@@ -67,6 +67,7 @@ describe('graph view timeline execution', () => {
 
     expect(handlers.showInformationMessage).toHaveBeenCalledWith('No commits found to index');
     expect(handlers.jumpToCommit).not.toHaveBeenCalled();
+    expect(handlers.sendMessage).toHaveBeenCalledWith({ type: 'CACHE_INVALIDATED' });
   });
 
   it('reports non-abort indexing failures and invalidates the cache', async () => {
@@ -98,7 +99,7 @@ describe('graph view timeline execution', () => {
     expect(handlers.sendMessage).toHaveBeenCalledWith({ type: 'CACHE_INVALIDATED' });
   });
 
-  it('returns quietly for abort failures', async () => {
+  it('clears indexing state for abort failures', async () => {
     const error = new Error('aborted');
     error.name = 'AbortError';
     const handlers = {
@@ -125,6 +126,6 @@ describe('graph view timeline execution', () => {
 
     expect(handlers.logError).not.toHaveBeenCalled();
     expect(handlers.showErrorMessage).not.toHaveBeenCalled();
-    expect(handlers.sendMessage).not.toHaveBeenCalledWith({ type: 'CACHE_INVALIDATED' });
+    expect(handlers.sendMessage).toHaveBeenCalledWith({ type: 'CACHE_INVALIDATED' });
   });
 });

--- a/packages/extension/tests/extension/graphView/timeline/provider/indexing.test.ts
+++ b/packages/extension/tests/extension/graphView/timeline/provider/indexing.test.ts
@@ -236,6 +236,8 @@ describe('graph view provider timeline indexing', () => {
 
   it('stores the commit graph as the raw source and reapplies the current view on jump', async () => {
     const sendMessage = vi.fn();
+    const computeMergedGroups = vi.fn();
+    const sendGroupsUpdated = vi.fn();
     const rawTimelineGraph = {
       nodes: [createGraphNode('src/index.ts')],
       edges: [],
@@ -260,6 +262,8 @@ describe('graph view provider timeline indexing', () => {
       _disabledPlugins: new Set<string>(['plugin.test']),
       _rawGraphData: { nodes: [createGraphNode('live.ts')], edges: [] } satisfies IGraphData,
       _graphData: { nodes: [], edges: [] } satisfies IGraphData,
+      _computeMergedGroups: computeMergedGroups,
+      _sendGroupsUpdated: sendGroupsUpdated,
       _applyViewTransform: applyViewTransform,
       _sendMessage: sendMessage,
     };
@@ -275,6 +279,8 @@ describe('graph view provider timeline indexing', () => {
     expect(source._rawGraphData).toBe(rawTimelineGraph);
     expect(source._graphData).toBe(transformedGraph);
     expect(applyViewTransform).toHaveBeenCalledOnce();
+    expect(computeMergedGroups).toHaveBeenCalledOnce();
+    expect(sendGroupsUpdated).toHaveBeenCalledOnce();
     expect(sendMessage).toHaveBeenCalledWith({
       type: 'COMMIT_GRAPH_DATA',
       payload: { sha: 'sha-1', graphData: transformedGraph },
@@ -342,6 +348,8 @@ describe('graph view provider timeline indexing', () => {
 
   it('resets to the first commit that still produces graph nodes', async () => {
     const sendMessage = vi.fn();
+    const computeMergedGroups = vi.fn();
+    const sendGroupsUpdated = vi.fn();
     const source = {
       _analyzer: { registry: { kind: 'registry' } } as never,
       _gitAnalyzer: {
@@ -357,6 +365,8 @@ describe('graph view provider timeline indexing', () => {
       _currentCommitSha: 'sha-9',
       _disabledPlugins: new Set<string>(),
       _graphData: { nodes: [createGraphNode('src/current.ts')], edges: [] } satisfies IGraphData,
+      _computeMergedGroups: computeMergedGroups,
+      _sendGroupsUpdated: sendGroupsUpdated,
       _sendMessage: sendMessage,
     };
     const graphData = { nodes: [createGraphNode('src/index.ts')], edges: [] } satisfies IGraphData;
@@ -373,6 +383,8 @@ describe('graph view provider timeline indexing', () => {
 
     expect(source._currentCommitSha).toBe('sha-2');
     expect(source._graphData).toBe(graphData);
+    expect(computeMergedGroups).toHaveBeenCalledOnce();
+    expect(sendGroupsUpdated).toHaveBeenCalledOnce();
     expect(sendMessage).toHaveBeenCalledWith({
       type: 'COMMIT_GRAPH_DATA',
       payload: { sha: 'sha-2', graphData },

--- a/packages/extension/tests/extension/pipeline/treesitter/pathHost.test.ts
+++ b/packages/extension/tests/extension/pipeline/treesitter/pathHost.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  treeSitterPathExists,
+  treeSitterPathIsDirectory,
+  treeSitterPathIsFile,
+  treeSitterReadDirectory,
+  treeSitterReadTextFile,
+  withTreeSitterPathHost,
+  type TreeSitterPathHost,
+} from '../../../../src/extension/pipeline/plugins/treesitter/runtime/pathHost';
+
+function createPathHost(): TreeSitterPathHost {
+  return {
+    exists: (absolutePath) => absolutePath === '/virtual/workspace/src' || absolutePath === '/virtual/workspace/src/app.ts',
+    isDirectory: (absolutePath) => absolutePath === '/virtual/workspace/src',
+    isFile: (absolutePath) => absolutePath === '/virtual/workspace/src/app.ts',
+    listDirectory: (absolutePath) => absolutePath === '/virtual/workspace/src' ? ['app.ts'] : null,
+    readTextFile: (absolutePath) => absolutePath === '/virtual/workspace/src/app.ts' ? 'export {};\n' : null,
+  };
+}
+
+describe('pipeline/plugins/treesitter/runtime/pathHost', () => {
+  it('uses the active host instead of the live filesystem', () => {
+    const result = withTreeSitterPathHost(createPathHost(), () => {
+      return {
+        exists: treeSitterPathExists('/virtual/workspace/src'),
+        isDirectory: treeSitterPathIsDirectory('/virtual/workspace/src'),
+        isFile: treeSitterPathIsFile('/virtual/workspace/src/app.ts'),
+        entries: treeSitterReadDirectory('/virtual/workspace/src'),
+        text: treeSitterReadTextFile('/virtual/workspace/src/app.ts'),
+      };
+    });
+
+    expect(result).toEqual({
+      exists: true,
+      isDirectory: true,
+      isFile: true,
+      entries: ['app.ts'],
+      text: 'export {};\n',
+    });
+  });
+
+  it('restores the default filesystem behavior outside the host scope', () => {
+    withTreeSitterPathHost(createPathHost(), () => {
+      expect(treeSitterPathExists('/virtual/workspace/src')).toBe(true);
+    });
+
+    expect(treeSitterPathExists('/virtual/workspace/src')).toBe(false);
+  });
+});

--- a/packages/extension/tests/extension/pipeline/treesitter/projectRoots/go/module.test.ts
+++ b/packages/extension/tests/extension/pipeline/treesitter/projectRoots/go/module.test.ts
@@ -21,14 +21,14 @@ describe('pipeline/plugins/treesitter/runtime/projectRoots/go/module', () => {
     expect(readGoModuleName(workspaceRoot)).toBe('github.com/acme/project');
   });
 
-  it('trims module names and reuses the cached lookup for the same project root', () => {
+  it('trims module names and rereads go.mod when the project file changes', () => {
     const workspaceRoot = createProjectRootsWorkspace();
     writeProjectRootsFile(workspaceRoot, 'go.mod', 'module   github.com/acme/project   \n');
 
     expect(readGoModuleName(workspaceRoot)).toBe('github.com/acme/project');
 
     writeProjectRootsFile(workspaceRoot, 'go.mod', 'module github.com/acme/other\n');
-    expect(readGoModuleName(workspaceRoot)).toBe('github.com/acme/project');
+    expect(readGoModuleName(workspaceRoot)).toBe('github.com/acme/other');
   });
 
   it('returns the matching package directory for root and nested imports', () => {

--- a/packages/extension/tests/webview/Timeline.test.tsx
+++ b/packages/extension/tests/webview/Timeline.test.tsx
@@ -57,13 +57,13 @@ describe('Timeline', () => {
 
   // ── State 1: Returns null ──────────────────────────────────────────────
 
-  it('shows a disabled "Index Repo" button when no graph data is available yet', () => {
+  it('shows a disabled "Index Git History" button when no graph data is available yet', () => {
     resetStore({ graphData: null, timelineActive: false, isIndexing: false });
     render(<Timeline />);
-    expect(screen.getByText('Index Repo')).toBeDisabled();
+    expect(screen.getByText('Index Git History')).toBeDisabled();
   });
 
-  it('shows a disabled "Index Repo" button while the graph is still loading', () => {
+  it('shows a disabled "Index Git History" button while the graph is still loading', () => {
     resetStore({
       graphData: MOCK_GRAPH_DATA,
       isLoading: true,
@@ -72,22 +72,22 @@ describe('Timeline', () => {
     });
     render(<Timeline />);
 
-    expect(screen.getByText('Index Repo')).toBeDisabled();
+    expect(screen.getByText('Index Git History')).toBeDisabled();
   });
 
-  // ── State 1: Index Repo button ─────────────────────────────────────────
+  // ── State 1: Index Git History button ──────────────────────────────────
 
-  it('shows "Index Repo" button when graph data exists but no timeline', () => {
+  it('shows "Index Git History" button when graph data exists but no timeline', () => {
     resetStore({ graphData: MOCK_GRAPH_DATA, timelineActive: false, isIndexing: false });
     render(<Timeline />);
-    expect(screen.getByText('Index Repo')).toBeInTheDocument();
+    expect(screen.getByText('Index Git History')).toBeInTheDocument();
   });
 
-  it('sends INDEX_REPO message when "Index Repo" button is clicked', () => {
+  it('sends INDEX_REPO message when "Index Git History" button is clicked', () => {
     resetStore({ graphData: MOCK_GRAPH_DATA, timelineActive: false, isIndexing: false });
     render(<Timeline />);
 
-    fireEvent.click(screen.getByText('Index Repo'));
+    fireEvent.click(screen.getByText('Index Git History'));
 
     expect(sentMessages).toContainEqual({ type: 'INDEX_REPO' });
   });

--- a/packages/extension/tests/webview/app/graph/surface.test.tsx
+++ b/packages/extension/tests/webview/app/graph/surface.test.tsx
@@ -21,6 +21,7 @@ describe('app/graph/surface', () => {
         coloredData={{ nodes: [{ id: 'colored-node', label: 'Colored', color: '#222222' }], edges: [] }}
         showOrphans
         depthMode={false}
+        timelineActive={false}
         theme="light"
         nodeDecorations={{}}
         edgeDecorations={{}}
@@ -41,6 +42,7 @@ describe('app/graph/surface', () => {
         coloredData={null}
         showOrphans={false}
         depthMode={false}
+        timelineActive={false}
         theme="light"
         nodeDecorations={{}}
         edgeDecorations={{}}
@@ -51,5 +53,25 @@ describe('app/graph/surface', () => {
     );
 
     expect(screen.getByText(/All files are hidden/)).toBeInTheDocument();
+  });
+
+  it('renders the timeline-specific empty hint when the active commit has no graphable files', () => {
+    render(
+      <GraphSurface
+        graphData={{ nodes: [], edges: [] }}
+        coloredData={null}
+        showOrphans
+        depthMode={false}
+        timelineActive
+        theme="light"
+        nodeDecorations={{}}
+        edgeDecorations={{}}
+        pluginHost={undefined}
+        onAddFilterRequested={() => {}}
+        onAddLegendRequested={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/No files found\. No graphable files exist in this commit\./)).toBeInTheDocument();
   });
 });

--- a/packages/extension/tests/webview/app/shell/behavior.test.tsx
+++ b/packages/extension/tests/webview/app/shell/behavior.test.tsx
@@ -749,7 +749,9 @@ describe('App behavior', () => {
 
     render(<App />);
 
-    expect(screen.getByText(/No files found/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/No files found\. No graphable files exist in this commit\./),
+    ).toBeInTheDocument();
   });
 
   it('renders empty state when graph has no nodes', () => {

--- a/packages/extension/tests/webview/app/shell/messages.test.ts
+++ b/packages/extension/tests/webview/app/shell/messages.test.ts
@@ -18,6 +18,12 @@ describe('app messages', () => {
     );
   });
 
+  it('prompts to try another commit when the timeline commit has no graphable files', () => {
+    expect(getNoDataHint({ nodes: [], edges: [] }, true, false, true)).toBe(
+      'No graphable files exist in this commit. Try another point in the timeline.',
+    );
+  });
+
   it('prompts to change depth focus when depth mode resolves to an empty graph', () => {
     expect(getNoDataHint({ nodes: [], edges: [] }, true, true)).toBe(
       'No nodes match the current depth focus. Try changing the focused file or disabling depth mode.',

--- a/packages/extension/tests/webview/app/shell/mutations.test.tsx
+++ b/packages/extension/tests/webview/app/shell/mutations.test.tsx
@@ -209,7 +209,9 @@ describe('App (mutation targets)', () => {
       timelineActive: true,
     });
     render(<App />);
-    expect(screen.getByText(/No files found/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/No files found\. No graphable files exist in this commit\./),
+    ).toBeInTheDocument();
   });
 
   it('shows empty state when graphData is null', () => {

--- a/packages/extension/tests/webview/components/timeline/view/Status.test.tsx
+++ b/packages/extension/tests/webview/components/timeline/view/Status.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import Status from '../../../../../src/webview/components/timeline/view/Status';
 
 describe('timeline/Status', () => {
-  it('renders a disabled Index Repo button when graph data is unavailable', () => {
+  it('renders a disabled Index Git History button when graph data is unavailable', () => {
     render(
       <Status
         hasGraphData={false}
@@ -14,10 +14,10 @@ describe('timeline/Status', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Index Repo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Index Git History' })).toBeDisabled();
   });
 
-  it('renders an Index Repo button when graph data is available', () => {
+  it('renders an Index Git History button when graph data is available', () => {
     render(
       <Status
         hasGraphData
@@ -28,10 +28,10 @@ describe('timeline/Status', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Index Repo' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Index Git History' })).toBeInTheDocument();
   });
 
-  it('calls onIndexRepo when the Index Repo button is clicked', () => {
+  it('calls onIndexRepo when the Index Git History button is clicked', () => {
     const onIndexRepo = vi.fn();
 
     render(
@@ -44,7 +44,7 @@ describe('timeline/Status', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Index Repo' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Index Git History' }));
 
     expect(onIndexRepo).toHaveBeenCalledTimes(1);
   });
@@ -93,7 +93,7 @@ describe('timeline/Status', () => {
     expect(screen.getByText('Indexing repository...')).toBeInTheDocument();
   });
 
-  it('keeps the Index Repo button disabled while the graph is still loading', () => {
+  it('keeps the Index Git History button disabled while the graph is still loading', () => {
     render(
       <Status
         hasGraphData={false}
@@ -104,6 +104,6 @@ describe('timeline/Status', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Index Repo' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Index Git History' })).toBeDisabled();
   });
 });

--- a/packages/plugin-api/README.md
+++ b/packages/plugin-api/README.md
@@ -30,6 +30,7 @@ Main seams in the current API:
 - host-side export saving: `saveExport`
 - graph/webview product surfaces: plugin toolbar buttons, plugin slots, tooltip actions, and optional future-facing view transforms
 - default styling via `fileColors`, which already lets a plugin act like a file-theme layer for extension matches, exact file names, and glob patterns
+- analysis hooks receive an optional `context` with a host-backed file-system adapter so plugins can resolve commit-local files during timeline indexing without reading `fs` directly
 
 Core runs its own base analysis first. Plugin `analyzeFile(...)` results are then merged on top in plugin order, with higher-priority plugins winning conflicts.
 
@@ -55,6 +56,14 @@ Path and source rules:
 - unresolved package/runtime targets should use `toFilePath: null`
 - `sourceId` in plugin output is plugin-local, like `wikilink` or `import`
 - the host qualifies provenance later, for example `codegraphy.markdown:wikilink`
+
+Timeline-safe plugins:
+
+- `analyzeFile(...)`, `onPreAnalyze(...)`, and `onFilesChanged(...)` may receive `context`
+- `context.mode` is `'workspace'` or `'timeline'`
+- `context.commitSha` is set for timeline replay
+- `context.fileSystem` exposes `exists`, `isFile`, `isDirectory`, `listDirectory`, and `readTextFile`
+- prefer `context.fileSystem` over raw Node `fs` when plugin behavior depends on repo state, config files, or sibling files
 
 Minimal working plugin object:
 

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -99,7 +99,13 @@ export type {
 } from './events';
 
 // Plugin interface
-export type { IPlugin, IAnalysisFile, IPluginFileColorDefinition } from './plugin';
+export type {
+  IPlugin,
+  IAnalysisFile,
+  IPluginAnalysisContext,
+  IPluginAnalysisFileSystem,
+  IPluginFileColorDefinition,
+} from './plugin';
 
 // Host API
 export type { CodeGraphyAPI, ExportRequest, IExporter, IToolbarAction, IToolbarActionItem } from './api';

--- a/packages/plugin-api/src/plugin.ts
+++ b/packages/plugin-api/src/plugin.ts
@@ -28,6 +28,20 @@ export interface IAnalysisFile {
   content: string;
 }
 
+export interface IPluginAnalysisFileSystem {
+  exists(filePath: string): Promise<boolean>;
+  isDirectory(filePath: string): Promise<boolean>;
+  isFile(filePath: string): Promise<boolean>;
+  listDirectory(filePath: string): Promise<string[] | null>;
+  readTextFile(filePath: string): Promise<string | null>;
+}
+
+export interface IPluginAnalysisContext {
+  mode: 'workspace' | 'timeline';
+  commitSha?: string;
+  fileSystem: IPluginAnalysisFileSystem;
+}
+
 export interface IPluginFileColorDefinition {
   color: string;
   shape2D?: GraphNodeShape2D;
@@ -128,6 +142,7 @@ export interface IPlugin {
     filePath: string,
     content: string,
     workspaceRoot: string,
+    context?: IPluginAnalysisContext,
   ): Promise<IFileAnalysisResult>;
 
   /**
@@ -177,7 +192,8 @@ export interface IPlugin {
    */
   onPreAnalyze?(
     files: IAnalysisFile[],
-    workspaceRoot: string
+    workspaceRoot: string,
+    context?: IPluginAnalysisContext,
   ): Promise<void>;
 
   /**
@@ -190,6 +206,7 @@ export interface IPlugin {
   onFilesChanged?(
     files: IAnalysisFile[],
     workspaceRoot: string,
+    context?: IPluginAnalysisContext,
   ): Promise<readonly string[] | void>;
 
   /**

--- a/packages/plugin-godot/src/plugin.ts
+++ b/packages/plugin-godot/src/plugin.ts
@@ -6,7 +6,10 @@
  */
 
 import * as path from 'path';
-import type { IPlugin } from '@codegraphy-vscode/plugin-api';
+import type {
+  IPlugin,
+  IPluginAnalysisContext,
+} from '@codegraphy-vscode/plugin-api';
 import { GDScriptPathResolver } from './PathResolver';
 import { detectClassNameDeclaration, normalizePath } from './parser';
 import type { GDScriptFileAnalysisResult } from './analysis';
@@ -47,6 +50,7 @@ export interface IGDScriptAnalyzeFilePlugin extends IPlugin {
     filePath: string,
     content: string,
     workspaceRoot: string,
+    context?: IPluginAnalysisContext,
   ): Promise<GDScriptFileAnalysisResult>;
 }
 

--- a/packages/plugin-godot/src/plugin.ts
+++ b/packages/plugin-godot/src/plugin.ts
@@ -10,7 +10,7 @@ import type { IPlugin } from '@codegraphy-vscode/plugin-api';
 import { GDScriptPathResolver } from './PathResolver';
 import { detectClassNameDeclaration, normalizePath } from './parser';
 import type { GDScriptFileAnalysisResult } from './analysis';
-import { resolveGodotProjectRoot } from './projectRoot';
+import { collectGodotProjectRoots, resolveGodotProjectRoot } from './projectRoot';
 import manifest from '../codegraphy.json';
 
 // Source detect functions
@@ -52,6 +52,7 @@ export interface IGDScriptAnalyzeFilePlugin extends IPlugin {
 
 export function createGDScriptPlugin(): IGDScriptAnalyzeFilePlugin {
   let resolver: GDScriptPathResolver | null = null;
+  let projectRoots = new Set<string>();
 
   const extractClassNames = (content: string): string[] => {
     const classNames = new Set<string>();
@@ -74,7 +75,7 @@ export function createGDScriptPlugin(): IGDScriptAnalyzeFilePlugin {
   ): Promise<GDScriptFileAnalysisResult> => {
     if (!resolver) resolver = new GDScriptPathResolver(workspaceRoot);
 
-    const projectRoot = resolveGodotProjectRoot(filePath, workspaceRoot);
+    const projectRoot = resolveGodotProjectRoot(filePath, workspaceRoot, projectRoots);
     const relativeFilePath = normalizePath(path.relative(workspaceRoot, filePath));
     const ctx = { resolver, projectRoot, workspaceRoot, relativeFilePath };
 
@@ -102,6 +103,7 @@ export function createGDScriptPlugin(): IGDScriptAnalyzeFilePlugin {
 
     async initialize(workspaceRoot: string): Promise<void> {
       resolver = new GDScriptPathResolver(workspaceRoot);
+      projectRoots = new Set();
       console.log('[CodeGraphy] GDScript plugin initialized');
     },
 
@@ -110,6 +112,7 @@ export function createGDScriptPlugin(): IGDScriptAnalyzeFilePlugin {
       workspaceRoot: string
     ): Promise<void> {
       resolver = new GDScriptPathResolver(workspaceRoot);
+      projectRoots = collectGodotProjectRoots(files.map(({ relativePath }) => relativePath));
 
       for (const { relativePath, content } of files) {
         // Register file for snake_case fallback resolution
@@ -127,6 +130,10 @@ export function createGDScriptPlugin(): IGDScriptAnalyzeFilePlugin {
       if (!resolver) {
         resolver = new GDScriptPathResolver(workspaceRoot);
       }
+      projectRoots = new Set([
+        ...projectRoots,
+        ...collectGodotProjectRoots(files.map(({ relativePath }) => relativePath)),
+      ]);
 
       let requiresBroadReanalysis = false;
 
@@ -150,6 +157,7 @@ export function createGDScriptPlugin(): IGDScriptAnalyzeFilePlugin {
     onUnload(): void {
       resolver?.clearClassNames();
       resolver = null;
+      projectRoots = new Set();
     },
   };
 }

--- a/packages/plugin-godot/src/projectRoot.ts
+++ b/packages/plugin-godot/src/projectRoot.ts
@@ -1,17 +1,34 @@
-import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { normalizePath } from './parser';
 
 function isWithinRoot(candidatePath: string, rootPath: string): boolean {
   const relativePath = path.relative(rootPath, candidatePath);
   return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
 }
 
-export function resolveGodotProjectRoot(filePath: string, workspaceRoot: string): string {
+export function collectGodotProjectRoots(relativePaths: readonly string[]): Set<string> {
+  return new Set(relativePaths.flatMap((relativePath) => {
+    if (path.basename(relativePath) !== 'project.godot') {
+      return [];
+    }
+
+    const projectRoot = normalizePath(path.dirname(relativePath));
+    return [projectRoot === '.' ? '' : projectRoot];
+  }));
+}
+
+export function resolveGodotProjectRoot(
+  filePath: string,
+  workspaceRoot: string,
+  projectRoots: ReadonlySet<string> = new Set(),
+): string {
   let currentPath = path.dirname(filePath);
   const normalizedWorkspaceRoot = path.resolve(workspaceRoot);
 
   while (true) {
-    if (fs.existsSync(path.join(currentPath, 'project.godot'))) {
+    const relativePath = normalizeProjectRoot(path.relative(normalizedWorkspaceRoot, currentPath));
+
+    if (projectRoots.has(relativePath)) {
       return currentPath;
     }
 
@@ -26,4 +43,9 @@ export function resolveGodotProjectRoot(filePath: string, workspaceRoot: string)
 
     currentPath = parentPath;
   }
+}
+
+function normalizeProjectRoot(relativePath: string): string {
+  const normalizedPath = normalizePath(relativePath);
+  return normalizedPath === '.' ? '' : normalizedPath;
 }

--- a/packages/plugin-godot/tests/projectRoot.test.ts
+++ b/packages/plugin-godot/tests/projectRoot.test.ts
@@ -1,0 +1,40 @@
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { collectGodotProjectRoots, resolveGodotProjectRoot } from '../src/projectRoot';
+
+describe('Godot project root resolution', () => {
+  it('collects nested and workspace-root project markers', () => {
+    expect(
+      collectGodotProjectRoots([
+        'project.godot',
+        'apps/game/project.godot',
+        'apps/game/scripts/player.gd',
+      ]),
+    ).toEqual(new Set(['', 'apps/game']));
+  });
+
+  it('resolves the nearest indexed project.godot root without reading the live filesystem', () => {
+    const workspaceRoot = '/workspace';
+    const projectRoots = new Set(['', 'apps/game']);
+
+    expect(
+      resolveGodotProjectRoot(
+        path.join(workspaceRoot, 'apps/game/scripts/player.gd'),
+        workspaceRoot,
+        projectRoots,
+      ),
+    ).toBe(path.join(workspaceRoot, 'apps/game'));
+  });
+
+  it('falls back to the workspace root when no indexed project marker matches', () => {
+    const workspaceRoot = '/workspace';
+
+    expect(
+      resolveGodotProjectRoot(
+        path.join(workspaceRoot, 'misc/tools/helper.gd'),
+        workspaceRoot,
+        new Set(['apps/game']),
+      ),
+    ).toBe(workspaceRoot);
+  });
+});

--- a/packages/plugin-markdown/src/PathResolver.ts
+++ b/packages/plugin-markdown/src/PathResolver.ts
@@ -5,7 +5,6 @@
  */
 
 import * as path from 'path';
-import * as fs from 'fs';
 
 /**
  * Resolves wikilink targets to absolute file paths.
@@ -30,8 +29,15 @@ export class PathResolver {
   /**
    * Retained for plugin lifecycle compatibility.
    */
-  buildIndex(_files: Array<{ absolutePath: string }>): void {
+  buildIndex(files: Array<{ absolutePath: string }>): void {
     this.fileIndex.clear();
+
+    for (const { absolutePath } of files) {
+      const relativePath = this.toLookupKey(path.relative(this.workspaceRoot, absolutePath));
+      const existing = this.fileIndex.get(relativePath) ?? [];
+      existing.push(absolutePath);
+      this.fileIndex.set(relativePath, existing);
+    }
   }
 
   /**
@@ -52,14 +58,29 @@ export class PathResolver {
   }
 
   private resolveByPath(target: string): string | null {
-    const normalizedTarget = target.replace(/\\/g, '/');
-    const candidates = [
-      path.join(this.workspaceRoot, normalizedTarget),
-      path.join(this.workspaceRoot, normalizedTarget + '.md'),
-    ];
+    const candidates = this.buildPathCandidates(target);
+
     for (const candidate of candidates) {
-      if (fs.existsSync(candidate)) return candidate;
+      const indexedCandidate = this.fileIndex.get(this.toLookupKey(candidate))?.[0];
+      if (indexedCandidate) {
+        return indexedCandidate;
+      }
     }
-    return null;
+
+    return path.join(this.workspaceRoot, candidates[0]);
+  }
+
+  private buildPathCandidates(target: string): string[] {
+    const normalizedTarget = target.replace(/\\/g, '/');
+
+    if (path.extname(normalizedTarget) !== '') {
+      return [normalizedTarget];
+    }
+
+    return [normalizedTarget + '.md'];
+  }
+
+  private toLookupKey(filePath: string): string {
+    return filePath.replace(/\\/g, '/').replace(/^\.\//, '').toLowerCase();
   }
 }


### PR DESCRIPTION
## Summary
- resolve timeline commit analysis against each commit snapshot instead of the live workspace
- stop diff replay from introducing unsupported timeline-only nodes
- add regression tests for commit-local path hosting and same-commit replay parity

## Testing
- pnpm --filter @codegraphy/extension run typecheck
- pnpm --filter @codegraphy/extension run lint
- ./node_modules/.bin/vitest run --config packages/extension/vitest.config.ts packages/extension/tests/extension/gitHistory/analyzer.test.ts packages/extension/tests/extension/gitHistory/diff/analysis.test.ts packages/extension/tests/extension/gitHistory/diff/changes.test.ts packages/extension/tests/extension/gitHistory/diff/replay.test.ts packages/extension/tests/extension/gitHistory/fullCommitAnalysis.test.ts packages/extension/tests/extension/gitHistory/reanalyzeGraphFile.test.ts packages/extension/tests/extension/pipeline/treesitter/resolve.test.ts packages/extension/tests/extension/pipeline/treesitter/pathHost.test.ts packages/extension/tests/extension/pipeline/treesitter/projectRoots/search.test.ts packages/extension/tests/extension/pipeline/treesitter/projectRoots/go/module.test.ts packages/extension/tests/extension/pipeline/treesitter/projectRoots/go/packagePath.test.ts packages/extension/tests/extension/pipeline/treesitter/projectRoots/java.test.ts packages/extension/tests/extension/gitHistory/commitPathHost.test.ts