### PR TITLE
Improve CLI index feedback

### DIFF
--- a/.changeset/calm-cli-index.md
+++ b/.changeset/calm-cli-index.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy/extension": patch
+"@codegraphy-vscode/mcp": patch
+---
+
+Ignore Turbo cache churn during graph refresh and show CLI indexing wait feedback.

--- a/packages/codegraphy-mcp/src/coreExtension/bridge.ts
+++ b/packages/codegraphy-mcp/src/coreExtension/bridge.ts
@@ -38,6 +38,8 @@ interface CommandResult {
   error?: Error;
 }
 
+const DEFAULT_RESPONSE_TIMEOUT_MS = 5 * 60 * 1000;
+
 export interface CoreExtensionBridgeDependencies {
   createRequestId(): string;
   createTempDir(): Promise<string>;
@@ -65,7 +67,9 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function waitForResponseFile(filePath: string): Promise<string> {
-  while (true) {
+  const deadline = Date.now() + DEFAULT_RESPONSE_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
     try {
       return await fs.readFile(filePath, 'utf8');
     } catch (error) {
@@ -82,6 +86,10 @@ async function waitForResponseFile(filePath: string): Promise<string> {
       throw error;
     }
   }
+
+  throw new Error(
+    `Timed out after ${Math.round(DEFAULT_RESPONSE_TIMEOUT_MS / 1000)}s waiting for ${filePath}`,
+  );
 }
 
 const DEFAULT_DEPENDENCIES: CoreExtensionBridgeDependencies = {
@@ -127,6 +135,10 @@ function formatCommandFailure(command: string, args: string[], result: CommandRe
   return `\`${[command, ...args].join(' ')}\` failed: ${detail}`;
 }
 
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export async function sendCoreExtensionRequest(
   input: CoreExtensionBridgeInput,
   dependencies: CoreExtensionBridgeDependencies = DEFAULT_DEPENDENCIES,
@@ -160,5 +172,14 @@ export async function sendCoreExtensionRequest(
     };
   }
 
-  return JSON.parse(await dependencies.waitForResponseFile(responsePath)) as CoreExtensionBridgeResponse;
+  try {
+    return JSON.parse(await dependencies.waitForResponseFile(responsePath)) as CoreExtensionBridgeResponse;
+  } catch (error) {
+    return {
+      requestId,
+      repo,
+      status: 'failed',
+      error: `CodeGraphy Core Extension did not write a response: ${formatErrorMessage(error)}`,
+    };
+  }
 }

--- a/packages/codegraphy-mcp/src/index/command.ts
+++ b/packages/codegraphy-mcp/src/index/command.ts
@@ -1,13 +1,30 @@
 import { readRepoRegistry } from '../repoRegistry/file';
 import type { CommandExecutionResult } from '../run/command';
 import { requestCodeGraphyIndexRepo } from '../coreExtension/indexing';
+import type { IndexRepoInput, IndexRepoResult, ToolErrorResult } from '../coreExtension/model';
+
+interface IndexCommandDependencies {
+  readRepoRegistry(): ReturnType<typeof readRepoRegistry>;
+  requestIndexRepo(input: IndexRepoInput): Promise<IndexRepoResult | ToolErrorResult>;
+  writeStatus(message: string): void;
+}
+
+const DEFAULT_DEPENDENCIES: IndexCommandDependencies = {
+  readRepoRegistry,
+  requestIndexRepo: requestCodeGraphyIndexRepo,
+  writeStatus: (message) => {
+    process.stderr.write(`${message}\n`);
+  },
+};
 
 function renderCommandResult(result: Record<string, unknown>): string {
   return JSON.stringify(result, null, 2);
 }
 
-export async function runIndexCommand(): Promise<CommandExecutionResult> {
-  const activeRepo = readRepoRegistry().activeRepo;
+export async function runIndexCommand(
+  dependencies: IndexCommandDependencies = DEFAULT_DEPENDENCIES,
+): Promise<CommandExecutionResult> {
+  const activeRepo = dependencies.readRepoRegistry().activeRepo;
   if (!activeRepo) {
     return {
       exitCode: 1,
@@ -15,7 +32,10 @@ export async function runIndexCommand(): Promise<CommandExecutionResult> {
     };
   }
 
-  const result = await requestCodeGraphyIndexRepo({ repo: activeRepo });
+  dependencies.writeStatus(
+    `CodeGraphy indexing started for ${activeRepo}. Waiting for the Core Extension response...`,
+  );
+  const result = await dependencies.requestIndexRepo({ repo: activeRepo });
 
   return {
     exitCode: 'error' in result ? 1 : 0,

--- a/packages/codegraphy-mcp/tests/coreExtension/bridge.test.ts
+++ b/packages/codegraphy-mcp/tests/coreExtension/bridge.test.ts
@@ -75,4 +75,30 @@ describe('coreExtension/bridge', () => {
       error: '`open vscode://codegraphy.codegraphy/index?request=%2Ftmp%2Fcodegraphy-request-2%2Frequest.json` failed: open failed',
     });
   });
+
+  it('returns a failed response when the Core Extension response cannot be read', async () => {
+    const result = await sendCoreExtensionRequest(
+      {
+        action: 'index',
+        repo: '/workspace/project',
+      },
+      {
+        createRequestId: () => 'request-3',
+        createTempDir: async () => '/tmp/codegraphy-request-3',
+        platform: 'darwin',
+        runCommand: () => ({ status: 0 }),
+        waitForResponseFile: async () => {
+          throw new Error('Timed out waiting for response');
+        },
+        writeFile: async () => undefined,
+      },
+    );
+
+    expect(result).toEqual({
+      requestId: 'request-3',
+      repo: '/workspace/project',
+      status: 'failed',
+      error: 'CodeGraphy Core Extension did not write a response: Timed out waiting for response',
+    });
+  });
 });

--- a/packages/codegraphy-mcp/tests/index/command.test.ts
+++ b/packages/codegraphy-mcp/tests/index/command.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runIndexCommand } from '../../src/index/command';
+
+describe('index/command', () => {
+  it('prints wait feedback before awaiting the Core Extension index response', async () => {
+    let finishIndex: (() => void) | undefined;
+    const writeStatus = vi.fn();
+    const indexing = runIndexCommand({
+      readRepoRegistry: () => ({
+        activeRepo: '/workspace/project',
+        repos: [],
+      }),
+      requestIndexRepo: async () => {
+        await new Promise<void>(resolve => {
+          finishIndex = resolve;
+        });
+
+        return {
+          repo: '/workspace/project',
+          graphCache: '.codegraphy/graph.lbug',
+          message: 'CodeGraphy indexing completed. Query tools can now read the Graph Cache.',
+        };
+      },
+      writeStatus,
+    });
+
+    await Promise.resolve();
+
+    expect(writeStatus).toHaveBeenCalledWith(
+      'CodeGraphy indexing started for /workspace/project. Waiting for the Core Extension response...',
+    );
+
+    finishIndex?.();
+    await expect(indexing).resolves.toMatchObject({ exitCode: 0 });
+  });
+});

--- a/packages/extension/src/core/discovery/pathMatching.ts
+++ b/packages/extension/src/core/discovery/pathMatching.ts
@@ -12,6 +12,7 @@ export const DEFAULT_EXCLUDE = [
   '**/out/**',
   '**/.git/**',
   '**/.codegraphy/**',
+  '**/.turbo/**',
   '**/coverage/**',
   '**/*.min.js',
   '**/*.bundle.js',

--- a/packages/extension/src/extension/config/defaults.ts
+++ b/packages/extension/src/extension/config/defaults.ts
@@ -15,6 +15,7 @@ export const DEFAULT_EXCLUDE_PATTERNS: readonly string[] = [
   '**/out/**',
   '**/.git/**',
   '**/.codegraphy/**',
+  '**/.turbo/**',
   '**/coverage/**',
   '**/*.min.js',
   '**/*.bundle.js',

--- a/packages/extension/tests/core/discovery/pathMatching.test.ts
+++ b/packages/extension/tests/core/discovery/pathMatching.test.ts
@@ -15,6 +15,7 @@ describe('pathMatching', () => {
       '**/out/**',
       '**/.git/**',
       '**/.codegraphy/**',
+      '**/.turbo/**',
       '**/coverage/**',
       '**/*.min.js',
       '**/*.bundle.js',

--- a/packages/extension/tests/extension/config/configuration.test.ts
+++ b/packages/extension/tests/extension/config/configuration.test.ts
@@ -185,6 +185,10 @@ describe('Configuration', () => {
       expect(DEFAULT_EXCLUDE_PATTERNS).toContain('**/.git/**');
     });
 
+    it('should include turbo cache artifacts', () => {
+      expect(DEFAULT_EXCLUDE_PATTERNS).toContain('**/.turbo/**');
+    });
+
     it('should include minified files', () => {
       expect(DEFAULT_EXCLUDE_PATTERNS).toContain('**/*.min.js');
     });

--- a/packages/extension/tests/extension/graphView/timeline/indexing/repository.test.ts
+++ b/packages/extension/tests/extension/graphView/timeline/indexing/repository.test.ts
@@ -4,6 +4,7 @@ import {
   type GraphViewTimelineIndexHandlers,
   type GraphViewTimelineIndexState,
 } from '../../../../../src/extension/graphView/timeline/indexing/repository';
+import { DEFAULT_EXCLUDE_PATTERNS } from '../../../../../src/extension/config/defaults';
 
 afterEach(() => {
   vi.doUnmock('../../../../../src/extension/graphView/timeline/indexing/setup');
@@ -149,16 +150,7 @@ describe('graph view timeline repository', () => {
 
     expect(handlers.verifyGitRepository).toHaveBeenCalledWith('/test/workspace');
     expect(handlers.createGitAnalyzer).toHaveBeenCalledWith('/test/workspace', [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/build/**',
-      '**/out/**',
-      '**/.git/**',
-      '**/.codegraphy/**',
-      '**/coverage/**',
-      '**/*.min.js',
-      '**/*.bundle.js',
-      '**/*.map',
+      ...DEFAULT_EXCLUDE_PATTERNS,
     ]);
     expect(handlers.sendMessage).toHaveBeenCalledWith({
       type: 'TIMELINE_DATA',

--- a/packages/extension/tests/extension/graphView/timeline/indexing/setup.test.ts
+++ b/packages/extension/tests/extension/graphView/timeline/indexing/setup.test.ts
@@ -4,6 +4,7 @@ import {
   type GraphViewTimelineIndexSetupHandlers,
   type GraphViewTimelineIndexSetupState,
 } from '../../../../../src/extension/graphView/timeline/indexing/setup';
+import { DEFAULT_EXCLUDE_PATTERNS } from '../../../../../src/extension/config/defaults';
 
 function createState(
   overrides: Partial<GraphViewTimelineIndexSetupState> = {},
@@ -82,16 +83,7 @@ describe('graph view timeline setup', () => {
     expect(state.analyzerInitialized).toBe(true);
     expect(state.gitAnalyzer).toBe(gitAnalyzer);
     expect(handlers.createGitAnalyzer).toHaveBeenCalledWith('/workspace', [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/build/**',
-      '**/out/**',
-      '**/.git/**',
-      '**/.codegraphy/**',
-      '**/coverage/**',
-      '**/*.min.js',
-      '**/*.bundle.js',
-      '**/*.map',
+      ...DEFAULT_EXCLUDE_PATTERNS,
       '**/*.generated.ts',
       'src/generated/**',
     ]);
@@ -117,16 +109,7 @@ describe('graph view timeline setup', () => {
 
     expect(ready).toBe(true);
     expect(handlers.createGitAnalyzer).toHaveBeenCalledWith('/workspace', [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/build/**',
-      '**/out/**',
-      '**/.git/**',
-      '**/.codegraphy/**',
-      '**/coverage/**',
-      '**/*.min.js',
-      '**/*.bundle.js',
-      '**/*.map',
+      ...DEFAULT_EXCLUDE_PATTERNS,
     ]);
   });
 

--- a/packages/extension/tests/extension/workspaceFiles/ignore.test.ts
+++ b/packages/extension/tests/extension/workspaceFiles/ignore.test.ts
@@ -30,6 +30,7 @@ describe('extension/workspaceFiles/ignore', () => {
     '/workspace/build/app.js',
     '/workspace/out/app.js',
     '/workspace/.git/config',
+    '/workspace/.turbo/cache/abc-meta.json',
     '/workspace/coverage/report.json',
     '/workspace/assets/app.min.js',
     '/workspace/assets/app.bundle.js',


### PR DESCRIPTION
## Summary
- ignore Turbo cache churn in default discovery and workspace refresh filters
- print immediate wait feedback for `codegraphy index`
- return a structured bridge failure when the Core Extension never writes a response

## Tests
- `pnpm --filter @codegraphy-vscode/mcp test`
- `pnpm --filter @codegraphy/extension exec vitest run --config vitest.config.ts tests/core/discovery/pathMatching.test.ts tests/extension/workspaceFiles/ignore.test.ts tests/extension/config/configuration.test.ts`
- `pnpm --filter @codegraphy-vscode/mcp lint`
- `pnpm --filter @codegraphy/extension exec eslint src/core/discovery/pathMatching.ts src/extension/config/defaults.ts tests/core/discovery/pathMatching.test.ts tests/extension/workspaceFiles/ignore.test.ts tests/extension/config/configuration.test.ts`
- `pnpm --filter @codegraphy-vscode/mcp typecheck`
- `pnpm --filter @codegraphy/extension typecheck`
- `pnpm --filter @codegraphy-vscode/mcp build`
- pre-commit hook: `pnpm run typecheck` + lint-staged
