### PR TITLE
Build MCP bundle before npm release

### DIFF
--- a/packages/codegraphy-mcp/CHANGELOG.md
+++ b/packages/codegraphy-mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @codegraphy-vscode/mcp
 
+## 1.0.1
+
+### Patch Changes
+
+- Rebuild the CLI bundle before publishing the MCP package so global installs include the `codegraphy` executable.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/codegraphy-mcp/package.json
+++ b/packages/codegraphy-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codegraphy-vscode/mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CodeGraphy MCP CLI and local query server",
   "license": "MIT",
   "type": "module",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -138,6 +138,7 @@ function toWorkspaceReleaseTarget(workspacePackage) {
     kind: hasVsceRelease ? 'vsce' : 'npm',
     packageName: manifest.name,
     version: manifest.version,
+    hasBuildScript: Boolean(manifest.scripts?.build),
     access: manifest.publishConfig?.access ?? 'public',
   };
 }
@@ -216,17 +217,25 @@ function runCoreRelease(mode, baseDir, runCommand) {
 }
 
 function runNpmRelease(mode, target, baseDir, runCommand) {
+  if (mode === 'publish' && npmVersionExists(target, baseDir, runCommand)) {
+    console.log(`${target.packageName}@${target.version} already exists on npm; skipping.`);
+    return { status: 0 };
+  }
+
+  const buildResult = target.hasBuildScript
+    ? runCommand('pnpm', ['--filter', target.packageName, 'run', 'build'], { cwd: baseDir })
+    : { status: 0 };
+
+  if (buildResult.status !== 0) {
+    return buildResult;
+  }
+
   if (mode === 'package') {
     const artifactDir = path.join(baseDir, 'artifacts', 'npm');
     mkdirSync(artifactDir, { recursive: true });
     return runCommand('pnpm', ['--filter', target.packageName, 'pack', '--pack-destination', artifactDir], {
       cwd: baseDir,
     });
-  }
-
-  if (npmVersionExists(target, baseDir, runCommand)) {
-    console.log(`${target.packageName}@${target.version} already exists on npm; skipping.`);
-    return { status: 0 };
   }
 
   return runCommand(

--- a/tests/release/releaseScript.test.mjs
+++ b/tests/release/releaseScript.test.mjs
@@ -76,12 +76,56 @@ test('npm package release creates a tarball artifact', () => {
   assert.deepEqual(calls, [
     {
       command: 'pnpm',
+      args: ['--filter', '@codegraphy-vscode/mcp', 'run', 'build'],
+      options: { cwd: repoRoot },
+    },
+    {
+      command: 'pnpm',
       args: [
         '--filter',
         '@codegraphy-vscode/mcp',
         'pack',
         '--pack-destination',
         path.join(repoRoot, 'artifacts', 'npm'),
+      ],
+      options: { cwd: repoRoot },
+    },
+  ]);
+});
+
+test('npm package publish builds before publishing', () => {
+  const calls = [];
+
+  runRelease('publish', 'mcp', repoRoot, (command, args, options = {}) => {
+    calls.push({ command, args, options });
+
+    if (command === 'npm' && args[0] === 'view') {
+      return { status: 1 };
+    }
+
+    return { status: 0 };
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: 'npm',
+      args: ['view', '@codegraphy-vscode/mcp@1.0.1', 'version', '--json'],
+      options: { cwd: repoRoot, stdio: 'pipe' },
+    },
+    {
+      command: 'pnpm',
+      args: ['--filter', '@codegraphy-vscode/mcp', 'run', 'build'],
+      options: { cwd: repoRoot },
+    },
+    {
+      command: 'pnpm',
+      args: [
+        '--filter',
+        '@codegraphy-vscode/mcp',
+        'publish',
+        '--access',
+        'public',
+        '--no-git-checks',
       ],
       options: { cwd: repoRoot },
     },


### PR DESCRIPTION
## Summary
- build npm release targets before pack/publish so CLI bundles are included
- add release-script regression coverage for MCP pack/publish build order
- bump @codegraphy-vscode/mcp to 1.0.1 because 1.0.0 was published without dist/main.js

## Verification
- pnpm run test:release
- pnpm exec eslint scripts/release.mjs tests/release/releaseScript.test.mjs
- pnpm run release:package mcp
- tar -tf artifacts/npm/codegraphy-vscode-mcp-1.0.1.tgz
- pre-commit hook: pnpm run typecheck