### PR TITLE
Raise default maxFiles to 1000

### DIFF
--- a/.changeset/raise-max-files-default-1000.md
+++ b/.changeset/raise-max-files-default-1000.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy/extension": patch
+---
+
+Increase the default `maxFiles` setting from 500 to 1000.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -62,7 +62,7 @@ Example:
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `maxFiles` | number | `500` | Maximum files to discover/analyze |
+| `maxFiles` | number | `1000` | Maximum files to discover/analyze |
 | `include` | string[] | `["**/*"]` | Glob patterns for files to include |
 | `filterPatterns` | string[] | `[]` | Glob patterns for files to exclude |
 | `respectGitignore` | boolean | `true` | Honor `.gitignore` patterns |

--- a/packages/extension/src/core/discovery/contracts.ts
+++ b/packages/extension/src/core/discovery/contracts.ts
@@ -9,7 +9,7 @@
 export interface IDiscoveryOptions {
   /** Absolute path to the workspace root */
   rootPath: string;
-  /** Maximum number of files to discover (default: 500) */
+  /** Maximum number of files to discover (default: 1000) */
   maxFiles?: number;
   /** Glob patterns for files to include (default: ['**\/*']) */
   include?: string[];

--- a/packages/extension/src/core/discovery/file/defaults.ts
+++ b/packages/extension/src/core/discovery/file/defaults.ts
@@ -3,6 +3,7 @@
  * @module core/discovery/file/defaults
  */
 
+export { DEFAULT_MAX_FILES } from '../../../shared/settings/defaults';
+
 export const DEFAULT_INCLUDE = ['**/*'];
 export const EMPTY_PATTERNS: string[] = [];
-export const DEFAULT_MAX_FILES = 500;

--- a/packages/extension/src/extension/config/reader.ts
+++ b/packages/extension/src/extension/config/reader.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import type { IGroup } from '../../shared/settings/groups';
+import { DEFAULT_MAX_FILES } from '../../shared/settings/defaults';
 import { getCodeGraphyConfiguration, onDidChangeCodeGraphyConfiguration } from '../repoSettings/current';
 import type { ICodeGraphyConfig } from './defaults';
 
@@ -42,10 +43,10 @@ export class Configuration {
   /**
    * Maximum number of files to analyze.
    * Shows a warning if the workspace exceeds this limit.
-   * @default 500
+   * @default 1000
    */
   get maxFiles(): number {
-    return this.config.get<number>('maxFiles', 500);
+    return this.config.get<number>('maxFiles', DEFAULT_MAX_FILES);
   }
 
   /**

--- a/packages/extension/src/extension/graphView/settings/snapshot.ts
+++ b/packages/extension/src/extension/graphView/settings/snapshot.ts
@@ -1,6 +1,7 @@
 import type { NodeSizeMode } from '../../../shared/settings/modes';
 import type { IPhysicsSettings } from '../../../shared/settings/physics';
 import type { ISettingsSnapshot } from '../../../shared/settings/snapshot';
+import { DEFAULT_MAX_FILES } from '../../../shared/settings/defaults';
 import { readGraphViewSettings } from './reader';
 
 interface GraphViewSettingsConfig {
@@ -49,7 +50,7 @@ export function captureGraphViewSettingsSnapshot(
     particleSpeed: config.get('particleSpeed', 0.005),
     particleSize: config.get('particleSize', 4),
     showLabels: config.get('showLabels', true),
-    maxFiles: config.get('maxFiles', 500),
+    maxFiles: config.get('maxFiles', DEFAULT_MAX_FILES),
     nodeSizeMode,
   };
 }

--- a/packages/extension/src/extension/graphView/webview/providerMessages/settingsContext/create.ts
+++ b/packages/extension/src/extension/graphView/webview/providerMessages/settingsContext/create.ts
@@ -1,4 +1,5 @@
 import type { GraphViewMessageListenerContext } from '../../messages/listener';
+import { DEFAULT_MAX_FILES } from '../../../../../shared/settings/defaults';
 import type {
   GraphViewProviderMessageListenerDependencies,
   GraphViewProviderMessageListenerSource,
@@ -71,7 +72,7 @@ export function createGraphViewProviderMessageSettingsContext(
       );
       await dependencies.executeUndoAction(action);
     },
-    getMaxFiles: () => config.get<number>('maxFiles', 500) ?? 500,
+    getMaxFiles: () => config.get<number>('maxFiles', DEFAULT_MAX_FILES) ?? DEFAULT_MAX_FILES,
     getPlaybackSpeed: () => config.get<number>('timeline.playbackSpeed', 1.0) ?? 1.0,
     getDepthMode: () => source._depthMode,
     getDagMode: () => source._dagMode,

--- a/packages/extension/src/extension/repoSettings/defaults.ts
+++ b/packages/extension/src/extension/repoSettings/defaults.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_DIRECTION_COLOR } from '../../shared/fileColors';
 import type { IGroup } from '../../shared/settings/groups';
 import type { DagMode, NodeSizeMode } from '../../shared/settings/modes';
+import { DEFAULT_MAX_FILES } from '../../shared/settings/defaults';
 import {
   createDefaultEdgeVisibility,
   createDefaultNodeColorEnabled,
@@ -54,7 +55,7 @@ export interface ICodeGraphyRepoSettings {
 export function createDefaultCodeGraphyRepoSettings(): ICodeGraphyRepoSettings {
   return {
     version: 1,
-    maxFiles: 500,
+    maxFiles: DEFAULT_MAX_FILES,
     include: ['**/*'],
     respectGitignore: true,
     showOrphans: true,

--- a/packages/extension/src/shared/settings/defaults.ts
+++ b/packages/extension/src/shared/settings/defaults.ts
@@ -1,0 +1,5 @@
+/**
+ * Shared default values for user-configurable CodeGraphy settings.
+ */
+
+export const DEFAULT_MAX_FILES = 1000;

--- a/packages/extension/src/webview/store/initialState.ts
+++ b/packages/extension/src/webview/store/initialState.ts
@@ -1,6 +1,7 @@
 import type { GraphStateFields } from './state';
 import { DEFAULT_PHYSICS, DEFAULT_SEARCH_OPTIONS } from './defaults';
 import { DEFAULT_DIRECTION_COLOR } from '../../shared/fileColors';
+import { DEFAULT_MAX_FILES } from '../../shared/settings/defaults';
 
 export const INITIAL_STATE: GraphStateFields = {
   graphData: null,
@@ -48,7 +49,7 @@ export const INITIAL_STATE: GraphStateFields = {
   pluginToolbarActions: [],
   expandedGroupId: null,
   activePanel: 'none' as const,
-  maxFiles: 500,
+  maxFiles: DEFAULT_MAX_FILES,
   activeFilePath: null,
   timelineActive: false,
   timelineCommits: [],

--- a/packages/extension/tests/extension/config/configReaders.test.ts
+++ b/packages/extension/tests/extension/config/configReaders.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as vscode from 'vscode';
 import { Configuration } from '../../../src/extension/config/reader';
+import { DEFAULT_MAX_FILES } from '../../../src/shared/settings/defaults';
 
 describe('Configuration (configReaders)', () => {
   let mockConfig: Record<string, unknown>;
@@ -19,12 +20,12 @@ describe('Configuration (configReaders)', () => {
 
   describe('maxFiles', () => {
     it('returns the configured value', () => {
-      mockConfig['maxFiles'] = 1000;
-      expect(new Configuration().maxFiles).toBe(1000);
+      mockConfig['maxFiles'] = 1200;
+      expect(new Configuration().maxFiles).toBe(1200);
     });
 
-    it('returns the default 500 when not configured', () => {
-      expect(new Configuration().maxFiles).toBe(500);
+    it('returns the default 1000 when not configured', () => {
+      expect(new Configuration().maxFiles).toBe(DEFAULT_MAX_FILES);
     });
 
     it('reads from the codegraphy section', () => {
@@ -154,7 +155,7 @@ describe('Configuration (configReaders)', () => {
 
     it('uses defaults for unconfigured values', () => {
       const all = new Configuration().getAll();
-      expect(all.maxFiles).toBe(500);
+      expect(all.maxFiles).toBe(DEFAULT_MAX_FILES);
       expect(all.showOrphans).toBe(true);
       expect(all.disabledPlugins).toEqual([]);
     });

--- a/packages/extension/tests/extension/config/configuration.test.ts
+++ b/packages/extension/tests/extension/config/configuration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Configuration } from '../../../src/extension/config/reader';
+import { DEFAULT_MAX_FILES } from '../../../src/shared/settings/defaults';
 import {
   DEFAULT_EXCLUDE_PATTERNS,
   type ICodeGraphyConfig,
@@ -21,7 +22,7 @@ describe('Configuration', () => {
   beforeEach(() => {
     // Reset mock config to defaults
     mockConfig = {
-      maxFiles: 500,
+      maxFiles: DEFAULT_MAX_FILES,
       include: ['**/*'],
       respectGitignore: true,
       showOrphans: true,
@@ -37,9 +38,9 @@ describe('Configuration', () => {
   });
 
   describe('default values', () => {
-    it('should return default maxFiles of 500', () => {
+    it('should return default maxFiles of 1000', () => {
       const config = new Configuration();
-      expect(config.maxFiles).toBe(500);
+      expect(config.maxFiles).toBe(DEFAULT_MAX_FILES);
     });
 
     it('should return default include pattern', () => {
@@ -65,9 +66,9 @@ describe('Configuration', () => {
 
   describe('custom values', () => {
     it('should return custom maxFiles', () => {
-      mockConfig.maxFiles = 500;
+      mockConfig.maxFiles = 1200;
       const config = new Configuration();
-      expect(config.maxFiles).toBe(500);
+      expect(config.maxFiles).toBe(1200);
     });
 
     it('should return custom include patterns', () => {
@@ -101,7 +102,7 @@ describe('Configuration', () => {
       const all: ICodeGraphyConfig = config.getAll();
 
       expect(all).toEqual({
-        maxFiles: 500,
+        maxFiles: DEFAULT_MAX_FILES,
         include: ['**/*'],
         respectGitignore: true,
         showOrphans: true,

--- a/packages/extension/tests/extension/graphView/settings/snapshotMessages.test.ts
+++ b/packages/extension/tests/extension/graphView/settings/snapshotMessages.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../../src/extension/graphView/settings/messages';
 import { captureGraphViewSettingsSnapshot } from '../../../../src/extension/graphView/settings/snapshot';
 import { DEFAULT_DIRECTION_COLOR } from '../../../../src/shared/fileColors';
+import { DEFAULT_MAX_FILES } from '../../../../src/shared/settings/defaults';
 
 function createConfig(values: Record<string, unknown>) {
   return {
@@ -55,7 +56,7 @@ describe('graphView/settings/snapshotMessages', () => {
       particleSpeed: 0.005,
       particleSize: 4,
       showLabels: true,
-      maxFiles: 500,
+      maxFiles: DEFAULT_MAX_FILES,
       nodeSizeMode: 'uniform',
     });
   });

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/listener.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/listener.test.ts
@@ -7,6 +7,7 @@ import type { ISettingsSnapshot } from '../../../../../src/shared/settings/snaps
 import type { IViewContext } from '@/core/views/contracts';
 import type { IUndoableAction } from '../../../../../src/extension/undoManager';
 import type { GraphViewMessageListenerContext } from '../../../../../src/extension/graphView/webview/messages/listener';
+import { DEFAULT_MAX_FILES } from '../../../../../src/shared/settings/defaults';
 import {
   setGraphViewProviderMessageListener,
   type GraphViewProviderMessageListenerDependencies,
@@ -45,7 +46,7 @@ function createSettingsSnapshot(): ISettingsSnapshot {
     particleSpeed: 0.005,
     particleSize: 4,
     showLabels: true,
-    maxFiles: 500,
+    maxFiles: DEFAULT_MAX_FILES,
     nodeSizeMode: 'connections',
     physics: {
       repelForce: 1,
@@ -433,11 +434,11 @@ describe('graph view provider listener bridge', () => {
     );
     expect(execute).toHaveBeenCalledTimes(1);
 
-    expect(context.getMaxFiles()).toBe(500);
+    expect(context.getMaxFiles()).toBe(DEFAULT_MAX_FILES);
     expect(context.getPlaybackSpeed()).toBe(1);
     expect(context.getDagMode()).toBe('td');
     expect(context.getNodeSizeMode()).toBe('file-size');
-    expect(configurationGet).toHaveBeenCalledWith('maxFiles', 500);
+    expect(configurationGet).toHaveBeenCalledWith('maxFiles', DEFAULT_MAX_FILES);
     expect(configurationGet).toHaveBeenCalledWith('timeline.playbackSpeed', 1.0);
   });
 

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/settingsContext/create.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/settingsContext/create.test.ts
@@ -3,6 +3,7 @@ import {
   createGraphViewProviderMessageSettingsContext,
 } from '../../../../../../src/extension/graphView/webview/providerMessages/settingsContext/create';
 import * as repoSettings from '../../../../../../src/extension/repoSettings/current';
+import { DEFAULT_MAX_FILES } from '../../../../../../src/shared/settings/defaults';
 
 vi.mock('../../../../../../src/extension/repoSettings/current', () => ({
   getCodeGraphyConfiguration: vi.fn(),
@@ -123,7 +124,7 @@ describe('graph view provider listener settings context', () => {
     expect(captureSettingsSnapshot).toHaveBeenCalledOnce();
     expect(createResetSettingsAction).toHaveBeenCalledOnce();
     expect(executeUndoAction).toHaveBeenCalledWith({ kind: 'reset-settings' });
-    expect(context.getMaxFiles()).toBe(500);
+    expect(context.getMaxFiles()).toBe(DEFAULT_MAX_FILES);
     expect(context.getPlaybackSpeed()).toBe(1);
   });
 

--- a/packages/extension/tests/extension/repoSettings/defaults.test.ts
+++ b/packages/extension/tests/extension/repoSettings/defaults.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_DIRECTION_COLOR } from '../../../src/shared/fileColors';
+import { DEFAULT_MAX_FILES } from '../../../src/shared/settings/defaults';
 import {
   createDefaultEdgeVisibility,
   createDefaultNodeColorEnabled,
@@ -12,7 +13,7 @@ describe('extension/repoSettings/defaults', () => {
   it('builds the full repo settings defaults', () => {
     expect(createDefaultCodeGraphyRepoSettings()).toEqual({
       version: 1,
-      maxFiles: 500,
+      maxFiles: DEFAULT_MAX_FILES,
       include: ['**/*'],
       respectGitignore: true,
       showOrphans: true,

--- a/packages/extension/tests/webview/store/state/defaults.test.ts
+++ b/packages/extension/tests/webview/store/state/defaults.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { DEFAULT_DIRECTION_COLOR } from '../../../../src/shared/fileColors';
+import { DEFAULT_MAX_FILES } from '../../../../src/shared/settings/defaults';
 import { createGraphStore } from '../../../../src/webview/store/state';
 
 describe('GraphStore initial state', () => {
@@ -35,7 +36,7 @@ describe('GraphStore initial state', () => {
     expect(state.depthLimit).toBe(1);
     expect(state.maxDepthLimit).toBe(10);
     expect(state.dagMode).toBeNull();
-    expect(state.maxFiles).toBe(500);
+    expect(state.maxFiles).toBe(DEFAULT_MAX_FILES);
   });
 
   it('starts with empty plugin decoration and context menu state', () => {


### PR DESCRIPTION
## Summary
- raise the shared default maxFiles setting from 500 to 1000
- keep extension config, repo settings, discovery, and webview state aligned on the same default constant
- update tests and settings docs to reflect the new default

## Testing
- pnpm --filter @codegraphy/extension test
- pnpm run test
