### PR TITLE
Fix monorepo release target discovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,14 @@ on:
         type: choice
         options:
           - core
+          - mcp
           - typescript
           - python
           - csharp
           - godot
           - plugin-api
+          - npm
+          - vsce
           - all
 
 permissions:
@@ -62,16 +65,14 @@ jobs:
       - name: Release checks
         run: pnpm run release:check
 
-      - name: Package selected VS Code extension artifacts
-        if: ${{ inputs.target != 'plugin-api' }}
+      - name: Package selected release artifacts
         run: pnpm run release:package ${{ inputs.target }}
 
-      - name: Upload VSIX artifacts
-        if: ${{ inputs.target != 'plugin-api' }}
+      - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: vsix-artifacts
-          path: artifacts/vsix/
+          name: release-artifacts
+          path: artifacts/
           retention-days: 30
 
       - name: Publish selected target

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 *.log
 .DS_Store
 dist-e2e/
+/artifacts/
 .worktrees/
 .playwright-mcp/
 .playwright-cli/

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,6 +8,7 @@ Release-facing metadata is not all in one package:
 - Core extension versioning lives in [`packages/extension/package.json`](../packages/extension/package.json)
 - Plugin extension marketplace metadata lives in each `packages/plugin-*/package.json`
 - Plugin API npm metadata lives in [`packages/plugin-api/package.json`](../packages/plugin-api/package.json)
+- MCP npm metadata lives in [`packages/codegraphy-mcp/package.json`](../packages/codegraphy-mcp/package.json)
 - The core extension icon source lives at [`assets/icon.svg`](../assets/icon.svg)
 - Each published plugin ships its own badged icon at `packages/plugin-*/assets/icon.svg`
 
@@ -27,10 +28,14 @@ Run the full release gate first:
 pnpm run release:check
 ```
 
-Package VSIX files locally:
+Package release artifacts locally:
 
 ```bash
 pnpm run release:package core
+pnpm run release:package mcp
+pnpm run release:package plugin-api
+pnpm run release:package npm
+pnpm run release:package vsce
 pnpm run release:package typescript
 pnpm run release:package python
 pnpm run release:package csharp
@@ -38,12 +43,15 @@ pnpm run release:package godot
 pnpm run release:package all
 ```
 
-`core` release packaging rebuilds `@codegraphy/extension` from source first, so it does not rely on whatever `dist/` happened to be left in the repo.
+`core` release packaging rebuilds `@codegraphy/extension` from source first, so it does not rely on whatever `dist/` happened to be left in the repo. npm packages are packed into `artifacts/npm/`; VS Code extensions are packed into `artifacts/vsix/`.
 
 Publish from a machine that already has `VSCE_PAT` and npm auth configured:
 
 ```bash
 pnpm run release:publish plugin-api
+pnpm run release:publish mcp
+pnpm run release:publish npm
+pnpm run release:publish vsce
 pnpm run release:publish core
 pnpm run release:publish typescript
 pnpm run release:publish python
@@ -52,7 +60,7 @@ pnpm run release:publish godot
 pnpm run release:publish all
 ```
 
-`pnpm run release:publish core` also rebuilds the core extension before staging and publishing.
+`pnpm run release:publish core` also rebuilds the core extension before staging and publishing. `all` and `npm` discover publishable workspace packages from `package.json` metadata, publish npm packages before Marketplace packages, and skip npm versions that already exist.
 
 Before the first local publish from this release setup, verify the authenticated publisher:
 
@@ -74,29 +82,33 @@ vsce verify-pat codegraphy
 8. If the core Marketplace extension changed, verify `packages/extension/package.json` and [`packages/extension/CHANGELOG.md`](../packages/extension/CHANGELOG.md) have matching top entries.
 9. Commit the generated version and changelog updates.
 10. Run `pnpm run release:check`.
-11. Publish `@codegraphy-vscode/plugin-api` with `pnpm run release:publish plugin-api`.
-12. Publish the core extension with `pnpm run release:publish core`.
-13. Publish each plugin extension separately:
+11. Publish every release target with `pnpm run release:publish all`.
+12. Or publish npm packages first with `pnpm run release:publish npm`, then publish Marketplace packages with `pnpm run release:publish vsce`.
+13. To publish separately, publish npm packages before Marketplace packages:
+   - `pnpm run release:publish plugin-api`
+   - `pnpm run release:publish mcp`
+14. Publish the core extension with `pnpm run release:publish core`.
+15. Publish each plugin extension separately:
    - `pnpm run release:publish typescript`
    - `pnpm run release:publish python`
    - `pnpm run release:publish csharp`
    - `pnpm run release:publish godot`
-14. Open each Marketplace listing and verify the dependency text, README, icon, gallery banner, and version.
-15. Verify the existing `codegraphy.codegraphy` listing has been updated in place to the new V4 release metadata.
-16. Open the npm package page for [`@codegraphy-vscode/plugin-api`](https://www.npmjs.com/package/@codegraphy-vscode/plugin-api) and verify the README and repository links.
+16. Open each Marketplace listing and verify the dependency text, README, icon, gallery banner, and version.
+17. Verify the existing `codegraphy.codegraphy` listing has been updated in place to the new V4 release metadata.
+18. Open the npm package pages for [`@codegraphy-vscode/plugin-api`](https://www.npmjs.com/package/@codegraphy-vscode/plugin-api) and [`@codegraphy-vscode/mcp`](https://www.npmjs.com/package/@codegraphy-vscode/mcp), then verify the README and repository links.
 
 ## GitHub Actions
 
 Use the `Release` workflow with `workflow_dispatch`.
 
-- `mode=package` builds and uploads VSIX artifacts.
-- `target` can be `core`, `typescript`, `python`, `csharp`, `godot`, `plugin-api`, or `all`.
-- `mode=publish` runs the same checks, packages VSIX files, publishes the selected VS Code extension target, and publishes `@codegraphy-vscode/plugin-api` when requested.
+- `mode=package` builds and uploads release artifacts.
+- `target` can be `all`, `npm`, `vsce`, `core`, `mcp`, `plugin-api`, `typescript`, `python`, `csharp`, or `godot`.
+- `mode=publish` runs the same checks, packages release artifacts, publishes selected Marketplace targets, and publishes selected npm packages.
 
 Required secrets:
 
 - `VSCE_PAT` for Marketplace publishing
-- `NPM_TOKEN` for `@codegraphy-vscode/plugin-api`
+- `NPM_TOKEN` for npm packages under the `@codegraphy-vscode` scope
 
 ## Marketplace migration note
 
@@ -116,3 +128,4 @@ If you ever move the core to a different publisher later, that would require a n
 - C# plugin: <https://marketplace.visualstudio.com/items?itemName=codegraphy.codegraphy-csharp>
 - GDScript plugin: <https://marketplace.visualstudio.com/items?itemName=codegraphy.codegraphy-godot>
 - Plugin API: <https://www.npmjs.com/package/@codegraphy-vscode/plugin-api>
+- MCP: <https://www.npmjs.com/package/@codegraphy-vscode/mcp>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"release:check": "pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run build",
 		"release:package": "node scripts/release.mjs package",
 		"release:publish": "node scripts/release.mjs publish",
-		"test:release": "node --test tests/release/changesets.test.mjs",
+		"test:release": "node --test tests/release/*.test.mjs",
 		"typecheck": "turbo run typecheck",
 		"typecheck:extension": "pnpm --filter @codegraphy/extension run typecheck",
 		"typecheck:plugin-api": "pnpm --filter @codegraphy-vscode/plugin-api run typecheck",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,89 +1,286 @@
+import { mkdirSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
-const [, , mode, target] = process.argv;
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workspaceDependencyTypes = ['dependencies', 'devDependencies', 'peerDependencies'];
 
-const pluginTargets = ['typescript', 'python', 'csharp', 'godot'];
-const publishTargets = ['core', ...pluginTargets, 'plugin-api', 'all'];
-const packageTargets = ['core', ...pluginTargets, 'all'];
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
 
-function run(command, args) {
+function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
-    cwd: process.cwd(),
+    cwd: repoRoot,
     stdio: 'inherit',
     shell: true,
+    ...options,
   });
 
+  return {
+    status: result.status ?? 1,
+  };
+}
+
+function requireSuccess(result) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
 }
 
-function printUsage() {
-  console.error(
-    [
-      'Usage:',
-      '  pnpm run release:package <core|typescript|python|csharp|godot|all>',
-      '  pnpm run release:publish <core|typescript|python|csharp|godot|plugin-api|all>',
-    ].join('\n'),
+function workspacePatterns(rootManifest) {
+  if (Array.isArray(rootManifest.workspaces)) {
+    return rootManifest.workspaces;
+  }
+
+  if (Array.isArray(rootManifest.workspaces?.packages)) {
+    return rootManifest.workspaces.packages;
+  }
+
+  return [];
+}
+
+function packageAlias(packageName) {
+  if (packageName.startsWith('@')) {
+    return packageName.split('/').at(-1);
+  }
+
+  if (packageName.startsWith('codegraphy-')) {
+    return packageName.slice('codegraphy-'.length);
+  }
+
+  return packageName;
+}
+
+function collectWorkspacePackages(baseDir) {
+  const rootManifest = readJson(path.join(baseDir, 'package.json'));
+  const packages = [];
+
+  for (const pattern of workspacePatterns(rootManifest)) {
+    if (!pattern.endsWith('/*')) {
+      continue;
+    }
+
+    const workspaceDir = path.join(baseDir, pattern.slice(0, -2));
+    const entries = readdirSync(workspaceDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const packageJsonPath = path.join(workspaceDir, entry.name, 'package.json');
+      const manifest = readJson(packageJsonPath);
+
+      packages.push({
+        dir: path.dirname(packageJsonPath),
+        manifest,
+      });
+    }
+  }
+
+  return packages;
+}
+
+function workspaceDependencies(manifest, workspacePackageNames) {
+  const dependencies = new Set();
+
+  for (const dependencyType of workspaceDependencyTypes) {
+    const dependencyEntries = Object.entries(manifest[dependencyType] ?? {});
+
+    for (const [packageName, versionRange] of dependencyEntries) {
+      if (versionRange === 'workspace:*' && workspacePackageNames.has(packageName)) {
+        dependencies.add(packageName);
+      }
+    }
+  }
+
+  return dependencies;
+}
+
+function sortByWorkspaceDependencies(packages) {
+  const workspacePackageNames = new Set(packages.map(({ manifest }) => manifest.name));
+  const pending = new Map(packages.map((workspacePackage) => [workspacePackage.manifest.name, workspacePackage]));
+  const sorted = [];
+
+  while (pending.size > 0) {
+    const readyPackages = Array.from(pending.values())
+      .filter(({ manifest }) => {
+        const dependencies = workspaceDependencies(manifest, workspacePackageNames);
+        return Array.from(dependencies).every((dependencyName) => !pending.has(dependencyName));
+      })
+      .sort((left, right) => left.manifest.name.localeCompare(right.manifest.name));
+
+    if (readyPackages.length === 0) {
+      const remainingPackages = Array.from(pending.values())
+        .sort((left, right) => left.manifest.name.localeCompare(right.manifest.name));
+      sorted.push(...remainingPackages);
+      break;
+    }
+
+    for (const workspacePackage of readyPackages) {
+      sorted.push(workspacePackage);
+      pending.delete(workspacePackage.manifest.name);
+    }
+  }
+
+  return sorted;
+}
+
+function toWorkspaceReleaseTarget(workspacePackage) {
+  const { manifest } = workspacePackage;
+  const hasVsceRelease = Boolean(manifest.scripts?.['package:vsix'] || manifest.scripts?.['publish:vsce']);
+
+  return {
+    id: packageAlias(manifest.name),
+    aliases: [packageAlias(manifest.name), manifest.name],
+    kind: hasVsceRelease ? 'vsce' : 'npm',
+    packageName: manifest.name,
+    version: manifest.version,
+    access: manifest.publishConfig?.access ?? 'public',
+  };
+}
+
+export function collectReleaseTargets(baseDir = repoRoot) {
+  const workspaceTargets = sortByWorkspaceDependencies(
+    collectWorkspacePackages(baseDir).filter(({ manifest }) => manifest.private !== true),
+  ).map(toWorkspaceReleaseTarget);
+
+  const npmTargets = workspaceTargets.filter((target) => target.kind === 'npm');
+  const vsceTargets = workspaceTargets.filter((target) => target.kind === 'vsce');
+
+  return [
+    ...npmTargets,
+    {
+      id: 'core',
+      aliases: ['core'],
+      kind: 'core',
+    },
+    ...vsceTargets,
+  ];
+}
+
+function targetMatches(target, requestedTarget) {
+  return target.aliases.includes(requestedTarget);
+}
+
+export function resolveReleaseTargets(requestedTarget, baseDir = repoRoot) {
+  const releaseTargets = collectReleaseTargets(baseDir);
+
+  if (requestedTarget === 'all') {
+    return releaseTargets;
+  }
+
+  if (requestedTarget === 'npm') {
+    return releaseTargets.filter((target) => target.kind === 'npm');
+  }
+
+  if (requestedTarget === 'vsce') {
+    return releaseTargets.filter((target) => target.kind === 'core' || target.kind === 'vsce');
+  }
+
+  return releaseTargets.filter((target) => targetMatches(target, requestedTarget));
+}
+
+function formatUsage(baseDir = repoRoot) {
+  const targetNames = [
+    'all',
+    'npm',
+    'vsce',
+    ...collectReleaseTargets(baseDir).map((target) => target.id),
+  ];
+  const targetList = Array.from(new Set(targetNames)).join('|');
+
+  return [
+    'Usage:',
+    `  pnpm run release:package <${targetList}>`,
+    `  pnpm run release:publish <${targetList}>`,
+  ].join('\n');
+}
+
+function npmVersionExists(target, baseDir, runCommand) {
+  const result = runCommand(
+    'npm',
+    ['view', `${target.packageName}@${target.version}`, 'version', '--json'],
+    { cwd: baseDir, stdio: 'pipe' },
+  );
+
+  return result.status === 0;
+}
+
+function runCoreRelease(mode, baseDir, runCommand) {
+  return runCommand('pnpm', ['run', mode === 'package' ? 'package:vsix' : 'publish:vsce'], {
+    cwd: baseDir,
+  });
+}
+
+function runNpmRelease(mode, target, baseDir, runCommand) {
+  if (mode === 'package') {
+    const artifactDir = path.join(baseDir, 'artifacts', 'npm');
+    mkdirSync(artifactDir, { recursive: true });
+    return runCommand('pnpm', ['--filter', target.packageName, 'pack', '--pack-destination', artifactDir], {
+      cwd: baseDir,
+    });
+  }
+
+  if (npmVersionExists(target, baseDir, runCommand)) {
+    console.log(`${target.packageName}@${target.version} already exists on npm; skipping.`);
+    return { status: 0 };
+  }
+
+  return runCommand(
+    'pnpm',
+    ['--filter', target.packageName, 'publish', '--access', target.access, '--no-git-checks'],
+    { cwd: baseDir },
   );
 }
 
-if (!mode || !target) {
-  printUsage();
-  process.exit(1);
+function runVsceRelease(mode, target, baseDir, runCommand) {
+  return runCommand(
+    'pnpm',
+    ['--filter', target.packageName, 'run', mode === 'package' ? 'package:vsix' : 'publish:vsce'],
+    { cwd: baseDir },
+  );
 }
 
-if (mode === 'package') {
-  if (!packageTargets.includes(target)) {
-    printUsage();
+function runReleaseTarget(mode, target, baseDir, runCommand) {
+  if (target.kind === 'core') {
+    return runCoreRelease(mode, baseDir, runCommand);
+  }
+
+  if (target.kind === 'npm') {
+    return runNpmRelease(mode, target, baseDir, runCommand);
+  }
+
+  return runVsceRelease(mode, target, baseDir, runCommand);
+}
+
+export function runRelease(mode, requestedTarget, baseDir = repoRoot, runCommand = run) {
+  if (mode !== 'package' && mode !== 'publish') {
+    console.error(formatUsage(baseDir));
     process.exit(1);
   }
 
-  if (target === 'all') {
-    run('pnpm', ['run', 'release:package', 'core']);
-    for (const pluginTarget of pluginTargets) {
-      run('pnpm', ['run', 'release:package', pluginTarget]);
-    }
-    process.exit(0);
-  }
+  const targets = resolveReleaseTargets(requestedTarget, baseDir);
 
-  if (target === 'core') {
-    run('pnpm', ['run', 'package:vsix']);
-    process.exit(0);
-  }
-
-  run('pnpm', ['--filter', `codegraphy-${target}`, 'run', 'package:vsix']);
-  process.exit(0);
-}
-
-if (mode === 'publish') {
-  if (!publishTargets.includes(target)) {
-    printUsage();
+  if (targets.length === 0) {
+    console.error(formatUsage(baseDir));
     process.exit(1);
   }
 
-  if (target === 'all') {
-    run('pnpm', ['run', 'release:publish', 'plugin-api']);
-    run('pnpm', ['run', 'release:publish', 'core']);
-    for (const pluginTarget of pluginTargets) {
-      run('pnpm', ['run', 'release:publish', pluginTarget]);
-    }
-    process.exit(0);
+  for (const target of targets) {
+    requireSuccess(runReleaseTarget(mode, target, baseDir, runCommand));
   }
-
-  if (target === 'plugin-api') {
-    run('pnpm', ['--filter', '@codegraphy-vscode/plugin-api', 'publish', '--access', 'public', '--no-git-checks']);
-    process.exit(0);
-  }
-
-  if (target === 'core') {
-    run('pnpm', ['run', 'publish:vsce']);
-    process.exit(0);
-  }
-
-  run('pnpm', ['--filter', `codegraphy-${target}`, 'run', 'publish:vsce']);
-  process.exit(0);
 }
 
-printUsage();
-process.exit(1);
+const [, , mode, target] = process.argv;
+
+if (mode || target) {
+  if (!mode || !target) {
+    console.error(formatUsage());
+    process.exit(1);
+  }
+
+  runRelease(mode, target);
+}

--- a/tests/release/releaseScript.test.mjs
+++ b/tests/release/releaseScript.test.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  collectReleaseTargets,
+  resolveReleaseTargets,
+  runRelease,
+} from '../../scripts/release.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+test('release targets include every public workspace package', () => {
+  const targets = collectReleaseTargets(repoRoot);
+  const packageNames = targets
+    .filter((target) => target.packageName)
+    .map((target) => target.packageName);
+
+  assert.deepEqual(packageNames, [
+    '@codegraphy-vscode/plugin-api',
+    '@codegraphy-vscode/mcp',
+    'codegraphy-csharp',
+    'codegraphy-godot',
+    'codegraphy-python',
+    'codegraphy-typescript',
+  ]);
+});
+
+test('all publish includes npm packages before marketplace packages', () => {
+  const calls = [];
+
+  runRelease('publish', 'all', repoRoot, (command, args, options = {}) => {
+    calls.push({ command, args, options });
+
+    if (command === 'npm' && args[0] === 'view') {
+      return { status: 1 };
+    }
+
+    return { status: 0 };
+  });
+
+  const releaseCalls = calls.filter((call) => call.command === 'pnpm');
+  const releaseArgs = releaseCalls.map((call) => call.args);
+
+  const pluginApiIndex = releaseArgs.findIndex((args) =>
+    args.includes('@codegraphy-vscode/plugin-api'),
+  );
+  const mcpIndex = releaseArgs.findIndex((args) =>
+    args.includes('@codegraphy-vscode/mcp'),
+  );
+  const coreIndex = releaseArgs.findIndex((args) =>
+    args.join(' ') === 'run publish:vsce',
+  );
+  const typescriptIndex = releaseArgs.findIndex((args) =>
+    args.includes('codegraphy-typescript'),
+  );
+
+  assert.ok(pluginApiIndex >= 0, 'expected plugin API npm publish');
+  assert.ok(mcpIndex >= 0, 'expected MCP npm publish');
+  assert.ok(coreIndex >= 0, 'expected core marketplace publish');
+  assert.ok(typescriptIndex >= 0, 'expected TypeScript marketplace publish');
+  assert.ok(pluginApiIndex < mcpIndex, 'expected plugin API to publish before MCP');
+  assert.ok(mcpIndex < coreIndex, 'expected npm packages before core marketplace publish');
+  assert.ok(coreIndex < typescriptIndex, 'expected core before plugin marketplace publishes');
+});
+
+test('npm package release creates a tarball artifact', () => {
+  const calls = [];
+
+  runRelease('package', 'mcp', repoRoot, (command, args, options = {}) => {
+    calls.push({ command, args, options });
+    return { status: 0 };
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: 'pnpm',
+      args: [
+        '--filter',
+        '@codegraphy-vscode/mcp',
+        'pack',
+        '--pack-destination',
+        path.join(repoRoot, 'artifacts', 'npm'),
+      ],
+      options: { cwd: repoRoot },
+    },
+  ]);
+});
+
+test('npm publish skips package versions already on npm', () => {
+  const calls = [];
+
+  runRelease('publish', 'plugin-api', repoRoot, (command, args, options = {}) => {
+    calls.push({ command, args, options });
+    return { status: 0 };
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: 'npm',
+      args: ['view', '@codegraphy-vscode/plugin-api@1.2.0', 'version', '--json'],
+      options: { cwd: repoRoot, stdio: 'pipe' },
+    },
+  ]);
+});
+
+test('target groups can release only npm packages', () => {
+  const targets = resolveReleaseTargets('npm', repoRoot);
+
+  assert.deepEqual(
+    targets.map((target) => target.packageName),
+    ['@codegraphy-vscode/plugin-api', '@codegraphy-vscode/mcp'],
+  );
+});


### PR DESCRIPTION
## Summary
- discover release targets from publishable workspace package metadata instead of maintaining hard-coded target lists
- include npm packages such as @codegraphy-vscode/mcp in package/publish flows, with npm tarball artifacts and duplicate-version skips
- update Release workflow/docs and add release-script coverage

## Verification
- pnpm run test:release
- pnpm exec eslint scripts/release.mjs tests/release/releaseScript.test.mjs tests/release/coreRelease.test.mjs tests/release/changesets.test.mjs
- pnpm --filter @codegraphy-vscode/mcp run build
- pnpm run release:package mcp
- pnpm run release:package npm
- tar -xOf artifacts/npm/codegraphy-vscode-mcp-1.0.0.tgz package/package.json | jq {name,version,dependencies,bin}
- pre-commit hook: pnpm run typecheck