### PR TITLE
Add New Folder for folder node context menus

### DIFF
--- a/.changeset/fuzzy-folders-begin.md
+++ b/.changeset/fuzzy-folders-begin.md
@@ -2,4 +2,4 @@
 "@codegraphy/extension": minor
 ---
 
-Add New Folder to folder node context menus and show newly created empty folders in the graph.
+Add New Folder to folder node and graph background context menus, show newly created empty folders in the graph, and refresh the graph after folders are deleted from the VS Code Explorer.

--- a/.changeset/fuzzy-folders-begin.md
+++ b/.changeset/fuzzy-folders-begin.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy/extension": minor
+---
+
+Add New Folder to folder node context menus and show newly created empty folders in the graph.

--- a/.changeset/graph-context-menu-folder-edge-actions.md
+++ b/.changeset/graph-context-menu-folder-edge-actions.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy/extension": patch
+---
+
+Add folder rename/delete actions, edge endpoint open actions, and clearer filter versus legend labels to the Graph Context Menu.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,7 @@ A node representing a concrete file in the workspace or selected graph revision.
 _Avoid_: Folder node, package node
 
 **Folder Node**:
-A structural node representing a directory in the workspace.
+A structural node representing a directory in the workspace, including an empty directory when folder nodes are active.
 _Avoid_: File node
 
 **Plugin Node**:
@@ -149,8 +149,12 @@ To mark a node as the current graph selection for actions, context menus, and fo
 _Avoid_: Open, preview
 
 **Context Selection**:
-The node or nodes targeted by a context menu action.
+The node or nodes targeted by a Graph Context Menu action.
 _Avoid_: Focused Node when right-click target differs from focus
+
+**Graph Context Menu**:
+The right-click menu opened from a **Context Selection** in the **Graph View**. The menu exposes actions that are valid for the selected graph target.
+_Avoid_: Context Window unless referring to a persistent panel or window
 
 **Preview File**:
 To open a file node in VS Code's temporary preview editor state.
@@ -363,6 +367,12 @@ _Avoid_: Graph export
 - Double-clicking a file node should select, focus, and **Open File** as a persistent tab.
 - Single-clicking a non-file node should select and focus it without opening a file.
 - Right-clicking an unselected node should select that node for **Context Selection** but should not preview or open it.
+- A **Graph Context Menu** is opened from the current **Context Selection** and should present actions that match that selection's target type.
+- Graph Context Menu action availability can be decided by an explicit menu decision model; that model owns which actions appear, not right-click selection mechanics.
+- A single **Folder Node** **Graph Context Menu** can offer child creation actions such as `New File...` and `New Folder...`; those actions target the selected folder.
+- A **File Node** **Graph Context Menu** stays file-focused and should not offer child creation actions by default.
+- Creating an empty directory from a **Folder Node** action should make that directory visible as a **Folder Node** after refresh or reindex.
+- Undoing a folder created from a **Folder Node** action should move the folder to trash only when it is still empty.
 - **Depth Mode** should use one **Focused Node**; if multi-selection conflicts with depth behavior, choose one selected node as the focus.
 - **Collapse** follows edge direction outward from the collapsed node and absorbs downstream relationship nodes.
 - Incoming edges to a **Collapsed Node** remain visible and target the collapsed marker.
@@ -411,6 +421,7 @@ _Avoid_: Graph export
 - **Timeline Snapshots** still flow through the same **Graph Scope**, **Filter**, **Search**, and view setting stages as the current workspace **Relationship Graph**.
 - A **Timeline Snapshot** uses a commit as its **Graph Revision** and should show the files and relationships from that commit only.
 - The default **Graph Revision** is the current `HEAD` plus working tree state, updated by **Live Updates**.
+- Graph Context Menu mutation actions should stay available for the default **Graph Revision** and should be disabled for historical **Timeline Snapshots**.
 - The **Core Extension** is the out-of-box Relationship Graph product and should work for most users without optional plugins.
 - The **Core Extension** uses Tree-sitter coverage, the bundled **Markdown Plugin**, and Material icon styling to provide a useful default graph.
 - A **Plugin** can add **Nodes**, **Node Types**, **Relationships**, **Edge Types**, preset filters, theming, exports, or UI.

--- a/docs/plans/2026-05-04-issue-128-context-window-folder-create.md
+++ b/docs/plans/2026-05-04-issue-128-context-window-folder-create.md
@@ -185,3 +185,27 @@ This slice is intentionally narrow until the product questions below are answere
    - Keep Folder Nodes structural and connected through `nests` relationships.
 
 5. Verify with targeted tests first, then broader extension checks.
+
+## Follow-Up Context Menu Candidates
+
+These are intentionally parked as product follow-ups, not part of the first folder-create slice.
+
+1. Add graph-native exploration actions for File Nodes.
+   - Candidate labels: `Show Dependencies`, `Show Dependents`, `Focus Neighborhood`.
+   - Why: these match CodeGraphy's core job better than generic file operations.
+
+2. Add reset/clear actions when there is active view context.
+   - Candidate labels: `Clear Focus`, `Clear Search`, `Return to Current Graph`.
+   - Why: the graph already has focus, search, and Timeline state, but those states are easier to enter than to escape from the context menu.
+
+3. Add richer Edge actions.
+   - Candidate labels: `Open Source`, `Open Target`, `Reveal Source`, `Reveal Target`.
+   - Why: the edge menu currently only copies endpoint paths, while edges are often used as navigation affordances.
+
+4. Add folder mutation parity only after a safe action model exists.
+   - Candidate labels: `Rename Folder...`, `Delete Folder...`.
+   - Why: users expect Folder Nodes to behave like Explorer folders, but recursive delete and undo/trash semantics need their own tests before being exposed.
+
+5. Add multi-selection group actions.
+   - Candidate labels: `Add Selection to Legend Group`, `Focus Selection`.
+   - Why: multi-select already supports filters and favorites, but not graph organization workflows.

--- a/docs/plans/2026-05-04-issue-128-context-window-folder-create.md
+++ b/docs/plans/2026-05-04-issue-128-context-window-folder-create.md
@@ -1,0 +1,187 @@
+# Issue 128: Create New Folder from Folder Node Context
+
+Trello: https://trello.com/c/GOvvj15w/128-create-new-folder-when-folder-nodes-active-in-context-window
+
+## Setup
+
+- Worktree: `/Users/poleski/Desktop/Projects/CodeGraphyV4-issue-128-context-window`
+- Branch: `codex/issue-128-context-window-folder-create`
+- Base: `origin/main` at `b5da9f2c release`
+- Trello state: `Core` label, In Progress list, no card description, comments, or checklist.
+- Domain docs: `CONTEXT.md` defines `Folder Node`, `Context Selection`, `Graph Context Menu`, `Graph View`, `Graph Scope`, `Graph Cache`, and `Graph Query`.
+- Term decision: `Graph Context Menu` is the right-click menu opened from a `Context Selection`; avoid `Context Window` unless the product adds a persistent panel or window.
+- CodeGraphy MCP note: the new worktree has no Graph Cache yet, so setup research used source inspection after checking MCP repo status.
+
+## Accepted Decisions
+
+- Use `Graph Context Menu` for the user-facing right-click menu.
+- Use `Context Selection` for the underlying graph target or targets that opened the menu.
+- Avoid `Context Window` for this behavior because there is not a persistent panel or window.
+- When exactly one Folder Node opens the Graph Context Menu, show both `New File...` and `New Folder...`.
+- Folder Node child creation actions target the selected folder, while the background `New File...` action remains root-level creation.
+- A newly created empty folder should become visible as a Folder Node after refresh or reindex when Folder Nodes are active.
+- File Node menus should not offer child creation actions for this card.
+- Use an explicit Graph Context Menu decision model for menu action availability only; do not move right-click selection mechanics into that model.
+- Mutation actions such as `New File...` and `New Folder...` should stay enabled for the default Graph Revision, including current `HEAD` plus working tree state.
+- Mutation actions should be disabled, not hidden, when the Graph Context Menu is opened from a historical Timeline Snapshot.
+- Undo for `New Folder...` should move the created folder to trash only while the folder is still empty.
+
+## Current Behavior
+
+- The background context menu includes `New File...` in the live Graph View.
+- The node context menu does not include file or folder creation actions.
+- `createFile` context effects always send `CREATE_FILE` with `directory: "."`.
+- The webview context menu model passes raw target ids, not node type or target classification.
+- File-oriented node menu labels are built from ids alone: `Open File`, `Rename...`, and `Delete File`.
+- Package nodes are suppressed in some webview menu paths by checking the `pkg:` prefix; Folder Nodes are not classified there.
+- Extension-side primary actions defensively block opening Folder Nodes and Package nodes.
+- Folder Nodes are structural projections from file paths. Empty filesystem folders do not appear to be represented as Folder Nodes unless another path creates a file node under them.
+
+## Source Surface
+
+- Webview context menu contracts: `packages/extension/src/webview/components/graph/contextMenu/contracts.ts`
+- Context menu entry builders: `packages/extension/src/webview/components/graph/contextMenu/build/`
+- Node menu entries: `packages/extension/src/webview/components/graph/contextMenu/node/`
+- Context action effects: `packages/extension/src/webview/components/graph/contextActions/`
+- Context menu runtime: `packages/extension/src/webview/components/graph/contextMenuRuntime/`
+- Interaction bridge: `packages/extension/src/webview/components/graph/runtime/use/interaction.ts`
+- Webview protocol: `packages/extension/src/shared/protocol/webviewToExtension.ts`
+- Extension message routing: `packages/extension/src/extension/graphView/webview/nodeFile/edit.ts`
+- Graph View primary actions: `packages/extension/src/extension/graphView/webview/providerMessages/primaryActions.ts`
+- File creation action path: `packages/extension/src/extension/graphView/files/actions.ts`
+- Existing create-file primitive: `packages/extension/src/extension/actions/createFile.ts`
+- Folder node projection: `packages/extension/src/shared/graphControls/nests/folders.ts`
+- Visible graph structural projection: `packages/extension/src/shared/visibleGraph/structure.ts`
+
+## Architecture Deepening Candidates
+
+1. Deepen the context target model.
+
+   Problem: `GraphContextSelection` only carries `kind`, `targets`, and optional `edgeId`. It does not carry target node type, target role, parent directory, or action affordances.
+
+   Why it matters: Folder-specific behavior currently has to be inferred later from raw ids or guarded after the user has already seen an action. That keeps the Module shallow and makes Context Selection less useful as a product concept.
+
+   Direction to explore: make Context Selection own enough meaning to answer "what is this target?" before menu entries and effects are built.
+
+2. Make built-in context actions target-aware.
+
+   Problem: built-in actions receive raw target paths, and `createFile` ignores them by hardcoding root directory creation.
+
+   Why it matters: `New File...`, `New Folder...`, rename, delete, and plugin actions all need slightly different target resolution rules. The current Interface has low Leverage because every new action must rediscover context rules.
+
+   Direction to explore: route actions through a resolved action context rather than a list of ids.
+
+3. Move action availability into the webview context menu model.
+
+   Problem: the webview can present file-oriented labels for non-file nodes, while extension handlers later block unsafe actions.
+
+   Why it matters: defensive extension guards are still useful, but the product behavior should be decided close to the menu the user sees. That improves Locality for labels, disabled/hidden actions, and test scenarios.
+
+   Direction to explore: classify File Node, Folder Node, Package, edge, and background targets before building entries.
+
+4. Decide whether empty directories are graph concepts.
+
+   Problem: Folder Nodes are currently derived from existing file paths. A newly created empty directory may exist on disk but not appear as a Folder Node after refresh or reindex.
+
+   Why it matters: if this card means "create a visible new Folder Node", then filesystem creation alone is not enough. If it means "create a directory from a Folder Node context action", the Relationship Graph may reasonably stay file-derived.
+
+   Direction to explore: define the product contract for empty folders before selecting the implementation path.
+
+5. Introduce a Graph Context Menu decision model.
+
+   Problem: multi-selection turns into a Context Selection when right-clicking an already-selected node, but the menu builder only sees `kind: node` plus raw ids. It cannot distinguish single file, single folder, all folders, all files, mixed file/folder, package, or plugin node selections.
+
+   Why it matters: without a central decision model, each new action adds another local condition. That makes the Graph Context Menu harder to reason about and increases the chance that file-only actions appear for Folder Nodes or mixed selections.
+
+   Direction to explore: keep selection mechanics separate from menu action decisions. The selection mechanics decide which graph targets are in the Context Selection; the menu decision model classifies that Context Selection into explicit menu states and only owns which actions appear.
+
+   Candidate states:
+
+   - Background
+   - Edge
+   - Single File Node
+   - Single Folder Node
+   - Single Package Node
+   - Multi File Node
+   - Multi Folder Node
+   - Mixed Node Selection
+   - Mutable default Graph Revision
+   - Historical Timeline Snapshot where mutation actions are disabled
+
+6. Replace timeline-only menu filtering with graph-revision mutability.
+
+   Problem: the current menu model receives `timelineActive` and hides mutation actions when it is true. That is too shallow for the accepted behavior because the current/default Graph Revision should still allow mutation, while historical Timeline Snapshots should not.
+
+   Why it matters: the Graph Context Menu should not decide mutability from the view alone. It needs to know whether the Context Selection belongs to a mutable Graph Revision.
+
+   Direction to explore: pass an explicit menu mutability state into the Graph Context Menu decision model, such as mutable default revision vs historical snapshot.
+
+## Initial Behavior Slice
+
+Candidate behavior for the first implementation slice:
+
+- When exactly one Folder Node is targeted in the live Graph View context menu, show `New Folder...`.
+- Also show `New File...` for that Folder Node.
+- Prompt for a file or folder name based on the chosen action.
+- Create the file or folder under the selected Folder Node's directory.
+- A created empty folder should become visible as a Folder Node after refresh or reindex.
+- Refresh the Graph View after creation.
+- Disable mutation actions when the Graph Context Menu targets a historical Timeline Snapshot.
+- Keep mutation actions enabled when the Graph Context Menu targets the default Graph Revision.
+- Support undo for `New Folder...` by trashing only the still-empty created folder.
+- Do not show the action for File Nodes, Package nodes, edge context, multi-select, or background until those cases are explicitly chosen.
+
+This slice is intentionally narrow until the product questions below are answered.
+
+## Current Selection Mechanics
+
+- Right-clicking an unselected node replaces the current selection with that node.
+- Right-clicking an already-selected node opens the Graph Context Menu for the full current selection.
+- Right-clicking the background opens a background Context Selection.
+- Right-clicking an edge opens an edge Context Selection.
+- Today, the Context Selection records target ids but not target node types.
+- A Graph Context Menu decision model would classify those targets before entries are built.
+
+## Test Surface
+
+- Webview menu model tests for Folder Node action visibility.
+- Webview context action tests for the new create-folder effect.
+- Protocol/message routing tests for a folder creation request.
+- Extension file action tests for creating a directory, duplicate handling, invalid names, refresh, and undo behavior if undo is supported.
+- Undo tests proving a created empty folder can be trashed, and a non-empty folder is not recursively removed.
+- Folder discovery/projection tests proving empty directories can become Folder Nodes when Folder Nodes are active.
+- Regression tests proving file-oriented actions are not shown for Folder Nodes unless explicitly desired.
+
+## Grill Questions
+
+1. [x] What should the canonical product term be: `Context Menu`, `Context Selection`, or `Context Window`?
+2. [x] Should the action be `New Folder...`, `New File...`, or both when right-clicking a Folder Node?
+3. [x] Should a newly created empty folder become visible as a Folder Node immediately, or is it acceptable for Folder Nodes to remain derived from files?
+4. [x] Should File Nodes offer child creation in their parent directory, or should creation stay folder-only?
+5. [x] Should the Graph Context Menu use an explicit decision model/state machine before deciding multi-selection actions?
+6. [x] Should this behavior be hidden, disabled, or available in Timeline View?
+7. [x] Should undo delete the newly created folder, and should that use trash semantics like file deletion?
+
+## Implementation Plan
+
+1. Add failing tests for the Graph Context Menu decision model.
+   - Classify Context Selection targets by node type.
+   - Keep right-click selection mechanics unchanged.
+   - Show `New File...` and `New Folder...` only for exactly one Folder Node in a mutable Graph Revision.
+   - Disable mutation actions for historical Timeline Snapshots.
+
+2. Add target-aware context action effects.
+   - Make `New File...` use the selected Folder Node path when invoked from a Folder Node.
+   - Add a `New Folder...` built-in action and message payload that includes the parent directory.
+
+3. Add extension-side folder creation.
+   - Prompt for a folder name.
+   - Create the directory under the selected folder.
+   - Refresh graph state after creation.
+   - Support conservative undo through trash only when the created folder is still empty.
+
+4. Extend folder discovery/projection.
+   - Include empty directories as Folder Nodes when Folder Nodes are active.
+   - Keep Folder Nodes structural and connected through `nests` relationships.
+
+5. Verify with targeted tests first, then broader extension checks.

--- a/docs/plans/2026-05-04-issue-128-context-window-folder-create.md
+++ b/docs/plans/2026-05-04-issue-128-context-window-folder-create.md
@@ -25,6 +25,11 @@ Trello: https://trello.com/c/GOvvj15w/128-create-new-folder-when-folder-nodes-ac
 - Mutation actions such as `New File...` and `New Folder...` should stay enabled for the default Graph Revision, including current `HEAD` plus working tree state.
 - Mutation actions should be disabled, not hidden, when the Graph Context Menu is opened from a historical Timeline Snapshot.
 - Undo for `New Folder...` should move the created folder to trash only while the folder is still empty.
+- Folder Node menus should include Explorer parity actions: `Reveal in Explorer`, path copy actions, `Rename Folder...`, and `Delete Folder`.
+- The synthetic `(root)` Folder Node should remain protected from folder rename/delete actions.
+- Edge menus should include direct endpoint navigation actions: `Open Source` and `Open Target`.
+- `Add Filter Pattern...` / `Add Filter Patterns...` and `Add Legend Group...` should be separate menu blocks because filters and legend groups are different graph organization concepts.
+- Node right-click should synchronously update the Context Selection and highlighted node before opening the Graph Context Menu so the menu matches the node under the pointer.
 
 ## Current Behavior
 
@@ -188,7 +193,7 @@ This slice is intentionally narrow until the product questions below are answere
 
 ## Follow-Up Context Menu Candidates
 
-These are intentionally parked as product follow-ups, not part of the first folder-create slice.
+These are intentionally parked as product follow-ups, or completed additions that came out of the context-menu pass.
 
 1. Add graph-native exploration actions for File Nodes.
    - Candidate labels: `Show Dependencies`, `Show Dependents`, `Focus Neighborhood`.
@@ -200,10 +205,12 @@ These are intentionally parked as product follow-ups, not part of the first fold
 
 3. Add richer Edge actions.
    - Candidate labels: `Open Source`, `Open Target`, `Reveal Source`, `Reveal Target`.
-   - Why: the edge menu currently only copies endpoint paths, while edges are often used as navigation affordances.
+   - Status: `Open Source` and `Open Target` are included in this slice. `Reveal Source` and `Reveal Target` remain candidates.
+   - Why: edges are often used as navigation affordances, not only copy targets.
 
 4. Add folder mutation parity only after a safe action model exists.
    - Candidate labels: `Rename Folder...`, `Delete Folder...`.
+   - Status: included in this slice with recursive trash/delete support, undo backup coverage, nested favorite path updates, and `(root)` protection.
    - Why: users expect Folder Nodes to behave like Explorer folders, but recursive delete and undo/trash semantics need their own tests before being exposed.
 
 5. Add multi-selection group actions.

--- a/packages/extension/src/core/discovery/contracts.ts
+++ b/packages/extension/src/core/discovery/contracts.ts
@@ -43,6 +43,8 @@ export interface IDiscoveredFile {
 export interface IDiscoveryResult {
   /** Discovered files */
   files: IDiscoveredFile[];
+  /** Discovered directory paths relative to the workspace root */
+  directories: string[];
   /** Whether the max file limit was hit */
   limitReached: boolean;
   /** Total files found before limit (if limit was reached) */

--- a/packages/extension/src/core/discovery/file/service.ts
+++ b/packages/extension/src/core/discovery/file/service.ts
@@ -49,6 +49,7 @@ export class FileDiscovery {
     const allExclude = [...DEFAULT_EXCLUDE, ...excludePatterns];
     const gitignore = respectGitignore ? loadGitignore(rootPath) : null;
     const files: IDiscoveredFile[] = [];
+    const directories: string[] = [];
     let totalFound = 0;
     let limitReached = false;
 
@@ -77,12 +78,16 @@ export class FileDiscovery {
         totalFound++;
         return true;
       },
+      relativePath => {
+        directories.push(relativePath);
+      },
       signal,
     );
 
     const durationMs = Date.now() - startTime;
     return {
       files,
+      directories,
       limitReached,
       totalFound: limitReached ? totalFound : undefined,
       durationMs,

--- a/packages/extension/src/core/discovery/file/walk.ts
+++ b/packages/extension/src/core/discovery/file/walk.ts
@@ -16,8 +16,16 @@ export async function walkDirectory(
   rootPath: string,
   currentPath: string,
   onFile: (relativePath: string, absolutePath: string) => boolean,
-  signal?: AbortSignal,
+  onDirectoryOrSignal?: ((relativePath: string, absolutePath: string) => void) | AbortSignal,
+  nextSignal?: AbortSignal,
 ): Promise<boolean> {
+  const onDirectory = typeof onDirectoryOrSignal === 'function'
+    ? onDirectoryOrSignal
+    : undefined;
+  const signal = typeof onDirectoryOrSignal === 'function'
+    ? nextSignal
+    : onDirectoryOrSignal;
+
   throwIfAborted(signal);
 
   let entries: fs.Dirent[];
@@ -38,7 +46,8 @@ export async function walkDirectory(
       if (shouldSkipKnownDirectory(relativePath)) {
         continue;
       }
-      const shouldContinue = await walkDirectory(rootPath, absolutePath, onFile, signal);
+      onDirectory?.(relativePath, absolutePath);
+      const shouldContinue = await walkDirectory(rootPath, absolutePath, onFile, onDirectory, signal);
       if (!shouldContinue) {
         return false;
       }

--- a/packages/extension/src/extension/actions/createFolder.ts
+++ b/packages/extension/src/extension/actions/createFolder.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+import { IUndoableAction } from '../undoManager';
+
+export class CreateFolderAction implements IUndoableAction {
+  readonly description: string;
+
+  constructor(
+    private readonly _path: string,
+    private readonly _workspaceFolder: vscode.Uri,
+    private readonly _refreshGraph: () => Promise<void>,
+  ) {
+    this.description = `Create folder: ${_path.split('/').pop()}`;
+  }
+
+  async execute(): Promise<void> {
+    const folderUri = vscode.Uri.joinPath(this._workspaceFolder, this._path);
+    await vscode.workspace.fs.createDirectory(folderUri);
+    await this._refreshGraph();
+  }
+
+  async undo(): Promise<void> {
+    const folderUri = vscode.Uri.joinPath(this._workspaceFolder, this._path);
+    const entries = await vscode.workspace.fs.readDirectory(folderUri);
+    if (entries.length > 0) {
+      return;
+    }
+
+    await vscode.workspace.fs.delete(folderUri, { recursive: false, useTrash: true });
+    await this._refreshGraph();
+  }
+}

--- a/packages/extension/src/extension/actions/deleteFiles.ts
+++ b/packages/extension/src/extension/actions/deleteFiles.ts
@@ -25,6 +25,8 @@ export class DeleteFilesAction implements IUndoableAction {
 
   /** Stored file contents for restoration */
   private _storedFiles: StoredFile[] = [];
+  /** Stored folder paths for restoration */
+  private _storedDirectories: string[] = [];
   /** Full favorites state BEFORE this action was executed */
   private _favoritesBefore: string[] = [];
   /** Full favorites state AFTER this action was executed */
@@ -50,22 +52,30 @@ export class DeleteFilesAction implements IUndoableAction {
   async execute(): Promise<void> {
     // Store file contents before deletion
     this._storedFiles = [];
+    this._storedDirectories = [];
 
     // Store favorites state before deletion
     const config = getCodeGraphyConfiguration();
     this._favoritesBefore = [...config.get<string[]>('favorites', [])];
     
     // Calculate new favorites (remove deleted files)
-    const deletedPaths = new Set(this._paths);
-    this._favoritesAfter = this._favoritesBefore.filter(fav => !deletedPaths.has(fav));
+    this._favoritesAfter = this._favoritesBefore.filter(fav =>
+      !this._paths.some(deletedPath => isPathWithinDeletedPath(fav, deletedPath))
+    );
 
     for (const filePath of this._paths) {
       const fileUri = vscode.Uri.joinPath(this._workspaceFolder, filePath);
       try {
-        const content = await vscode.workspace.fs.readFile(fileUri);
-        this._storedFiles.push({ path: filePath, content });
-        // Delete to trash for extra safety
-        await vscode.workspace.fs.delete(fileUri, { useTrash: true });
+        const stat = await vscode.workspace.fs.stat(fileUri);
+        if (isDirectoryStat(stat)) {
+          await this._storeDirectory(filePath, fileUri);
+          await vscode.workspace.fs.delete(fileUri, { recursive: true, useTrash: true });
+        } else {
+          const content = await vscode.workspace.fs.readFile(fileUri);
+          this._storedFiles.push({ path: filePath, content });
+          // Delete to trash for extra safety
+          await vscode.workspace.fs.delete(fileUri, { useTrash: true });
+        }
       } catch (error) {
         console.error(`[CodeGraphy] Failed to delete ${filePath}:`, error);
         // Continue with other files
@@ -79,6 +89,17 @@ export class DeleteFilesAction implements IUndoableAction {
   }
 
   async undo(): Promise<void> {
+    // Restore directories first so nested files have parents.
+    for (const directoryPath of [...this._storedDirectories].sort(comparePathDepth)) {
+      const directoryUri = vscode.Uri.joinPath(this._workspaceFolder, directoryPath);
+      try {
+        await vscode.workspace.fs.createDirectory(directoryUri);
+      } catch (error) {
+        console.error(`[CodeGraphy] Failed to restore ${directoryPath}:`, error);
+        vscode.window.showErrorMessage(`Failed to restore ${directoryPath}`);
+      }
+    }
+
     // Restore all stored files
     for (const storedFile of this._storedFiles) {
       const fileUri = vscode.Uri.joinPath(this._workspaceFolder, storedFile.path);
@@ -96,4 +117,34 @@ export class DeleteFilesAction implements IUndoableAction {
 
     await this._refreshGraph();
   }
+
+  private async _storeDirectory(directoryPath: string, directoryUri: vscode.Uri): Promise<void> {
+    this._storedDirectories.push(directoryPath);
+
+    const entries = await vscode.workspace.fs.readDirectory(directoryUri);
+    for (const [entryName, entryType] of entries) {
+      const entryPath = `${directoryPath}/${entryName}`;
+      const entryUri = vscode.Uri.joinPath(directoryUri, entryName);
+
+      if ((entryType & vscode.FileType.Directory) !== 0) {
+        await this._storeDirectory(entryPath, entryUri);
+        continue;
+      }
+
+      const content = await vscode.workspace.fs.readFile(entryUri);
+      this._storedFiles.push({ path: entryPath, content });
+    }
+  }
+}
+
+function isDirectoryStat(stat: vscode.FileStat): boolean {
+  return (stat.type & vscode.FileType.Directory) !== 0;
+}
+
+function isPathWithinDeletedPath(path: string, deletedPath: string): boolean {
+  return path === deletedPath || path.startsWith(`${deletedPath}/`);
+}
+
+function comparePathDepth(left: string, right: string): number {
+  return left.split('/').length - right.split('/').length;
 }

--- a/packages/extension/src/extension/actions/renameFile.ts
+++ b/packages/extension/src/extension/actions/renameFile.ts
@@ -53,7 +53,7 @@ export class RenameFileAction implements IUndoableAction {
       
       // Calculate new favorites state (update path if file was favorited)
       this._favoritesAfter = currentFavorites.map(fav =>
-        fav === this._oldPath ? this._newPath : fav
+        renameFavoritePath(fav, this._oldPath, this._newPath)
       );
       this._hasExecuted = true;
     }
@@ -62,7 +62,9 @@ export class RenameFileAction implements IUndoableAction {
     await vscode.workspace.fs.rename(oldUri, newUri);
 
     // Only update favorites if the file was in favorites (state actually changed)
-    const favoritesChanged = this._favoritesBefore.includes(this._oldPath);
+    const favoritesChanged = this._favoritesBefore.some(fav =>
+      isPathWithinRenamedPath(fav, this._oldPath)
+    );
     if (favoritesChanged) {
       await config.update('favorites', this._favoritesAfter);
     }
@@ -78,7 +80,9 @@ export class RenameFileAction implements IUndoableAction {
     await vscode.workspace.fs.rename(newUri, oldUri);
 
     // Only restore favorites if the file was originally in favorites
-    const favoritesChanged = this._favoritesBefore.includes(this._oldPath);
+    const favoritesChanged = this._favoritesBefore.some(fav =>
+      isPathWithinRenamedPath(fav, this._oldPath)
+    );
     if (favoritesChanged) {
       const config = getCodeGraphyConfiguration();
       await config.update('favorites', this._favoritesBefore);
@@ -86,4 +90,20 @@ export class RenameFileAction implements IUndoableAction {
 
     await this._refreshGraph();
   }
+}
+
+function renameFavoritePath(favoritePath: string, oldPath: string, newPath: string): string {
+  if (favoritePath === oldPath) {
+    return newPath;
+  }
+
+  if (favoritePath.startsWith(`${oldPath}/`)) {
+    return `${newPath}${favoritePath.slice(oldPath.length)}`;
+  }
+
+  return favoritePath;
+}
+
+function isPathWithinRenamedPath(path: string, oldPath: string): boolean {
+  return path === oldPath || path.startsWith(`${oldPath}/`);
 }

--- a/packages/extension/src/extension/graphView/files/actions.ts
+++ b/packages/extension/src/extension/graphView/files/actions.ts
@@ -21,6 +21,13 @@ export interface GraphViewFileCreateHandlers {
   showErrorMessage(message: string): void;
 }
 
+export interface GraphViewFolderCreateHandlers {
+  workspaceFolder?: GraphViewWorkspaceFolderRef;
+  showInputBox(options: vscode.InputBoxOptions): PromiseLike<string | undefined>;
+  executeCreateFolderAction(folderPath: string, workspaceFolderUri: vscode.Uri): PromiseLike<void>;
+  showErrorMessage(message: string): void;
+}
+
 export interface GraphViewExcludeHandlers {
   executeAddToExcludeAction(patterns: string[]): PromiseLike<void>;
 }
@@ -62,6 +69,28 @@ export async function createGraphViewFile(
     await handlers.executeCreateAction(filePath, handlers.workspaceFolder.uri);
   } catch (error) {
     handlers.showErrorMessage(`Failed to create file: ${toErrorMessage(error)}`);
+  }
+}
+
+export async function createGraphViewFolder(
+  directory: string,
+  handlers: GraphViewFolderCreateHandlers,
+): Promise<void> {
+  if (!handlers.workspaceFolder) return;
+
+  const folderName = await handlers.showInputBox({
+    prompt: 'Enter folder name',
+    placeHolder: 'new-folder',
+    ignoreFocusOut: true,
+  });
+  if (!folderName) return;
+
+  const folderPath = directory === '.' ? folderName : `${directory}/${folderName}`;
+
+  try {
+    await handlers.executeCreateFolderAction(folderPath, handlers.workspaceFolder.uri);
+  } catch (error) {
+    handlers.showErrorMessage(`Failed to create folder: ${toErrorMessage(error)}`);
   }
 }
 

--- a/packages/extension/src/extension/graphView/provider/file/actions.ts
+++ b/packages/extension/src/extension/graphView/provider/file/actions.ts
@@ -2,10 +2,11 @@ import * as vscode from 'vscode';
 import { getUndoManager } from '../../../undoManager';
 import type { IUndoableAction } from '../../../undoManager';
 import { CreateFileAction } from '../../../actions/createFile';
+import { CreateFolderAction } from '../../../actions/createFolder';
 import { DeleteFilesAction } from '../../../actions/deleteFiles';
 import { RenameFileAction } from '../../../actions/renameFile';
 import { ToggleFavoriteAction } from '../../../actions/toggleFavorite';
-import { createGraphViewFile, deleteGraphViewFiles } from '../../files/actions';
+import { createGraphViewFile, createGraphViewFolder, deleteGraphViewFiles } from '../../files/actions';
 import { renameGraphViewFile } from '../../files/rename';
 import { toggleGraphViewFavorites } from '../../favorites';
 import {
@@ -32,6 +33,7 @@ export interface GraphViewProviderFileActionMethods {
   _deleteFiles(paths: string[]): Promise<void>;
   _renameFile(filePath: string): Promise<void>;
   _createFile(directory: string): Promise<void>;
+  _createFolder(directory: string): Promise<void>;
   _toggleFavorites(paths: string[]): Promise<void>;
 }
 
@@ -42,6 +44,7 @@ export interface GraphViewProviderFileActionMethodDependencies {
   deleteFiles: typeof deleteGraphViewFiles;
   renameFile: typeof renameGraphViewFile;
   createFile: typeof createGraphViewFile;
+  createFolder: typeof createGraphViewFolder;
   toggleFavorites: typeof toggleGraphViewFavorites;
   getWorkspaceFolder(): vscode.WorkspaceFolder | undefined;
   showWarningMessage(
@@ -67,6 +70,11 @@ export interface GraphViewProviderFileActionMethodDependencies {
     workspaceFolderUri: vscode.Uri,
     analyzeAndSendData: () => Promise<void>,
   ): IUndoableAction;
+  createCreateFolderAction(
+    folderPath: string,
+    workspaceFolderUri: vscode.Uri,
+    analyzeAndSendData: () => Promise<void>,
+  ): IUndoableAction;
   createToggleFavoriteAction(paths: string[], sendFavorites: () => void): IUndoableAction;
   executeUndoAction(action: IUndoableAction): Promise<void>;
 }
@@ -78,6 +86,7 @@ const DEFAULT_DEPENDENCIES: GraphViewProviderFileActionMethodDependencies = {
   deleteFiles: deleteGraphViewFiles,
   renameFile: renameGraphViewFile,
   createFile: createGraphViewFile,
+  createFolder: createGraphViewFolder,
   toggleFavorites: toggleGraphViewFavorites,
   getWorkspaceFolder: () => vscode.workspace.workspaceFolders?.[0],
   showWarningMessage: (message, options, deleteAction) =>
@@ -94,6 +103,8 @@ const DEFAULT_DEPENDENCIES: GraphViewProviderFileActionMethodDependencies = {
     new RenameFileAction(oldPath, newPath, workspaceFolderUri, analyzeAndSendData),
   createCreateAction: (filePath, workspaceFolderUri, analyzeAndSendData) =>
     new CreateFileAction(filePath, workspaceFolderUri, analyzeAndSendData),
+  createCreateFolderAction: (folderPath, workspaceFolderUri, analyzeAndSendData) =>
+    new CreateFolderAction(folderPath, workspaceFolderUri, analyzeAndSendData),
   createToggleFavoriteAction: (paths, sendFavorites) =>
     new ToggleFavoriteAction(paths, sendFavorites),
   executeUndoAction: action => getUndoManager().execute(action),
@@ -178,6 +189,24 @@ export function createGraphViewProviderFileActionMethods(
     });
   };
 
+  const _createFolder = async (directory: string): Promise<void> => {
+    await dependencies.createFolder(directory, {
+      workspaceFolder: dependencies.getWorkspaceFolder(),
+      showInputBox: options => dependencies.showInputBox(options),
+      executeCreateFolderAction: async (folderPath, workspaceFolderUri) => {
+        const action = dependencies.createCreateFolderAction(
+          folderPath,
+          workspaceFolderUri,
+          () => source._analyzeAndSendData(),
+        );
+        await dependencies.executeUndoAction(action);
+      },
+      showErrorMessage: message => {
+        dependencies.showErrorMessage(message);
+      },
+    });
+  };
+
   const _toggleFavorites = async (paths: string[]): Promise<void> => {
     await dependencies.toggleFavorites(paths, {
       executeToggleFavoritesAction: async nextPaths => {
@@ -196,6 +225,7 @@ export function createGraphViewProviderFileActionMethods(
     _deleteFiles,
     _renameFile,
     _createFile,
+    _createFolder,
     _toggleFavorites,
   };
 }

--- a/packages/extension/src/extension/graphView/provider/source/delegates/fileTimeline.ts
+++ b/packages/extension/src/extension/graphView/provider/source/delegates/fileTimeline.ts
@@ -16,6 +16,7 @@ export function createGraphViewProviderFileTimelineMethodDelegates(
   | '_deleteFiles'
   | '_renameFile'
   | '_createFile'
+  | '_createFolder'
   | '_toggleFavorites'
   | '_setFocusedFile'
   | '_getFocusedFile'
@@ -40,6 +41,7 @@ export function createGraphViewProviderFileTimelineMethodDelegates(
     _deleteFiles: paths => owner._methodContainers.fileAction._deleteFiles(paths),
     _renameFile: filePath => owner._methodContainers.fileAction._renameFile(filePath),
     _createFile: directory => owner._methodContainers.fileAction._createFile(directory),
+    _createFolder: directory => owner._methodContainers.fileAction._createFolder(directory),
     _toggleFavorites: paths => owner._methodContainers.fileAction._toggleFavorites(paths),
     _setFocusedFile: filePath => owner._methodContainers.viewSelection.setFocusedFile(filePath),
     _getFocusedFile: () => owner._viewContext.focusedFile,

--- a/packages/extension/src/extension/graphView/webview/dispatch/primary.ts
+++ b/packages/extension/src/extension/graphView/webview/dispatch/primary.ts
@@ -14,6 +14,7 @@ import { dispatchGraphViewPrimaryStateMessage } from './stateful';
 export interface GraphViewPrimaryMessageContext {
   getTimelineActive(): boolean;
   getCurrentCommitSha(): string | undefined;
+  getCanMutateGraphRevision(): boolean;
   getUserGroups(): IGroup[];
   getDisabledPlugins(): Set<string>;
   getFilterPatterns(): string[];
@@ -37,6 +38,7 @@ export interface GraphViewPrimaryMessageContext {
   deleteFiles(paths: string[]): Promise<void>;
   renameFile(filePath: string): Promise<void>;
   createFile(directory: string): Promise<void>;
+  createFolder(directory: string): Promise<void>;
   toggleFavorites(paths: string[]): Promise<void>;
   addToExclude(patterns: string[]): Promise<void>;
   indexAndSendData(): Promise<void>;

--- a/packages/extension/src/extension/graphView/webview/dispatch/primaryState.ts
+++ b/packages/extension/src/extension/graphView/webview/dispatch/primaryState.ts
@@ -19,6 +19,7 @@ export function createGraphViewPrimaryNodeFileHandlers(
     indexGraph: () => context.indexAndSendData(),
     refreshGraph: () => context.refreshIndex(),
     timelineActive: context.getTimelineActive(),
+    canMutateGraphRevision: context.getCanMutateGraphRevision(),
     currentCommitSha: context.getCurrentCommitSha(),
   };
 }

--- a/packages/extension/src/extension/graphView/webview/nodeFile/edit.ts
+++ b/packages/extension/src/extension/graphView/webview/nodeFile/edit.ts
@@ -2,9 +2,11 @@ import type { WebviewToExtensionMessage } from '../../../../shared/protocol/webv
 
 export interface GraphViewNodeFileEditHandlers {
   timelineActive: boolean;
+  canMutateGraphRevision: boolean;
   deleteFiles(paths: string[]): Promise<void>;
   renameFile(filePath: string): Promise<void>;
   createFile(directory: string): Promise<void>;
+  createFolder(directory: string): Promise<void>;
   toggleFavorites(paths: string[]): Promise<void>;
   addToExclude(patterns: string[]): Promise<void>;
 }
@@ -14,6 +16,7 @@ function isTimelineBoundEditMessage(message: WebviewToExtensionMessage): boolean
     message.type === 'DELETE_FILES'
     || message.type === 'RENAME_FILE'
     || message.type === 'CREATE_FILE'
+    || message.type === 'CREATE_FOLDER'
     || message.type === 'ADD_TO_EXCLUDE'
   );
 }
@@ -22,7 +25,7 @@ function applyTimelineBoundEditMessage(
   message: WebviewToExtensionMessage,
   handlers: GraphViewNodeFileEditHandlers,
 ): boolean {
-  if (handlers.timelineActive) {
+  if (!handlers.canMutateGraphRevision) {
     return isTimelineBoundEditMessage(message);
   }
 
@@ -35,6 +38,9 @@ function applyTimelineBoundEditMessage(
       return true;
     case 'CREATE_FILE':
       void handlers.createFile(message.payload.directory);
+      return true;
+    case 'CREATE_FOLDER':
+      void handlers.createFolder(message.payload.directory);
       return true;
     case 'ADD_TO_EXCLUDE':
       void handlers.addToExclude(message.payload.patterns);

--- a/packages/extension/src/extension/graphView/webview/providerMessages/listener.ts
+++ b/packages/extension/src/extension/graphView/webview/providerMessages/listener.ts
@@ -66,6 +66,9 @@ export interface GraphViewProviderMessageListenerDependencies {
 export interface GraphViewProviderMessageListenerSource {
   _timelineActive: boolean;
   _currentCommitSha: string | undefined;
+  _gitAnalyzer?: {
+    getCachedCommitList(): Array<{ sha: string }> | null | undefined;
+  };
   _userGroups: IGroup[];
   _disabledPlugins: Set<string>;
   _filterPatterns: string[];
@@ -113,6 +116,7 @@ export interface GraphViewProviderMessageListenerSource {
   _deleteFiles(paths: string[]): Promise<void>;
   _renameFile(filePath: string): Promise<void>;
   _createFile(directory: string): Promise<void>;
+  _createFolder(directory: string): Promise<void>;
   _toggleFavorites(paths: string[]): Promise<void>;
   _addToExclude(patterns: string[]): Promise<void>;
   _loadAndSendData(): Promise<void>;

--- a/packages/extension/src/extension/graphView/webview/providerMessages/primaryActions.ts
+++ b/packages/extension/src/extension/graphView/webview/providerMessages/primaryActions.ts
@@ -24,6 +24,7 @@ type GraphViewProviderPrimaryActions = Pick<
   | 'deleteFiles'
   | 'renameFile'
   | 'createFile'
+  | 'createFolder'
   | 'toggleFavorites'
   | 'addToExclude'
   | 'loadAndSendData'
@@ -77,6 +78,7 @@ export function createGraphViewProviderMessagePrimaryActions(
     deleteFiles: paths => source._deleteFiles(paths),
     renameFile: filePath => source._renameFile(filePath),
     createFile: directory => source._createFile(directory),
+    createFolder: directory => source._createFolder(directory),
     toggleFavorites: paths => source._toggleFavorites(paths),
     addToExclude: patterns => source._addToExclude(patterns),
     loadAndSendData: () => source._loadAndSendData(),

--- a/packages/extension/src/extension/graphView/webview/providerMessages/primaryActions.ts
+++ b/packages/extension/src/extension/graphView/webview/providerMessages/primaryActions.ts
@@ -77,8 +77,8 @@ export function createGraphViewProviderMessagePrimaryActions(
     copyToClipboard: text => source._copyToClipboard(text),
     deleteFiles: paths => source._deleteFiles(paths),
     renameFile: filePath => source._renameFile(filePath),
-    createFile: directory => source._createFile(directory),
-    createFolder: directory => source._createFolder(directory),
+    createFile: directory => source._createFile(normalizeGraphMutationDirectory(directory)),
+    createFolder: directory => source._createFolder(normalizeGraphMutationDirectory(directory)),
     toggleFavorites: paths => source._toggleFavorites(paths),
     addToExclude: patterns => source._addToExclude(patterns),
     loadAndSendData: () => source._loadAndSendData(),
@@ -133,6 +133,10 @@ export function createGraphViewProviderMessagePrimaryActions(
     applyViewTransform: () => source._applyViewTransform(),
     smartRebuild: id => source._smartRebuild(id),
   };
+}
+
+function normalizeGraphMutationDirectory(directory: string): string {
+  return directory === '(root)' ? '.' : directory;
 }
 
 function canOpenGraphPath(

--- a/packages/extension/src/extension/graphView/webview/providerMessages/readContext.ts
+++ b/packages/extension/src/extension/graphView/webview/providerMessages/readContext.ts
@@ -8,6 +8,7 @@ type GraphViewProviderReadContext = Pick<
   GraphViewMessageListenerContext,
   | 'getTimelineActive'
   | 'getCurrentCommitSha'
+  | 'getCanMutateGraphRevision'
   | 'getUserGroups'
   | 'getDepthMode'
   | 'getDisabledPlugins'
@@ -30,6 +31,14 @@ export function createGraphViewProviderMessageReadContext(
   return {
     getTimelineActive: () => source._timelineActive,
     getCurrentCommitSha: () => source._currentCommitSha,
+    getCanMutateGraphRevision: () => {
+      if (!source._timelineActive) {
+        return true;
+      }
+
+      const currentHeadSha = source._gitAnalyzer?.getCachedCommitList()?.at(-1)?.sha;
+      return !!currentHeadSha && source._currentCommitSha === currentHeadSha;
+    },
     getUserGroups: () => source._userGroups,
     getDepthMode: () => source._depthMode,
     getDisabledPlugins: () => source._disabledPlugins,

--- a/packages/extension/src/extension/pipeline/analysis/analyze.ts
+++ b/packages/extension/src/extension/pipeline/analysis/analyze.ts
@@ -31,6 +31,7 @@ export interface WorkspacePipelineAnalysisSource {
     disabledPlugins: Set<string>,
   ): IGraphData;
   _eventBus?: EventBus;
+  _lastDiscoveredDirectories: string[];
   _lastDiscoveredFiles: IDiscoveredFile[];
   _lastFileAnalysis: Map<string, IFileAnalysisResult>;
   _lastFileConnections: Map<string, IProjectedConnection[]>;
@@ -126,6 +127,7 @@ export async function analyzeWorkspaceWithAnalyzer(
 
   source._lastFileAnalysis = analysisResult.fileAnalysis;
   source._lastFileConnections = analysisResult.fileConnections;
+  source._lastDiscoveredDirectories = discoveryResult.directories ?? [];
   source._lastDiscoveredFiles = discoveryResult.files;
   source._lastWorkspaceRoot = workspaceRoot;
 

--- a/packages/extension/src/extension/pipeline/analysis/run.ts
+++ b/packages/extension/src/extension/pipeline/analysis/run.ts
@@ -24,10 +24,11 @@ export function runWorkspacePipelineAnalysis(
     source,
     {
       discover: async options => {
-        const result = await discovery.discover(options);
-        return {
-          durationMs: result.durationMs,
-          files: result.files,
+      const result = await discovery.discover(options);
+      return {
+        directories: result.directories,
+        durationMs: result.durationMs,
+        files: result.files,
           limitReached: result.limitReached,
           totalFound: result.totalFound ?? result.files.length,
         };

--- a/packages/extension/src/extension/pipeline/analysis/state.ts
+++ b/packages/extension/src/extension/pipeline/analysis/state.ts
@@ -39,6 +39,7 @@ export interface WorkspacePipelineRebuildSource {
   ): IGraphData;
   _lastFileAnalysis: Map<string, IFileAnalysisResult>;
   _lastFileConnections: Map<string, IProjectedConnection[]>;
+  _lastDiscoveredDirectories: string[];
   _lastWorkspaceRoot: string;
 }
 

--- a/packages/extension/src/extension/pipeline/analysisSource.ts
+++ b/packages/extension/src/extension/pipeline/analysisSource.ts
@@ -39,6 +39,7 @@ export interface WorkspacePipelineSourceOwner {
     nextSignal?: AbortSignal,
   ): Promise<void>;
   _eventBus?: EventBus;
+  _lastDiscoveredDirectories: string[];
   _lastDiscoveredFiles: IDiscoveredFile[];
   _lastFileAnalysis: Map<string, IFileAnalysisResult>;
   _lastFileConnections: Map<string, IProjectedConnection[]>;
@@ -107,6 +108,12 @@ export function createWorkspacePipelineAnalysisSource(
         owner._lastDiscoveredFiles = files;
       },
     },
+    _lastDiscoveredDirectories: {
+      get: () => owner._lastDiscoveredDirectories,
+      set: (directories: string[]) => {
+        owner._lastDiscoveredDirectories = directories;
+      },
+    },
     _lastFileConnections: {
       get: () => owner._lastFileConnections,
       set: (fileConnections: Map<string, IProjectedConnection[]>) => {
@@ -173,6 +180,9 @@ export function createWorkspacePipelineRebuildSource(
     },
     _lastWorkspaceRoot: {
       get: () => owner._lastWorkspaceRoot,
+    },
+    _lastDiscoveredDirectories: {
+      get: () => owner._lastDiscoveredDirectories,
     },
   });
 

--- a/packages/extension/src/extension/pipeline/discovery.ts
+++ b/packages/extension/src/extension/pipeline/discovery.ts
@@ -7,6 +7,7 @@ export interface WorkspacePipelineDiscoveryConfig {
 }
 
 export interface WorkspacePipelineDiscoveryResult<TFile> {
+  directories?: string[];
   durationMs: number;
   files: TFile[];
   limitReached: boolean;

--- a/packages/extension/src/extension/pipeline/graph/build.ts
+++ b/packages/extension/src/extension/pipeline/graph/build.ts
@@ -18,10 +18,12 @@ export interface WorkspacePipelineGraphSource {
   _registry: {
     getPluginForFile(absolutePath: string): IPlugin | undefined;
   };
+  _lastDiscoveredDirectories?: readonly string[];
 }
 
 export interface WorkspacePipelineGraphDependencies {
   cacheFiles: Record<string, { size?: number }>;
+  directoryPaths?: readonly string[];
   disabledPlugins: ReadonlySet<string>;
   fileConnections: ReadonlyMap<string, IProjectedConnection[]>;
   getPluginForFile: (absolutePath: string) => IPlugin | undefined;
@@ -38,6 +40,7 @@ export function buildWorkspacePipelineGraph(
 
   return buildWorkspaceGraphData({
     cacheFiles: dependencies.cacheFiles,
+    directoryPaths: dependencies.directoryPaths ?? [],
     disabledPlugins: dependencies.disabledPlugins,
     fileConnections: dependencies.fileConnections,
     showOrphans: dependencies.showOrphans,
@@ -56,6 +59,7 @@ export function buildWorkspacePipelineGraphForSource(
 ): IGraphData {
   return buildWorkspacePipelineGraph({
     cacheFiles: source._cache.files,
+    directoryPaths: source._lastDiscoveredDirectories ?? [],
     disabledPlugins,
     fileConnections,
     getPluginForFile: absolutePath => source._registry.getPluginForFile(absolutePath),

--- a/packages/extension/src/extension/pipeline/graph/data.ts
+++ b/packages/extension/src/extension/pipeline/graph/data.ts
@@ -10,6 +10,7 @@ import { buildWorkspaceGraphNodes } from './nodes';
 
 export interface IWorkspaceGraphDataOptions {
   cacheFiles: Record<string, { size?: number }>;
+  directoryPaths?: readonly string[];
   disabledPlugins: ReadonlySet<string>;
   fileConnections: ReadonlyMap<string, IProjectedConnection[]>;
   showOrphans: boolean;
@@ -21,6 +22,7 @@ export interface IWorkspaceGraphDataOptions {
 export function buildWorkspaceGraphData(options: IWorkspaceGraphDataOptions): IGraphData {
   const {
     cacheFiles,
+    directoryPaths = [],
     disabledPlugins,
     fileConnections,
     showOrphans,
@@ -38,6 +40,7 @@ export function buildWorkspaceGraphData(options: IWorkspaceGraphDataOptions): IG
   const nodes = buildWorkspaceGraphNodes({
     cacheFiles,
     connectedIds,
+    directoryPaths,
     nodeIds,
     showOrphans,
     visitCounts,

--- a/packages/extension/src/extension/pipeline/graph/nodes.ts
+++ b/packages/extension/src/extension/pipeline/graph/nodes.ts
@@ -4,9 +4,12 @@
  */
 
 import * as path from 'path';
-import { DEFAULT_NODE_COLOR } from '../../../shared/fileColors';
+import {
+  DEFAULT_FOLDER_NODE_COLOR,
+  DEFAULT_NODE_COLOR,
+  DEFAULT_PACKAGE_NODE_COLOR,
+} from '../../../shared/fileColors';
 import type { IGraphNode } from '../../../shared/graph/contracts';
-import { DEFAULT_PACKAGE_NODE_COLOR } from '../../../shared/fileColors';
 import {
   getExternalPackageLabelFromNodeId,
   isExternalPackageNodeId,
@@ -15,9 +18,57 @@ import {
 export interface IWorkspaceGraphNodesOptions {
   cacheFiles: Record<string, { size?: number }>;
   connectedIds: ReadonlySet<string>;
+  directoryPaths?: readonly string[];
   nodeIds: ReadonlySet<string>;
   showOrphans: boolean;
   visitCounts: Record<string, number>;
+}
+
+function normalizeDirectoryPath(directoryPath: string): string {
+  return directoryPath.replace(/\\/g, '/');
+}
+
+function collectFolderPathsFromFileNodes(nodeIds: ReadonlySet<string>): Set<string> {
+  const folderPaths = new Set<string>();
+
+  for (const nodeId of nodeIds) {
+    if (isExternalPackageNodeId(nodeId)) {
+      continue;
+    }
+
+    const segments = nodeId.split('/');
+    for (let index = 1; index < segments.length; index += 1) {
+      folderPaths.add(segments.slice(0, index).join('/'));
+    }
+  }
+
+  return folderPaths;
+}
+
+function buildDiscoveredDirectoryNodes(
+  directoryPaths: readonly string[],
+  nodeIds: ReadonlySet<string>,
+): IGraphNode[] {
+  const fileFolderPaths = collectFolderPathsFromFileNodes(nodeIds);
+  const seen = new Set<string>();
+  const nodes: IGraphNode[] = [];
+
+  for (const directoryPath of directoryPaths) {
+    const normalizedPath = normalizeDirectoryPath(directoryPath);
+    if (!normalizedPath || fileFolderPaths.has(normalizedPath) || seen.has(normalizedPath)) {
+      continue;
+    }
+
+    seen.add(normalizedPath);
+    nodes.push({
+      id: normalizedPath,
+      label: normalizedPath.split('/').pop() ?? normalizedPath,
+      color: DEFAULT_FOLDER_NODE_COLOR,
+      nodeType: 'folder',
+    });
+  }
+
+  return nodes;
 }
 
 export function buildWorkspaceGraphNodes(
@@ -26,6 +77,7 @@ export function buildWorkspaceGraphNodes(
   const {
     cacheFiles,
     connectedIds,
+    directoryPaths = [],
     nodeIds,
     showOrphans,
     visitCounts,
@@ -60,5 +112,8 @@ export function buildWorkspaceGraphNodes(
     });
   }
 
-  return nodes;
+  return [
+    ...nodes,
+    ...buildDiscoveredDirectoryNodes(directoryPaths, nodeIds),
+  ];
 }

--- a/packages/extension/src/extension/pipeline/service/base/internal.ts
+++ b/packages/extension/src/extension/pipeline/service/base/internal.ts
@@ -81,6 +81,7 @@ export abstract class WorkspacePipelineInternalBase extends WorkspacePipelineSta
       workspaceRoot,
       showOrphans,
       disabledPlugins,
+      this._lastDiscoveredDirectories,
     );
   }
 
@@ -98,6 +99,7 @@ export abstract class WorkspacePipelineInternalBase extends WorkspacePipelineSta
       workspaceRoot,
       showOrphans,
       disabledPlugins,
+      this._lastDiscoveredDirectories,
     );
   }
 

--- a/packages/extension/src/extension/pipeline/service/base/state.ts
+++ b/packages/extension/src/extension/pipeline/service/base/state.ts
@@ -23,6 +23,7 @@ export abstract class WorkspacePipelineStateBase {
   protected _cache: IWorkspaceAnalysisCache;
   protected _lastFileAnalysis: Map<string, IFileAnalysisResult> = new Map();
   protected _lastFileConnections: Map<string, IProjectedConnection[]> = new Map();
+  protected _lastDiscoveredDirectories: string[] = [];
   protected _lastDiscoveredFiles: IDiscoveredFile[] = [];
   protected _lastWorkspaceRoot = '';
   protected _eventBus?: EventBus;

--- a/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
@@ -114,6 +114,7 @@ export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipeline
       discoveryResult.files.map(file => [file.relativePath, []]),
     );
 
+    this._lastDiscoveredDirectories = discoveryResult.directories ?? [];
     this._lastDiscoveredFiles = discoveryResult.files;
     this._lastFileAnalysis = new Map();
     this._lastFileConnections = fileConnections;

--- a/packages/extension/src/extension/pipeline/service/lifecycleFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/lifecycleFacade.ts
@@ -46,6 +46,13 @@ export class WorkspacePipelineLifecycleFacade extends WorkspacePipelineRefreshFa
       return [];
     }
 
+    this._lastDiscoveredDirectories = removeInvalidatedDiscoveredDirectories(
+      this._lastDiscoveredDirectories,
+      filePaths,
+      workspaceRoot,
+      (root, filePath) => this._toWorkspaceRelativePath(root, filePath),
+    );
+
     const invalidated = invalidateWorkspacePipelineFiles(
       {
         cache: this._cache,
@@ -92,3 +99,35 @@ export class WorkspacePipelineLifecycleFacade extends WorkspacePipelineRefreshFa
 }
 
 export { WorkspacePipelineLifecycleFacade as WorkspacePipeline };
+
+function normalizeWorkspaceRelativePath(filePath: string): string {
+  return filePath.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+}
+
+function isDirectoryAtOrBelowPath(directoryPath: string, targetPath: string): boolean {
+  return directoryPath === targetPath || directoryPath.startsWith(`${targetPath}/`);
+}
+
+function removeInvalidatedDiscoveredDirectories(
+  directories: readonly string[],
+  filePaths: readonly string[],
+  workspaceRoot: string,
+  toWorkspaceRelativePath: (workspaceRoot: string, filePath: string) => string | undefined,
+): string[] {
+  const invalidatedPaths = filePaths
+    .map(filePath => toWorkspaceRelativePath(workspaceRoot, filePath))
+    .filter((filePath): filePath is string => Boolean(filePath))
+    .map(normalizeWorkspaceRelativePath)
+    .filter(Boolean);
+
+  if (invalidatedPaths.length === 0) {
+    return [...directories];
+  }
+
+  return directories.filter((directoryPath) => {
+    const normalizedDirectory = normalizeWorkspaceRelativePath(directoryPath);
+    return !invalidatedPaths.some(invalidatedPath =>
+      isDirectoryAtOrBelowPath(normalizedDirectory, invalidatedPath),
+    );
+  });
+}

--- a/packages/extension/src/extension/pipeline/service/refreshFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/refreshFacade.ts
@@ -36,6 +36,7 @@ export abstract class WorkspacePipelineRefreshFacade extends WorkspacePipelineDi
         vscode.window.showWarningMessage(message);
       },
     );
+    this._lastDiscoveredDirectories = discoveryResult.directories ?? [];
 
     return refreshWorkspacePipelineChangedFiles(((current) => ({
       _analyzeFiles: (files, root, progress, abortSignal) =>

--- a/packages/extension/src/extension/pipeline/service/runtime/discovery.ts
+++ b/packages/extension/src/extension/pipeline/service/runtime/discovery.ts
@@ -15,6 +15,7 @@ export function createWorkspacePipelineDiscoveryDependencies(
     discover: async options => {
       const result = await discovery.discover(options);
       return {
+        directories: result.directories,
         durationMs: result.durationMs,
         files: result.files,
         limitReached: result.limitReached,

--- a/packages/extension/src/extension/pipeline/service/runtime/graph.ts
+++ b/packages/extension/src/extension/pipeline/service/runtime/graph.ts
@@ -14,6 +14,7 @@ export function buildWorkspacePipelineGraph(
   workspaceRoot: string,
   showOrphans: boolean,
   disabledPlugins: Set<string>,
+  directoryPaths: readonly string[] = [],
 ): IGraphData {
   return buildWorkspacePipelineGraphData(
     cache,
@@ -23,6 +24,7 @@ export function buildWorkspacePipelineGraph(
     workspaceRoot,
     showOrphans,
     disabledPlugins,
+    directoryPaths,
   );
 }
 
@@ -34,6 +36,7 @@ export function buildWorkspacePipelineGraphFromAnalysis(
   workspaceRoot: string,
   showOrphans: boolean,
   disabledPlugins: Set<string>,
+  directoryPaths: readonly string[] = [],
 ): IGraphData {
   return buildWorkspacePipelineGraph(
     cache,
@@ -43,5 +46,6 @@ export function buildWorkspacePipelineGraphFromAnalysis(
     workspaceRoot,
     showOrphans,
     disabledPlugins,
+    directoryPaths,
   );
 }

--- a/packages/extension/src/extension/pipeline/serviceAdapters.ts
+++ b/packages/extension/src/extension/pipeline/serviceAdapters.ts
@@ -79,10 +79,12 @@ export function buildWorkspacePipelineGraphData(
   workspaceRoot: string,
   showOrphans: boolean,
   disabledPlugins: Set<string> = new Set(),
+  directoryPaths: readonly string[] = [],
 ): IGraphData {
   const source: WorkspacePipelineGraphSource = {
     _cache: cache,
     _context: context,
+    _lastDiscoveredDirectories: directoryPaths,
     _registry: registry,
   };
 

--- a/packages/extension/src/extension/workspaceFiles/refresh/watchers.ts
+++ b/packages/extension/src/extension/workspaceFiles/refresh/watchers.ts
@@ -6,6 +6,39 @@ import {
 } from '../ignore';
 import { scheduleWorkspaceRefresh } from './scheduler';
 
+function refreshWorkspacePaths(
+  provider: GraphViewProvider,
+  logMessage: string,
+  filePaths: readonly string[],
+): string[] {
+  const refreshPaths = filePaths.filter(filePath =>
+    !shouldIgnoreWorkspaceFileWatcherRefresh(filePath),
+  );
+
+  if (refreshPaths.length > 0) {
+    scheduleWorkspaceRefresh(provider, logMessage, refreshPaths);
+  }
+
+  return refreshPaths;
+}
+
+function refreshWorkspaceFileOperation(
+  provider: GraphViewProvider,
+  logMessage: string,
+  files: readonly vscode.Uri[],
+  eventName: 'workspace:fileCreated' | 'workspace:fileDeleted',
+): void {
+  const refreshPaths = refreshWorkspacePaths(
+    provider,
+    logMessage,
+    files.map(uri => uri.fsPath),
+  );
+
+  for (const filePath of refreshPaths) {
+    provider.emitEvent(eventName, { filePath });
+  }
+}
+
 export function registerSaveHandler(
   context: vscode.ExtensionContext,
   provider: GraphViewProvider,
@@ -32,28 +65,62 @@ export function registerFileWatcher(
   const fileWatcher = vscode.workspace.createFileSystemWatcher('**/*');
   context.subscriptions.push(
     fileWatcher.onDidCreate((uri) => {
-      if (shouldIgnoreWorkspaceFileWatcherRefresh(uri.fsPath)) {
-        return;
-      }
-      scheduleWorkspaceRefresh(
+      refreshWorkspaceFileOperation(
         provider,
         '[CodeGraphy] File created, refreshing graph',
-        [uri.fsPath],
+        [uri],
+        'workspace:fileCreated',
       );
-      provider.emitEvent('workspace:fileCreated', { filePath: uri.fsPath });
     }),
   );
   context.subscriptions.push(
     fileWatcher.onDidDelete((uri) => {
-      if (shouldIgnoreWorkspaceFileWatcherRefresh(uri.fsPath)) {
-        return;
-      }
-      scheduleWorkspaceRefresh(
+      refreshWorkspaceFileOperation(
         provider,
         '[CodeGraphy] File deleted, refreshing graph',
-        [uri.fsPath],
+        [uri],
+        'workspace:fileDeleted',
       );
-      provider.emitEvent('workspace:fileDeleted', { filePath: uri.fsPath });
+    }),
+  );
+  context.subscriptions.push(
+    vscode.workspace.onDidCreateFiles((event) => {
+      refreshWorkspaceFileOperation(
+        provider,
+        '[CodeGraphy] File created, refreshing graph',
+        event.files,
+        'workspace:fileCreated',
+      );
+    }),
+  );
+  context.subscriptions.push(
+    vscode.workspace.onDidDeleteFiles((event) => {
+      refreshWorkspaceFileOperation(
+        provider,
+        '[CodeGraphy] File deleted, refreshing graph',
+        event.files,
+        'workspace:fileDeleted',
+      );
+    }),
+  );
+  context.subscriptions.push(
+    vscode.workspace.onDidRenameFiles((event) => {
+      const refreshPaths = refreshWorkspacePaths(
+        provider,
+        '[CodeGraphy] File renamed, refreshing graph',
+        event.files.flatMap(file => [file.oldUri.fsPath, file.newUri.fsPath]),
+      );
+
+      if (refreshPaths.length === 0) {
+        return;
+      }
+
+      for (const file of event.files) {
+        provider.emitEvent('workspace:fileRenamed', {
+          oldPath: file.oldUri.fsPath,
+          newPath: file.newUri.fsPath,
+        });
+      }
     }),
   );
   context.subscriptions.push(fileWatcher);

--- a/packages/extension/src/shared/graphControls/nests/folders.ts
+++ b/packages/extension/src/shared/graphControls/nests/folders.ts
@@ -20,6 +20,26 @@ export function collectFolderPaths(
   return { paths: folderPaths, hasRootFiles };
 }
 
+function addFolderPathWithAncestors(folderPaths: Set<string>, folderPath: string): void {
+  const segments = folderPath.split('/');
+  for (let index = 1; index <= segments.length; index += 1) {
+    folderPaths.add(segments.slice(0, index).join('/'));
+  }
+}
+
+export function collectStructuralFolderPaths(
+  fileNodes: IGraphData['nodes'],
+  folderNodes: IGraphData['nodes'],
+): { paths: Set<string>; hasRootFiles: boolean } {
+  const result = collectFolderPaths(fileNodes);
+
+  for (const folderNode of folderNodes) {
+    addFolderPathWithAncestors(result.paths, folderNode.id);
+  }
+
+  return result;
+}
+
 export function createFolderNodes(
   folderPaths: Set<string>,
   folderNodeColor: string,

--- a/packages/extension/src/shared/protocol/webviewToExtension.ts
+++ b/packages/extension/src/shared/protocol/webviewToExtension.ts
@@ -24,6 +24,7 @@ export type WebviewToExtensionMessage =
   | { type: 'DELETE_FILES'; payload: { paths: string[] } }
   | { type: 'RENAME_FILE'; payload: { path: string } }
   | { type: 'CREATE_FILE'; payload: { directory: string } }
+  | { type: 'CREATE_FOLDER'; payload: { directory: string } }
   | { type: 'TOGGLE_FAVORITE'; payload: { paths: string[] } }
   | { type: 'ADD_TO_EXCLUDE'; payload: { patterns: string[] } }
   | { type: 'REFRESH_GRAPH' }

--- a/packages/extension/src/shared/visibleGraph/structure.ts
+++ b/packages/extension/src/shared/visibleGraph/structure.ts
@@ -1,5 +1,5 @@
 import type { IGraphData, IGraphEdge, IGraphNode } from '../graph/contracts';
-import { collectFolderPaths, createFolderNodes } from '../graphControls/nests/folders';
+import { collectStructuralFolderPaths, createFolderNodes } from '../graphControls/nests/folders';
 import { createWorkspacePackageNodes } from '../graphControls/packages/nodes';
 import {
   collectWorkspacePackageRoots,
@@ -15,6 +15,10 @@ import {
   PACKAGE_NODE_TYPE,
   STRUCTURAL_NESTS_EDGE_KIND,
 } from './model';
+
+function isFolderNode(node: IGraphNode): boolean {
+  return node.nodeType === FOLDER_NODE_TYPE;
+}
 
 function createStructuralEdge(from: string, to: string): IGraphEdge {
   return {
@@ -91,10 +95,17 @@ export function applyStructuralProjection(
   const hasNestsScope = enabledEdgeTypes.has(STRUCTURAL_NESTS_EDGE_KIND) || disabledEdgeTypes.has(STRUCTURAL_NESTS_EDGE_KIND);
   const nestsEnabled = hasNestsScope ? enabledEdgeTypes.has(STRUCTURAL_NESTS_EDGE_KIND) : true;
   const sourceFileNodes = sourceGraphData.nodes.filter(isFileNode);
+  const sourceFolderNodes = sourceGraphData.nodes.filter(isFolderNode);
   const visibleFileNodes = graphData.nodes.filter(isFileNode);
-  const folderPaths = folderEnabled ? collectFolderPaths(sourceFileNodes).paths : new Set<string>();
+  const visibleFolderNodeIds = new Set(graphData.nodes.filter(isFolderNode).map((node) => node.id));
+  const folderPaths = folderEnabled
+    ? collectStructuralFolderPaths(sourceFileNodes, sourceFolderNodes).paths
+    : new Set<string>();
+  const generatedFolderPaths = new Set(
+    Array.from(folderPaths).filter((folderPath) => !visibleFolderNodeIds.has(folderPath)),
+  );
   const folderNodes = folderEnabled
-    ? createFolderNodes(folderPaths, '')
+    ? createFolderNodes(generatedFolderPaths, '')
     : [];
   const workspacePackageRoots = packageEnabled
     ? collectWorkspacePackageRoots(sourceFileNodes)

--- a/packages/extension/src/webview/components/graph/contextActions/builtin/effects.ts
+++ b/packages/extension/src/webview/components/graph/contextActions/builtin/effects.ts
@@ -19,6 +19,10 @@ import {
 
 const BUILT_IN_CONTEXT_ACTION_EFFECTS = {
   open: (targetPaths: string[]) => createOpenFileEffects(targetPaths),
+  openEdgeSource: (targetPaths: string[]) =>
+    createOpenFileEffects(targetPaths[0] ? [targetPaths[0]] : []),
+  openEdgeTarget: (targetPaths: string[]) =>
+    createOpenFileEffects(targetPaths[1] ? [targetPaths[1]] : []),
   reveal: (targetPaths: string[]) =>
     createOptionalSinglePathMessageEffects(targetPaths[0], 'REVEAL_IN_EXPLORER'),
   copyRelative: (targetPaths: string[]) => createClipboardEffects(targetPaths.join('\n')),

--- a/packages/extension/src/webview/components/graph/contextActions/builtin/effects.ts
+++ b/packages/extension/src/webview/components/graph/contextActions/builtin/effects.ts
@@ -3,6 +3,7 @@ import type { GraphContextEffect } from '../effects';
 import {
   createClipboardEffects,
   createCreateFileEffects,
+  createCreateFolderEffects,
   createOptionalClipboardEffects,
   createOptionalSinglePathMessageEffects,
   createPathListMessageEffects,
@@ -37,7 +38,8 @@ const BUILT_IN_CONTEXT_ACTION_EFFECTS = {
   delete: (targetPaths: string[]) => createPathListMessageEffects('DELETE_FILES', targetPaths),
   refresh: () => createRefreshEffects(),
   fitView: () => createFitViewEffects(),
-  createFile: () => createCreateFileEffects(),
+  createFile: (targetPaths: string[]) => createCreateFileEffects(targetPaths[0] ?? '.'),
+  createFolder: (targetPaths: string[]) => createCreateFolderEffects(targetPaths[0] ?? '.'),
 } satisfies Record<BuiltInContextMenuAction, (targetPaths: string[]) => GraphContextEffect[]>;
 
 export function getBuiltInContextActionEffectsImpl(

--- a/packages/extension/src/webview/components/graph/contextActions/builtin/effects.ts
+++ b/packages/extension/src/webview/components/graph/contextActions/builtin/effects.ts
@@ -38,8 +38,8 @@ const BUILT_IN_CONTEXT_ACTION_EFFECTS = {
   delete: (targetPaths: string[]) => createPathListMessageEffects('DELETE_FILES', targetPaths),
   refresh: () => createRefreshEffects(),
   fitView: () => createFitViewEffects(),
-  createFile: (targetPaths: string[]) => createCreateFileEffects(targetPaths[0] ?? '.'),
-  createFolder: (targetPaths: string[]) => createCreateFolderEffects(targetPaths[0] ?? '.'),
+  createFile: (targetPaths: string[]) => createCreateFileEffects(getMutationDirectory(targetPaths)),
+  createFolder: (targetPaths: string[]) => createCreateFolderEffects(getMutationDirectory(targetPaths)),
 } satisfies Record<BuiltInContextMenuAction, (targetPaths: string[]) => GraphContextEffect[]>;
 
 export function getBuiltInContextActionEffectsImpl(
@@ -47,4 +47,9 @@ export function getBuiltInContextActionEffectsImpl(
   targetPaths: string[]
 ): GraphContextEffect[] {
   return BUILT_IN_CONTEXT_ACTION_EFFECTS[action](targetPaths);
+}
+
+function getMutationDirectory(targetPaths: string[]): string {
+  const directory = targetPaths[0] ?? '.';
+  return directory === '(root)' ? '.' : directory;
 }

--- a/packages/extension/src/webview/components/graph/contextActions/messages.ts
+++ b/packages/extension/src/webview/components/graph/contextActions/messages.ts
@@ -41,6 +41,10 @@ export function createRefreshEffects(): GraphContextEffect[] {
   return [createPostMessageEffect({ type: 'REFRESH_GRAPH' })];
 }
 
-export function createCreateFileEffects(): GraphContextEffect[] {
-  return [createPostMessageEffect({ type: 'CREATE_FILE', payload: { directory: '.' } })];
+export function createCreateFileEffects(directory = '.'): GraphContextEffect[] {
+  return [createPostMessageEffect({ type: 'CREATE_FILE', payload: { directory } })];
+}
+
+export function createCreateFolderEffects(directory = '.'): GraphContextEffect[] {
+  return [createPostMessageEffect({ type: 'CREATE_FOLDER', payload: { directory } })];
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/background/entries.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/background/entries.ts
@@ -5,6 +5,7 @@ export function buildBackgroundEntries(timelineActive: boolean): GraphContextMen
   const entries: GraphContextMenuEntry[] = [];
   if (!timelineActive) {
     entries.push(builtInItem('background-create-file', 'New File...', 'createFile'));
+    entries.push(builtInItem('background-create-folder', 'New Folder...', 'createFolder'));
     entries.push(separator('background-separator-primary'));
   }
   entries.push(

--- a/packages/extension/src/webview/components/graph/contextMenu/build/entries.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/build/entries.ts
@@ -1,17 +1,23 @@
 import { buildBackgroundEntries } from '../background/entries';
 import type { BuildGraphContextMenuOptions, GraphContextMenuEntry } from '../contracts';
+import { decideGraphContextMenu } from '../decision/model';
 import { buildEdgeEntries } from '../edge/entries';
-import { buildNodeEntries } from '../node/entries';
+import { buildNodeEntries, buildSingleFolderNodeEntries } from '../node/entries';
 import { buildPluginEntries } from '../plugin/entries';
 
 export function buildGraphContextMenuEntries(
   options: BuildGraphContextMenuOptions
 ): GraphContextMenuEntry[] {
-  const { selection, timelineActive, favorites, pluginItems } = options;
-  const baseEntries = selection.kind === 'background'
+  const { selection, timelineActive, favorites, pluginItems, nodes } = options;
+  const mutationAvailability = options.mutationAvailability
+    ?? (timelineActive ? 'hidden' : 'enabled');
+  const decision = decideGraphContextMenu(selection, nodes);
+  const baseEntries = decision.kind === 'background'
     ? buildBackgroundEntries(timelineActive)
-    : selection.kind === 'node'
-      ? buildNodeEntries(selection.targets, timelineActive, favorites)
-      : buildEdgeEntries(selection.targets);
+    : decision.kind === 'singleFolderNode'
+      ? buildSingleFolderNodeEntries(decision.target, mutationAvailability, favorites)
+      : decision.kind === 'node'
+        ? buildNodeEntries(decision.targets, timelineActive, favorites)
+        : buildEdgeEntries(decision.targets);
   return [...baseEntries, ...buildPluginEntries(selection, pluginItems)];
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/common/entryFactories.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/common/entryFactories.ts
@@ -5,6 +5,7 @@ import type {
 
 interface BuiltInItemOptions {
   destructive?: boolean;
+  disabled?: boolean;
   shortcut?: string;
 }
 
@@ -24,6 +25,7 @@ export function builtInItem(
     label,
     action: { kind: 'builtin', action },
     destructive: options?.destructive,
+    disabled: options?.disabled,
     shortcut: options?.shortcut,
   };
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
@@ -5,6 +5,8 @@ export type GraphContextMutationAvailability = 'enabled' | 'disabled' | 'hidden'
 
 export type BuiltInContextMenuAction =
   | 'open'
+  | 'openEdgeSource'
+  | 'openEdgeTarget'
   | 'reveal'
   | 'copyRelative'
   | 'copyAbsolute'

--- a/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
@@ -1,6 +1,7 @@
 import type { IPluginContextMenuItem } from '../../../../shared/plugins/contextMenu';
 
 export type GraphContextTargetKind = 'background' | 'node' | 'edge';
+export type GraphContextMutationAvailability = 'enabled' | 'disabled' | 'hidden';
 
 export type BuiltInContextMenuAction =
   | 'open'
@@ -18,7 +19,8 @@ export type BuiltInContextMenuAction =
   | 'delete'
   | 'refresh'
   | 'fitView'
-  | 'createFile';
+  | 'createFile'
+  | 'createFolder';
 
 export type GraphContextMenuAction =
   | { kind: 'builtin'; action: BuiltInContextMenuAction }
@@ -31,6 +33,7 @@ export type GraphContextMenuEntry =
       label: string;
       action: GraphContextMenuAction;
       destructive?: boolean;
+      disabled?: boolean;
       shortcut?: string;
     }
   | {
@@ -44,9 +47,18 @@ export interface GraphContextSelection {
   edgeId?: string;
 }
 
+export interface GraphContextMenuNode {
+  id: string;
+  label?: string;
+  color?: string;
+  nodeType?: string;
+}
+
 export interface BuildGraphContextMenuOptions {
   selection: GraphContextSelection;
   timelineActive: boolean;
+  mutationAvailability?: GraphContextMutationAvailability;
   favorites: ReadonlySet<string>;
   pluginItems: readonly IPluginContextMenuItem[];
+  nodes?: readonly GraphContextMenuNode[];
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/decision/model.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/decision/model.ts
@@ -1,0 +1,47 @@
+import type {
+  GraphContextMenuNode,
+  GraphContextSelection,
+} from '../contracts';
+
+export type GraphContextMenuDecision =
+  | { kind: 'background' }
+  | { kind: 'edge'; targets: readonly string[] }
+  | { kind: 'singleFolderNode'; target: string }
+  | { kind: 'node'; targets: readonly string[] };
+
+function createNodeTypeMap(nodes: readonly GraphContextMenuNode[]): Map<string, string> {
+  return new Map(nodes.map(node => [node.id, node.nodeType ?? 'file']));
+}
+
+function getNodeType(nodeId: string, nodeTypes: ReadonlyMap<string, string>): string {
+  if (nodeId.startsWith('pkg:')) {
+    return 'package';
+  }
+
+  return nodeTypes.get(nodeId) ?? 'file';
+}
+
+export function decideGraphContextMenu(
+  selection: GraphContextSelection,
+  nodes: readonly GraphContextMenuNode[] = [],
+): GraphContextMenuDecision {
+  if (selection.kind === 'background') {
+    return { kind: 'background' };
+  }
+
+  if (selection.kind === 'edge') {
+    return { kind: 'edge', targets: selection.targets };
+  }
+
+  const nodeTypes = createNodeTypeMap(nodes);
+  const target = selection.targets[0];
+  if (
+    selection.targets.length === 1
+    && target
+    && getNodeType(target, nodeTypes) === 'folder'
+  ) {
+    return { kind: 'singleFolderNode', target };
+  }
+
+  return { kind: 'node', targets: selection.targets };
+}

--- a/packages/extension/src/webview/components/graph/contextMenu/edge/entries.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/edge/entries.ts
@@ -6,6 +6,12 @@ export function buildEdgeEntries(targets: readonly string[]): GraphContextMenuEn
   const entries: GraphContextMenuEntry[] = [];
 
   if (sourceId) {
+    entries.push(builtInItem('edge-open-source', 'Open Source', 'openEdgeSource'));
+  }
+  if (targetId) {
+    entries.push(builtInItem('edge-open-target', 'Open Target', 'openEdgeTarget'));
+  }
+  if (sourceId) {
     entries.push(builtInItem('edge-copy-source', 'Copy Source Path', 'copyEdgeSource'));
   }
   if (targetId) {

--- a/packages/extension/src/webview/components/graph/contextMenu/node/destructive/block.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/node/destructive/block.ts
@@ -10,11 +10,18 @@ export function buildFilterBlock(targets: readonly string[]): GraphContextMenuEn
   const isMultiSelect = targets.length > 1;
   const entries: GraphContextMenuEntry[] = [
     separator('node-separator-filter'),
-    builtInItem('node-add-filter', isMultiSelect ? 'Add All to Filter' : 'Add to Filter', 'addToFilter'),
+    builtInItem(
+      'node-add-filter',
+      isMultiSelect ? 'Add Filter Patterns...' : 'Add Filter Pattern...',
+      'addToFilter'
+    ),
   ];
 
   if (!isMultiSelect) {
-    entries.push(builtInItem('node-add-legend', 'Add Legend Group', 'addNodeLegend'));
+    entries.push(
+      separator('node-separator-legend'),
+      builtInItem('node-add-legend', 'Add Legend Group...', 'addNodeLegend')
+    );
   }
 
   return entries;
@@ -36,4 +43,15 @@ export function buildDestructiveBlock(targets: readonly string[]): GraphContextM
   );
 
   return entries;
+}
+
+export function buildFolderDestructiveBlock(disabled: boolean): GraphContextMenuEntry[] {
+  return [
+    separator('node-separator-folder-destructive'),
+    builtInItem('node-rename-folder', 'Rename Folder...', 'rename', { disabled }),
+    builtInItem('node-delete-folder', 'Delete Folder', 'delete', {
+      destructive: true,
+      disabled,
+    }),
+  ];
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/node/entries.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/node/entries.ts
@@ -5,7 +5,11 @@ import {
   buildCopyBlock,
 } from './openCopyBlocks';
 import { buildFavoriteBlock } from './destructive/favoritesBlocks';
-import { buildDestructiveBlock, buildFilterBlock } from './destructive/block';
+import {
+  buildDestructiveBlock,
+  buildFilterBlock,
+  buildFolderDestructiveBlock,
+} from './destructive/block';
 
 export function buildNodeEntries(
   targets: readonly string[],
@@ -49,6 +53,10 @@ export function buildSingleFolderNodeEntries(
     ...buildFavoriteBlock(targets, favorites),
     ...buildFilterBlock(targets),
   );
+
+  if (target !== '(root)' && mutationAvailability !== 'hidden') {
+    entries.push(...buildFolderDestructiveBlock(mutationAvailability === 'disabled'));
+  }
 
   return entries;
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/node/entries.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/node/entries.ts
@@ -1,4 +1,5 @@
-import type { GraphContextMenuEntry } from '../contracts';
+import type { GraphContextMenuEntry, GraphContextMutationAvailability } from '../contracts';
+import { builtInItem, separator } from '../common/entryFactories';
 import {
   buildOpenBlock,
   buildCopyBlock,
@@ -21,6 +22,33 @@ export function buildNodeEntries(
   if (!timelineActive) {
     entries.push(...buildDestructiveBlock(targets));
   }
+
+  return entries;
+}
+
+export function buildSingleFolderNodeEntries(
+  target: string,
+  mutationAvailability: GraphContextMutationAvailability,
+  favorites: ReadonlySet<string>
+): GraphContextMenuEntry[] {
+  const targets = [target];
+  const entries: GraphContextMenuEntry[] = [];
+
+  if (mutationAvailability !== 'hidden') {
+    const disabled = mutationAvailability === 'disabled';
+    entries.push(
+      builtInItem('node-create-file', 'New File...', 'createFile', { disabled }),
+      builtInItem('node-create-folder', 'New Folder...', 'createFolder', { disabled }),
+      separator('node-separator-create'),
+    );
+  }
+
+  entries.push(
+    builtInItem('node-reveal', 'Reveal in Explorer', 'reveal'),
+    ...buildCopyBlock(targets),
+    ...buildFavoriteBlock(targets, favorites),
+    ...buildFilterBlock(targets),
+  );
 
   return entries;
 }

--- a/packages/extension/src/webview/components/graph/interactionRuntime/handlers.ts
+++ b/packages/extension/src/webview/components/graph/interactionRuntime/handlers.ts
@@ -80,7 +80,7 @@ export function createGraphInteractionHandlers(
   const selectionHandlers = createSelectionHandlers(dependencies);
   const contextMenuHandlers = createContextMenuHandlers(
     dependencies,
-    selectionHandlers.setSelection,
+    selectionHandlers,
   );
   const viewHandlers = createViewHandlers(dependencies);
   const effectHandlers = createEffectHandlers(dependencies, {

--- a/packages/extension/src/webview/components/graph/interactionRuntime/handlers/contextMenu.ts
+++ b/packages/extension/src/webview/components/graph/interactionRuntime/handlers/contextMenu.ts
@@ -1,3 +1,4 @@
+import { flushSync } from 'react-dom';
 import {
   makeBackgroundContextSelection,
   makeEdgeContextSelection,
@@ -12,6 +13,11 @@ export interface ContextMenuHandlers {
   openBackgroundContextMenu(this: void, event: MouseEvent): void;
   openEdgeContextMenu(this: void, link: FGLink, event: MouseEvent): void;
   openNodeContextMenu(this: void, nodeId: string, event: MouseEvent): void;
+}
+
+export interface ContextMenuSelectionHandlers {
+  setHighlight(this: void, nodeId: string | null): void;
+  setSelection(this: void, nodeIds: string[]): void;
 }
 
 export interface ContextMenuPointerState {
@@ -61,7 +67,7 @@ function openContextMenuFromGraphCallback(
 
 export function createContextMenuHandlers(
   dependencies: GraphInteractionHandlersDependencies,
-  setSelection: (nodeIds: string[]) => void,
+  selectionHandlers: ContextMenuSelectionHandlers,
 ): ContextMenuHandlers {
   const openNodeContextMenu = (nodeId: string, event: MouseEvent): void => {
     const selection = getNodeContextMenuSelection(
@@ -69,13 +75,16 @@ export function createContextMenuHandlers(
       dependencies.selectedNodesSetRef.current,
     );
 
-    if (selection.shouldUpdateSelection) {
-      setSelection(selection.nodeIds);
-    }
+    flushSync(() => {
+      selectionHandlers.setHighlight(nodeId);
+      if (selection.shouldUpdateSelection) {
+        selectionHandlers.setSelection(selection.nodeIds);
+      }
 
-    dependencies.setContextSelection(
-      makeNodeContextSelection(nodeId, new Set(selection.nodeIds)),
-    );
+      dependencies.setContextSelection(
+        makeNodeContextSelection(nodeId, new Set(selection.nodeIds)),
+      );
+    });
     dependencies.lastGraphContextEventRef.current = Date.now();
     openContextMenuFromGraphCallback(dependencies, event);
   };
@@ -96,15 +105,19 @@ export function createContextMenuHandlers(
       dependencies.dataRef.current.edges,
     );
 
-    dependencies.setContextSelection(
-      makeEdgeContextSelection(edgeId, sourceId, targetId),
-    );
+    flushSync(() => {
+      dependencies.setContextSelection(
+        makeEdgeContextSelection(edgeId, sourceId, targetId),
+      );
+    });
     dependencies.lastGraphContextEventRef.current = Date.now();
     openContextMenuFromGraphCallback(dependencies, event);
   };
 
   const openBackgroundContextMenu = (event: MouseEvent): void => {
-    dependencies.setContextSelection(makeBackgroundContextSelection());
+    flushSync(() => {
+      dependencies.setContextSelection(makeBackgroundContextSelection());
+    });
     dependencies.lastGraphContextEventRef.current = Date.now();
     openContextMenuFromGraphCallback(dependencies, event);
   };

--- a/packages/extension/src/webview/components/graph/view/store.ts
+++ b/packages/extension/src/webview/components/graph/view/store.ts
@@ -4,6 +4,7 @@ import type { GraphState } from '../../../store/state';
 export type GraphViewStoreState = Pick<
   GraphState,
   | 'bidirectionalMode'
+  | 'currentCommitSha'
   | 'dagMode'
   | 'directionColor'
   | 'directionMode'
@@ -18,12 +19,14 @@ export type GraphViewStoreState = Pick<
   | 'setGraphMode'
   | 'showLabels'
   | 'timelineActive'
+  | 'timelineCommits'
   | 'depthMode'
 >;
 
 export function useGraphViewStoreState(): GraphViewStoreState {
   return {
     bidirectionalMode: useGraphStore(state => state.bidirectionalMode),
+    currentCommitSha: useGraphStore(state => state.currentCommitSha),
     dagMode: useGraphStore(state => state.dagMode),
     depthMode: useGraphStore(state => state.depthMode),
     directionColor: useGraphStore(state => state.directionColor),
@@ -39,5 +42,6 @@ export function useGraphViewStoreState(): GraphViewStoreState {
     setGraphMode: useGraphStore(state => state.setGraphMode),
     showLabels: useGraphStore(state => state.showLabels),
     timelineActive: useGraphStore(state => state.timelineActive),
+    timelineCommits: useGraphStore(state => state.timelineCommits),
   };
 }

--- a/packages/extension/src/webview/components/graph/viewport/model.ts
+++ b/packages/extension/src/webview/components/graph/viewport/model.ts
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
 import type { GraphViewStoreState } from '../view/store';
-import type { GraphContextMenuEntry } from '../contextMenu/contracts';
+import type {
+  GraphContextMenuEntry,
+  GraphContextMutationAvailability,
+} from '../contextMenu/contracts';
 import { buildGraphContextMenuEntries } from '../contextMenu/build/entries';
 import type { UseGraphInteractionRuntimeResult } from '../runtime/use/interaction';
 import type { UseGraphRenderingRuntimeResult } from '../runtime/use/rendering';
@@ -28,8 +31,28 @@ export interface GraphViewportModelOptions {
   viewportRuntime: Pick<UseGraphRenderingRuntimeResult, 'containerSize'>;
   viewState: Pick<
     GraphViewStoreState,
-    'dagMode' | 'favorites' | 'physicsSettings' | 'pluginContextMenuItems' | 'setGraphMode' | 'timelineActive'
+    | 'currentCommitSha'
+    | 'dagMode'
+    | 'favorites'
+    | 'physicsSettings'
+    | 'pluginContextMenuItems'
+    | 'setGraphMode'
+    | 'timelineActive'
+    | 'timelineCommits'
   >;
+}
+
+export function getGraphContextMutationAvailability(
+  viewState: Pick<GraphViewStoreState, 'currentCommitSha' | 'timelineActive' | 'timelineCommits'>,
+): GraphContextMutationAvailability {
+  if (!viewState.timelineActive) {
+    return 'enabled';
+  }
+
+  const currentHeadSha = viewState.timelineCommits.at(-1)?.sha;
+  return currentHeadSha && viewState.currentCommitSha === currentHeadSha
+    ? 'enabled'
+    : 'disabled';
 }
 
 export function useGraphViewportModel({
@@ -64,8 +87,10 @@ export function useGraphViewportModel({
   const menuEntries = buildGraphContextMenuEntries({
     selection: graphState.contextSelection,
     timelineActive: viewState.timelineActive,
+    mutationAvailability: getGraphContextMutationAvailability(viewState),
     favorites: viewState.favorites,
     pluginItems: viewState.pluginContextMenuItems,
+    nodes: graphState.graphData.nodes,
   });
 
   const { backgroundColor, borderColor } = getGraphSurfaceColors(theme);

--- a/packages/extension/src/webview/components/graph/viewport/view.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/view.tsx
@@ -129,6 +129,7 @@ export function Viewport({
             <ContextMenuItem
               key={entry.id}
               className={entry.destructive ? 'text-red-400 focus:text-red-300' : undefined}
+              disabled={entry.disabled}
               onClick={() => handleMenuAction(entry.action)}
             >
               {entry.label}

--- a/packages/extension/src/webview/graphControls/filtering.ts
+++ b/packages/extension/src/webview/graphControls/filtering.ts
@@ -2,7 +2,7 @@ import type { EdgeDecorationPayload } from '../../shared/plugins/decorations';
 import type { IGraphData } from '../../shared/graph/contracts';
 import type { IGraphEdgeTypeDefinition } from '../../shared/graphControls/contracts';
 import { applyEdgeTypeDefaultColors, filterSemanticEdges, filterVisibleEdgeDecorations, filterVisibleStructuralEdges } from './filtering/edges';
-import { applyNodeTypeColors, getFileNodes, isNodeVisible, withResolvedNodeTypes } from './filtering/nodes';
+import { applyNodeTypeColors, getFileNodes, getFolderNodes, isNodeVisible, withResolvedNodeTypes } from './filtering/nodes';
 import { buildStructuralEdges, buildStructuralGraphNodes } from './filtering/structures';
 
 export interface GraphControlsFilteringOptions {
@@ -36,7 +36,12 @@ export function applyGraphControls({
     folderNodes,
     packageNodes,
     workspacePackageRoots,
-  } = buildStructuralGraphNodes(getFileNodes(baseNodes), nodeVisibility, nodeColors);
+  } = buildStructuralGraphNodes(
+    getFileNodes(baseNodes),
+    nodeVisibility,
+    nodeColors,
+    getFolderNodes(baseNodes),
+  );
 
   const nodes = [...visibleBaseNodes, ...folderNodes, ...packageNodes];
   const visibleNodeIds = new Set(nodes.map((node) => node.id));

--- a/packages/extension/src/webview/graphControls/filtering/nodes.ts
+++ b/packages/extension/src/webview/graphControls/filtering/nodes.ts
@@ -49,3 +49,7 @@ function getFallbackColor(nodeType: string): string {
 export function getFileNodes(nodes: IGraphNode[]): IGraphNode[] {
   return nodes.filter((node) => getResolvedNodeType(node) === 'file');
 }
+
+export function getFolderNodes(nodes: IGraphNode[]): IGraphNode[] {
+  return nodes.filter((node) => getResolvedNodeType(node) === 'folder');
+}

--- a/packages/extension/src/webview/graphControls/filtering/structures.ts
+++ b/packages/extension/src/webview/graphControls/filtering/structures.ts
@@ -1,5 +1,5 @@
 import {
-  collectFolderPaths,
+  collectStructuralFolderPaths,
   createFolderNodes,
 } from '../../../shared/graphControls/nests/folders';
 import { buildContainmentEdges } from '../../../shared/graphControls/nests/edges';
@@ -17,16 +17,23 @@ import {
 
 function buildFolderStructuralNodes(
   fileNodes: IGraphNode[],
+  sourceFolderNodes: IGraphNode[],
   nodeVisibility: Record<string, boolean>,
   nodeColors: Record<string, string>,
 ): { folderNodes: IGraphNode[]; folderPaths: Set<string> } {
   const folderEnabled = nodeVisibility.folder ?? false;
-  const folderPaths = folderEnabled ? collectFolderPaths(fileNodes).paths : new Set<string>();
+  const folderPaths = folderEnabled
+    ? collectStructuralFolderPaths(fileNodes, sourceFolderNodes).paths
+    : new Set<string>();
+  const sourceFolderNodeIds = new Set(sourceFolderNodes.map((node) => node.id));
+  const generatedFolderPaths = new Set(
+    Array.from(folderPaths).filter((folderPath) => !sourceFolderNodeIds.has(folderPath)),
+  );
 
   return {
     folderPaths,
     folderNodes: folderEnabled
-      ? createFolderNodes(folderPaths, nodeColors.folder ?? DEFAULT_FOLDER_NODE_COLOR)
+      ? createFolderNodes(generatedFolderPaths, nodeColors.folder ?? DEFAULT_FOLDER_NODE_COLOR)
       : [],
   };
 }
@@ -56,13 +63,14 @@ export function buildStructuralGraphNodes(
   fileNodes: IGraphNode[],
   nodeVisibility: Record<string, boolean>,
   nodeColors: Record<string, string>,
+  sourceFolderNodes: IGraphNode[] = [],
 ): {
   folderPaths: Set<string>;
   folderNodes: IGraphNode[];
   packageNodes: IGraphNode[];
   workspacePackageRoots: Set<string>;
 } {
-  const { folderNodes, folderPaths } = buildFolderStructuralNodes(fileNodes, nodeVisibility, nodeColors);
+  const { folderNodes, folderPaths } = buildFolderStructuralNodes(fileNodes, sourceFolderNodes, nodeVisibility, nodeColors);
   const { packageNodes, workspacePackageRoots } = buildPackageStructuralNodes(fileNodes, nodeVisibility, nodeColors);
 
   return {

--- a/packages/extension/tests/__mocks__/vscode.ts
+++ b/packages/extension/tests/__mocks__/vscode.ts
@@ -29,6 +29,9 @@ export const workspace = {
   })),
   onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
   onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+  onDidCreateFiles: vi.fn(() => ({ dispose: vi.fn() })),
+  onDidDeleteFiles: vi.fn(() => ({ dispose: vi.fn() })),
+  onDidRenameFiles: vi.fn(() => ({ dispose: vi.fn() })),
   createFileSystemWatcher: vi.fn(() => ({
     onDidCreate: vi.fn(() => ({ dispose: vi.fn() })),
     onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),

--- a/packages/extension/tests/core/discovery/file/discovery.discover.test.ts
+++ b/packages/extension/tests/core/discovery/file/discovery.discover.test.ts
@@ -213,6 +213,7 @@ describe('FileDiscovery discover', () => {
     const result = await discovery.discover({ rootPath: tempDir });
 
     expect(result.files).toHaveLength(0);
+    expect(result.directories).toEqual(['empty']);
   });
 
   it('handles deeply nested files', async () => {

--- a/packages/extension/tests/extension/actions/createFolder.test.ts
+++ b/packages/extension/tests/extension/actions/createFolder.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { CreateFolderAction } from '../../../src/extension/actions/createFolder';
+
+vi.mock('vscode', () => ({
+  workspace: {
+    fs: {
+      createDirectory: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      readDirectory: vi.fn().mockResolvedValue([]),
+    },
+  },
+  Uri: {
+    joinPath: vi.fn((base: { fsPath: string }, ...pathSegments: string[]) => ({
+      fsPath: `${base.fsPath}/${pathSegments.join('/')}`,
+      toString: () => `file://${base.fsPath}/${pathSegments.join('/')}`,
+    })),
+  },
+  FileType: {
+    File: 1,
+  },
+}));
+
+describe('CreateFolderAction', () => {
+  const mockWorkspaceFolder = { fsPath: '/workspace' } as vscode.Uri;
+  let mockRefreshGraph: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRefreshGraph = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(vscode.workspace.fs.readDirectory).mockResolvedValue([]);
+  });
+
+  it('uses the folder name in the description', () => {
+    const action = new CreateFolderAction('src/components', mockWorkspaceFolder, mockRefreshGraph);
+
+    expect(action.description).toBe('Create folder: components');
+  });
+
+  it('creates the folder and refreshes graph data', async () => {
+    const action = new CreateFolderAction('src/components', mockWorkspaceFolder, mockRefreshGraph);
+
+    await action.execute();
+
+    expect(vscode.Uri.joinPath).toHaveBeenCalledWith(mockWorkspaceFolder, 'src/components');
+    expect(vscode.workspace.fs.createDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ fsPath: '/workspace/src/components' }),
+    );
+    expect(mockRefreshGraph).toHaveBeenCalledOnce();
+  });
+
+  it('moves an empty created folder to trash on undo', async () => {
+    const action = new CreateFolderAction('src/components', mockWorkspaceFolder, mockRefreshGraph);
+
+    await action.undo();
+
+    expect(vscode.workspace.fs.readDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ fsPath: '/workspace/src/components' }),
+    );
+    expect(vscode.workspace.fs.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ fsPath: '/workspace/src/components' }),
+      { recursive: false, useTrash: true },
+    );
+    expect(mockRefreshGraph).toHaveBeenCalledOnce();
+  });
+
+  it('does not remove a created folder that now contains files', async () => {
+    vi.mocked(vscode.workspace.fs.readDirectory).mockResolvedValue([
+      ['later.ts', vscode.FileType.File],
+    ]);
+    const action = new CreateFolderAction('src/components', mockWorkspaceFolder, mockRefreshGraph);
+
+    await action.undo();
+
+    expect(vscode.workspace.fs.delete).not.toHaveBeenCalled();
+    expect(mockRefreshGraph).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/tests/extension/actions/deleteFiles.test.ts
+++ b/packages/extension/tests/extension/actions/deleteFiles.test.ts
@@ -5,8 +5,11 @@ import { DeleteFilesAction } from '../../../src/extension/actions/deleteFiles';
 vi.mock('vscode', () => ({
   workspace: {
     fs: {
+      stat: vi.fn(),
+      readDirectory: vi.fn(),
       readFile: vi.fn(),
       writeFile: vi.fn().mockResolvedValue(undefined),
+      createDirectory: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),
     },
     getConfiguration: vi.fn(),
@@ -19,6 +22,10 @@ vi.mock('vscode', () => ({
       fsPath: `${base.fsPath}/${pathSegments.join('/')}`,
       toString: () => `file://${base.fsPath}/${pathSegments.join('/')}`,
     })),
+  },
+  FileType: {
+    File: 1,
+    Directory: 2,
   },
   ConfigurationTarget: {
     Global: 1,
@@ -41,8 +48,13 @@ describe('DeleteFilesAction', () => {
     vi.mocked(vscode.workspace.fs.readFile).mockResolvedValue(
       new Uint8Array([72, 101, 108, 108, 111])
     );
+    vi.mocked(vscode.workspace.fs.stat).mockResolvedValue({
+      type: vscode.FileType.File,
+    } as vscode.FileStat);
+    vi.mocked(vscode.workspace.fs.readDirectory).mockResolvedValue([]);
     vi.mocked(vscode.workspace.fs.delete).mockResolvedValue(undefined);
     vi.mocked(vscode.workspace.fs.writeFile).mockResolvedValue(undefined);
+    vi.mocked(vscode.workspace.fs.createDirectory).mockResolvedValue(undefined);
 
     mockConfigUpdate = vi.fn().mockResolvedValue(undefined);
     vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
@@ -162,6 +174,52 @@ describe('DeleteFilesAction', () => {
       await action.execute();
 
       expect(mockRefreshGraph).toHaveBeenCalledOnce();
+    });
+
+    it('deletes folders recursively after backing up nested files', async () => {
+      vi.mocked(vscode.workspace.fs.stat).mockResolvedValue({
+        type: vscode.FileType.Directory,
+      } as vscode.FileStat);
+      vi.mocked(vscode.workspace.fs.readDirectory).mockImplementation(async (uri: vscode.Uri) => {
+        if (uri.fsPath === '/workspace/src') {
+          return [
+            ['app.ts', vscode.FileType.File],
+            ['nested', vscode.FileType.Directory],
+          ];
+        }
+        if (uri.fsPath === '/workspace/src/nested') {
+          return [['leaf.ts', vscode.FileType.File]];
+        }
+        return [];
+      });
+      vi.mocked(vscode.workspace.fs.readFile).mockImplementation(async (uri: vscode.Uri) =>
+        uri.fsPath.endsWith('leaf.ts')
+          ? new Uint8Array([2])
+          : new Uint8Array([1])
+      );
+      const action = new DeleteFilesAction(['src'], mockWorkspaceFolder, mockRefreshGraph);
+
+      await action.execute();
+      await action.undo();
+
+      expect(vscode.workspace.fs.delete).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: '/workspace/src' }),
+        { recursive: true, useTrash: true },
+      );
+      expect(vscode.workspace.fs.createDirectory).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: '/workspace/src' }),
+      );
+      expect(vscode.workspace.fs.createDirectory).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: '/workspace/src/nested' }),
+      );
+      expect(vscode.workspace.fs.writeFile).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: '/workspace/src/app.ts' }),
+        new Uint8Array([1]),
+      );
+      expect(vscode.workspace.fs.writeFile).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: '/workspace/src/nested/leaf.ts' }),
+        new Uint8Array([2]),
+      );
     });
   });
 

--- a/packages/extension/tests/extension/actions/deleteFilesMutants.test.ts
+++ b/packages/extension/tests/extension/actions/deleteFilesMutants.test.ts
@@ -17,14 +17,23 @@ import { DeleteFilesAction } from '../../../src/extension/actions/deleteFiles';
 vi.mock('vscode', () => ({
   workspace: {
     fs: {
+      stat: vi.fn(),
       readFile: vi.fn(),
       writeFile: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),
+      readDirectory: vi.fn(),
+      createDirectory: vi.fn(),
     },
     getConfiguration: vi.fn(),
   },
   window: {
     showErrorMessage: vi.fn(),
+  },
+  FileType: {
+    Unknown: 0,
+    File: 1,
+    Directory: 2,
+    SymbolicLink: 64,
   },
   Uri: {
     joinPath: vi.fn((base: { fsPath: string }, ...pathSegments: string[]) => ({
@@ -51,6 +60,9 @@ describe('DeleteFilesAction (mutant coverage)', () => {
     mockConfigGet = vi.fn().mockReturnValue([]);
     mockConfigUpdate = vi.fn().mockResolvedValue(undefined);
 
+    vi.mocked(vscode.workspace.fs.stat).mockResolvedValue({
+      type: vscode.FileType.File,
+    } as vscode.FileStat);
     vi.mocked(vscode.workspace.fs.readFile).mockResolvedValue(
       new Uint8Array([72, 101, 108, 108, 111])
     );

--- a/packages/extension/tests/extension/actions/fileActions.test.ts
+++ b/packages/extension/tests/extension/actions/fileActions.test.ts
@@ -14,10 +14,13 @@ import { getUndoManager, resetUndoManager } from '../../../src/extension/undoMan
 vi.mock('vscode', () => ({
   workspace: {
     fs: {
+      stat: vi.fn(),
       readFile: vi.fn(),
       writeFile: vi.fn(),
       delete: vi.fn(),
       rename: vi.fn(),
+      readDirectory: vi.fn(),
+      createDirectory: vi.fn(),
     },
     openTextDocument: vi.fn(),
     getConfiguration: vi.fn(() => ({
@@ -32,6 +35,12 @@ vi.mock('vscode', () => ({
   },
   commands: {
     executeCommand: vi.fn(),
+  },
+  FileType: {
+    Unknown: 0,
+    File: 1,
+    Directory: 2,
+    SymbolicLink: 64,
   },
   Uri: {
     joinPath: vi.fn((base, ...pathSegments) => ({
@@ -55,6 +64,9 @@ describe('DeleteFilesAction', () => {
     mockRefreshGraph = vi.fn().mockResolvedValue(undefined);
     
     // Setup default mock implementations
+    (vscode.workspace.fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({
+      type: vscode.FileType.File,
+    });
     (vscode.workspace.fs.readFile as ReturnType<typeof vi.fn>).mockResolvedValue(
       new Uint8Array([104, 101, 108, 108, 111]) // "hello"
     );

--- a/packages/extension/tests/extension/actions/renameFile.test.ts
+++ b/packages/extension/tests/extension/actions/renameFile.test.ts
@@ -132,6 +132,20 @@ describe('RenameFileAction', () => {
         undefined,
       );
     });
+
+    it('updates nested favorites when renaming a folder path', async () => {
+      currentFavorites = ['src/app.ts', 'src/nested/leaf.ts', 'other.ts'];
+
+      const action = new RenameFileAction('src', 'lib', mockWorkspaceFolder, mockRefreshGraph);
+
+      await action.execute();
+
+      expect(mockConfigUpdate).toHaveBeenCalledWith(
+        'favorites',
+        ['lib/app.ts', 'lib/nested/leaf.ts', 'other.ts'],
+        undefined,
+      );
+    });
   });
 
   describe('undo', () => {

--- a/packages/extension/tests/extension/extension.test.ts
+++ b/packages/extension/tests/extension/extension.test.ts
@@ -65,9 +65,10 @@ describe('Extension', () => {
       activate(mockContext as unknown as Parameters<typeof activate>[0]);
 
       // view providers (2) + config listener (1) + active editor listener (1) + save listener (1)
-      // + file watcher events (2) + file watcher (1) + URI handler (1) + runtime bridge listener (1)
+      // + file watcher events (2) + workspace file operation events (3) + file watcher (1)
+      // + URI handler (1) + runtime bridge listener (1)
       // + 16 commands (open, openInEditor, fitView, zoomIn, zoomOut, undo, redo, exportPng, exportSvg, exportJpeg, exportJson, exportMarkdown, clearCache, toggleDepthMode, cycleLayout, toggleDimension)
-      expect(mockContext.subscriptions.length).toBe(26);
+      expect(mockContext.subscriptions.length).toBe(29);
     });
 
     it('should ignore workspace settings saves when deciding graph refresh', async () => {

--- a/packages/extension/tests/extension/graphView/files/actions.test.ts
+++ b/packages/extension/tests/extension/graphView/files/actions.test.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import {
   addGraphViewExcludePatterns,
   createGraphViewFile,
+  createGraphViewFolder,
   deleteGraphViewFiles,
 } from '../../../../src/extension/graphView/files/actions';
 
@@ -108,6 +109,28 @@ describe('graphView/files/actions', () => {
 
     expect(executeCreateAction).toHaveBeenCalledWith(
       'newfile.ts',
+      vscode.Uri.file('/workspace'),
+    );
+  });
+
+  it('creates the folder selected in the input box', async () => {
+    const executeCreateFolderAction = vi.fn(async () => undefined);
+    const showInputBox = vi.fn(async () => 'components');
+
+    await createGraphViewFolder('src', {
+      workspaceFolder: { uri: vscode.Uri.file('/workspace') },
+      showInputBox,
+      executeCreateFolderAction,
+      showErrorMessage: vi.fn(),
+    });
+
+    expect(showInputBox).toHaveBeenCalledWith({
+      prompt: 'Enter folder name',
+      placeHolder: 'new-folder',
+      ignoreFocusOut: true,
+    });
+    expect(executeCreateFolderAction).toHaveBeenCalledWith(
+      'src/components',
       vscode.Uri.file('/workspace'),
     );
   });

--- a/packages/extension/tests/extension/graphView/provider/file/actions.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/file/actions.test.ts
@@ -27,6 +27,7 @@ describe('graphView/provider/file/actions', () => {
     vi.doUnmock('../../../../../src/extension/actions/deleteFiles');
     vi.doUnmock('../../../../../src/extension/actions/renameFile');
     vi.doUnmock('../../../../../src/extension/actions/createFile');
+    vi.doUnmock('../../../../../src/extension/actions/createFolder');
     vi.doUnmock('../../../../../src/extension/actions/toggleFavorite');
     vi.doUnmock('../../../../../src/extension/undoManager');
     vi.resetModules();
@@ -49,6 +50,7 @@ describe('graphView/provider/file/actions', () => {
       deleteFiles: vi.fn(async () => undefined),
       renameFile: vi.fn(async () => undefined),
       createFile: vi.fn(async () => undefined),
+      createFolder: vi.fn(async () => undefined),
       toggleFavorites: vi.fn(async () => undefined),
       getWorkspaceFolder: vi.fn(),
       showWarningMessage: vi.fn(),
@@ -57,6 +59,7 @@ describe('graphView/provider/file/actions', () => {
       createDeleteAction: vi.fn(() => createUndoableAction()),
       createRenameAction: vi.fn(() => createUndoableAction()),
       createCreateAction: vi.fn(() => createUndoableAction()),
+      createCreateFolderAction: vi.fn(() => createUndoableAction()),
       createToggleFavoriteAction: vi.fn(() => createUndoableAction()),
       executeUndoAction: vi.fn(async () => undefined),
     });
@@ -84,6 +87,7 @@ describe('graphView/provider/file/actions', () => {
     const createDeleteAction = vi.fn(() => createUndoableAction({ type: 'delete' }));
     const createRenameAction = vi.fn(() => createUndoableAction({ type: 'rename' }));
     const createCreateAction = vi.fn(() => createUndoableAction({ type: 'create' }));
+    const createCreateFolderAction = vi.fn(() => createUndoableAction({ type: 'create-folder' }));
     const deleteFiles = vi.fn(async (_paths, handlers) => {
       await handlers.executeDeleteAction(['src/app.ts'], { fsPath: '/workspace' });
     });
@@ -92,6 +96,9 @@ describe('graphView/provider/file/actions', () => {
     });
     const createFile = vi.fn(async (_directory, handlers) => {
       await handlers.executeCreateAction('src/new.ts', { fsPath: '/workspace' });
+    });
+    const createFolder = vi.fn(async (_directory, handlers) => {
+      await handlers.executeCreateFolderAction('src/components', { fsPath: '/workspace' });
     });
     const source = {
       _incrementVisitCount: vi.fn(async () => undefined),
@@ -106,6 +113,7 @@ describe('graphView/provider/file/actions', () => {
       deleteFiles,
       renameFile,
       createFile,
+      createFolder,
       toggleFavorites: vi.fn(async () => undefined),
       getWorkspaceFolder: vi.fn(() => ({
         uri: { fsPath: '/workspace' },
@@ -118,6 +126,7 @@ describe('graphView/provider/file/actions', () => {
       createDeleteAction,
       createRenameAction,
       createCreateAction,
+      createCreateFolderAction,
       createToggleFavoriteAction: vi.fn(() => createUndoableAction()),
       executeUndoAction,
     });
@@ -125,6 +134,7 @@ describe('graphView/provider/file/actions', () => {
     await methods._deleteFiles(['src/app.ts']);
     await methods._renameFile('src/app.ts');
     await methods._createFile('src');
+    await methods._createFolder('src');
 
     expect(createDeleteAction).toHaveBeenCalledWith(
       ['src/app.ts'],
@@ -142,7 +152,12 @@ describe('graphView/provider/file/actions', () => {
       { fsPath: '/workspace' },
       expect.any(Function),
     );
-    expect(executeUndoAction).toHaveBeenCalledTimes(3);
+    expect(createCreateFolderAction).toHaveBeenCalledWith(
+      'src/components',
+      { fsPath: '/workspace' },
+      expect.any(Function),
+    );
+    expect(executeUndoAction).toHaveBeenCalledTimes(4);
   });
 
   it('creates undoable favorite toggles that resync favorites after completion', async () => {
@@ -167,6 +182,7 @@ describe('graphView/provider/file/actions', () => {
       deleteFiles: vi.fn(async () => undefined),
       renameFile: vi.fn(async () => undefined),
       createFile: vi.fn(async () => undefined),
+      createFolder: vi.fn(async () => undefined),
       toggleFavorites,
       getWorkspaceFolder: vi.fn(),
       showWarningMessage: vi.fn(),
@@ -175,6 +191,7 @@ describe('graphView/provider/file/actions', () => {
       createDeleteAction: vi.fn(() => createUndoableAction()),
       createRenameAction: vi.fn(() => createUndoableAction()),
       createCreateAction: vi.fn(() => createUndoableAction()),
+      createCreateFolderAction: vi.fn(() => createUndoableAction()),
       createToggleFavoriteAction,
       executeUndoAction,
     });
@@ -269,6 +286,23 @@ describe('graphView/provider/file/actions', () => {
     expect(source._analyzeAndSendData).toHaveBeenCalledOnce();
   });
 
+  it('uses vscode input and error defaults for create folder actions', async () => {
+    const { source, methods, showInputBox, showErrorMessage, CreateFolderAction, execute } =
+      await createDefaultDependencyHarness();
+
+    await methods._createFolder('src');
+
+    expect(showInputBox).toHaveBeenCalledWith({ prompt: 'Create folder' });
+    expect(showErrorMessage).toHaveBeenCalledWith('create folder failed');
+    expect(CreateFolderAction).toHaveBeenCalledWith(
+      'src/components',
+      { fsPath: '/workspace' },
+      expect.any(Function),
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(source._analyzeAndSendData).toHaveBeenCalledOnce();
+  });
+
   it('uses the undo manager default for favorite toggles', async () => {
     const { source, methods, ToggleFavoriteAction, execute } = await createDefaultDependencyHarness();
 
@@ -327,6 +361,17 @@ async function createDefaultDependencyHarness(
     await handlers.executeCreateAction('src/new.ts', { fsPath: '/workspace' });
     handlers.showErrorMessage('create failed');
   });
+  const createFolder = vi.fn(async (_directory: string, handlers: {
+    workspaceFolder: unknown;
+    showInputBox(options: { prompt: string }): PromiseLike<string | undefined>;
+    executeCreateFolderAction(folderPath: string, workspaceFolderUri: { fsPath: string }): Promise<void>;
+    showErrorMessage(message: string): void;
+  }) => {
+    expect(handlers.workspaceFolder).toEqual(workspaceFolder);
+    await handlers.showInputBox({ prompt: 'Create folder' });
+    await handlers.executeCreateFolderAction('src/components', { fsPath: '/workspace' });
+    handlers.showErrorMessage('create folder failed');
+  });
   const toggleFavorites = vi.fn(async (_paths: string[], handlers: {
     executeToggleFavoritesAction(paths: string[]): Promise<void>;
   }) => {
@@ -373,6 +418,17 @@ async function createDefaultDependencyHarness(
     this.undo = vi.fn(async () => undefined);
     this.analyzeAndSendData = analyzeAndSendData;
   });
+  const CreateFolderAction = vi.fn(function (
+    this: MockUndoableAction,
+    _folderPath: string,
+    _workspaceFolderUri: { fsPath: string },
+    analyzeAndSendData: () => Promise<void>,
+  ) {
+    Object.defineProperty(this, 'description', { value: 'create folder', configurable: true });
+    this.execute = vi.fn(async () => undefined);
+    this.undo = vi.fn(async () => undefined);
+    this.analyzeAndSendData = analyzeAndSendData;
+  });
   const ToggleFavoriteAction = vi.fn(function (
     this: MockUndoableAction,
     _paths: string[],
@@ -401,6 +457,7 @@ async function createDefaultDependencyHarness(
   }));
   vi.doMock('../../../../../src/extension/graphView/files/actions', () => ({
     createGraphViewFile: createFile,
+    createGraphViewFolder: createFolder,
     deleteGraphViewFiles: deleteFiles,
   }));
   vi.doMock('../../../../../src/extension/graphView/files/rename', () => ({
@@ -417,6 +474,9 @@ async function createDefaultDependencyHarness(
   }));
   vi.doMock('../../../../../src/extension/actions/createFile', () => ({
     CreateFileAction,
+  }));
+  vi.doMock('../../../../../src/extension/actions/createFolder', () => ({
+    CreateFolderAction,
   }));
   vi.doMock('../../../../../src/extension/actions/toggleFavorite', () => ({
     ToggleFavoriteAction,
@@ -450,6 +510,7 @@ async function createDefaultDependencyHarness(
     DeleteFilesAction,
     RenameFileAction,
     CreateFileAction,
+    CreateFolderAction,
     ToggleFavoriteAction,
   };
 }

--- a/packages/extension/tests/extension/graphView/provider/source/delegates/fileTimeline.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/source/delegates/fileTimeline.test.ts
@@ -15,6 +15,7 @@ describe('source/delegates/fileTimeline', () => {
     await delegates._deleteFiles(['src/app.ts']);
     await delegates._renameFile('src/app.ts');
     await delegates._createFile('src');
+    await delegates._createFolder('src');
     delegates._toggleFavorites(['src/app.ts']);
     delegates._setFocusedFile('src/app.ts');
     expect(delegates._getFocusedFile!()).toBe('src/focused.ts');
@@ -37,6 +38,7 @@ describe('source/delegates/fileTimeline', () => {
     expect(owner._fileActionMethods._deleteFiles).toHaveBeenCalledWith(['src/app.ts']);
     expect(owner._fileActionMethods._renameFile).toHaveBeenCalledWith('src/app.ts');
     expect(owner._fileActionMethods._createFile).toHaveBeenCalledWith('src');
+    expect(owner._fileActionMethods._createFolder).toHaveBeenCalledWith('src');
     expect(owner._fileActionMethods._toggleFavorites).toHaveBeenCalledWith(['src/app.ts']);
     expect(owner._viewSelectionMethods.setFocusedFile).toHaveBeenCalledWith('src/app.ts');
     expect(owner._fileVisitMethods._getFileInfo).toHaveBeenCalledWith('src/app.ts');

--- a/packages/extension/tests/extension/graphView/provider/source/fakes.ts
+++ b/packages/extension/tests/extension/graphView/provider/source/fakes.ts
@@ -27,6 +27,7 @@ export function createMethodSourceOwnerStub(): GraphViewProviderMethodSourceOwne
     _deleteFiles: vi.fn(async () => undefined),
     _renameFile: vi.fn(async () => undefined),
     _createFile: vi.fn(async () => undefined),
+    _createFolder: vi.fn(async () => undefined),
     _toggleFavorites: vi.fn(),
   };
   const fileVisitMethods = {

--- a/packages/extension/tests/extension/graphView/webview/dispatch/context.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/context.ts
@@ -10,6 +10,7 @@ export function createPrimaryMessageContext(
   const context = {
     getTimelineActive: vi.fn(() => false),
     getCurrentCommitSha: vi.fn(() => undefined),
+    getCanMutateGraphRevision: vi.fn(() => true),
     getUserGroups: vi.fn(() => []),
     getDisabledPlugins: vi.fn(() => new Set<string>()),
     getFilterPatterns: vi.fn(() => []),
@@ -25,6 +26,7 @@ export function createPrimaryMessageContext(
     deleteFiles: vi.fn(() => Promise.resolve()),
     renameFile: vi.fn(() => Promise.resolve()),
     createFile: vi.fn(() => Promise.resolve()),
+    createFolder: vi.fn(() => Promise.resolve()),
     toggleFavorites: vi.fn(() => Promise.resolve()),
     addToExclude: vi.fn(() => Promise.resolve()),
     analyzeAndSendData: vi.fn(() => Promise.resolve()),

--- a/packages/extension/tests/extension/graphView/webview/dispatch/primary/legendState.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/primary/legendState.test.ts
@@ -13,6 +13,7 @@ function createContext(
   const context = {
     getTimelineActive: vi.fn(() => false),
     getCurrentCommitSha: vi.fn(() => undefined),
+    getCanMutateGraphRevision: vi.fn(() => true),
     getUserGroups: vi.fn(() => []),
     getDisabledPlugins: vi.fn(() => new Set<string>()),
     getFilterPatterns: vi.fn(() => []),
@@ -29,6 +30,7 @@ function createContext(
     deleteFiles: vi.fn(() => Promise.resolve()),
     renameFile: vi.fn(() => Promise.resolve()),
     createFile: vi.fn(() => Promise.resolve()),
+    createFolder: vi.fn(() => Promise.resolve()),
     toggleFavorites: vi.fn(() => Promise.resolve()),
     addToExclude: vi.fn(() => Promise.resolve()),
     analyzeAndSendData: vi.fn(() => Promise.resolve()),

--- a/packages/extension/tests/extension/graphView/webview/dispatch/primary/nodeFile.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/primary/nodeFile.test.ts
@@ -12,6 +12,7 @@ function createContext(
   const context = {
     getTimelineActive: vi.fn(() => false),
     getCurrentCommitSha: vi.fn(() => undefined),
+    getCanMutateGraphRevision: vi.fn(() => true),
     getUserGroups: vi.fn(() => []),
     getDisabledPlugins: vi.fn(() => new Set<string>()),
     getFilterPatterns: vi.fn(() => []),
@@ -29,6 +30,7 @@ function createContext(
     deleteFiles: vi.fn(() => Promise.resolve()),
     renameFile: vi.fn(() => Promise.resolve()),
     createFile: vi.fn(() => Promise.resolve()),
+    createFolder: vi.fn(() => Promise.resolve()),
     toggleFavorites: vi.fn(() => Promise.resolve()),
     addToExclude: vi.fn(() => Promise.resolve()),
     indexAndSendData: vi.fn(() => Promise.resolve()),
@@ -83,11 +85,13 @@ describe('createGraphViewPrimaryNodeFileHandlers', () => {
     const handlers = createGraphViewPrimaryNodeFileHandlers(context);
 
     expect(handlers.timelineActive).toBe(true);
+    expect(handlers.canMutateGraphRevision).toBe(true);
     expect(handlers.currentCommitSha).toBe('abc123');
     expect(handlers.openSelectedNode).toBe(context.openSelectedNode);
     expect(handlers.setFocusedFile).toBe(context.setFocusedFile);
     expect(handlers.previewFileAtCommit).toBe(context.previewFileAtCommit);
     expect(handlers.getFileInfo).toBe(context.getFileInfo);
+    expect(handlers.createFolder).toBe(context.createFolder);
     expect(handlers.indexGraph).toBeDefined();
     expect(handlers.refreshGraph).toBeDefined();
   });

--- a/packages/extension/tests/extension/graphView/webview/dispatch/primary/settingsState.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/primary/settingsState.test.ts
@@ -10,6 +10,7 @@ function createContext(
   const context = {
     getTimelineActive: vi.fn(() => false),
     getCurrentCommitSha: vi.fn(() => undefined),
+    getCanMutateGraphRevision: vi.fn(() => true),
     getUserGroups: vi.fn(() => []),
     getDisabledPlugins: vi.fn(() => new Set<string>()),
     getFilterPatterns: vi.fn(() => []),
@@ -25,6 +26,7 @@ function createContext(
     deleteFiles: vi.fn(() => Promise.resolve()),
     renameFile: vi.fn(() => Promise.resolve()),
     createFile: vi.fn(() => Promise.resolve()),
+    createFolder: vi.fn(() => Promise.resolve()),
     toggleFavorites: vi.fn(() => Promise.resolve()),
     addToExclude: vi.fn(() => Promise.resolve()),
     analyzeAndSendData: vi.fn(() => Promise.resolve()),

--- a/packages/extension/tests/extension/graphView/webview/messages/listener.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/messages/listener.test.ts
@@ -14,6 +14,7 @@ function createContext(
   const context = {
     getTimelineActive: vi.fn(() => false),
     getCurrentCommitSha: vi.fn(() => undefined),
+    getCanMutateGraphRevision: vi.fn(() => true),
     getUserGroups: vi.fn(() => []),
     getDisabledPlugins: vi.fn(() => new Set<string>()),
     getFilterPatterns: vi.fn(() => []),
@@ -30,6 +31,7 @@ function createContext(
     deleteFiles: vi.fn(() => Promise.resolve()),
     renameFile: vi.fn(() => Promise.resolve()),
     createFile: vi.fn(() => Promise.resolve()),
+    createFolder: vi.fn(() => Promise.resolve()),
     toggleFavorites: vi.fn(() => Promise.resolve()),
     addToExclude: vi.fn(() => Promise.resolve()),
     analyzeAndSendData: vi.fn(() => Promise.resolve()),

--- a/packages/extension/tests/extension/graphView/webview/nodeFile/edit.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/nodeFile/edit.test.ts
@@ -9,9 +9,11 @@ function createHandlers(
 ): GraphViewNodeFileEditHandlers {
   return {
     timelineActive: false,
+    canMutateGraphRevision: true,
     deleteFiles: vi.fn(() => Promise.resolve()),
     renameFile: vi.fn(() => Promise.resolve()),
     createFile: vi.fn(() => Promise.resolve()),
+    createFolder: vi.fn(() => Promise.resolve()),
     toggleFavorites: vi.fn(() => Promise.resolve()),
     addToExclude: vi.fn(() => Promise.resolve()),
     ...overrides,
@@ -30,8 +32,11 @@ describe('graph view node/file edit message', () => {
     expect(handlers.deleteFiles).toHaveBeenCalledWith(['src/app.ts']);
   });
 
-  it('skips deletes while timeline mode is active', async () => {
-    const handlers = createHandlers({ timelineActive: true });
+  it('skips deletes when the graph revision is not mutable', async () => {
+    const handlers = createHandlers({
+      timelineActive: true,
+      canMutateGraphRevision: false,
+    });
 
     await applyNodeFileEditMessage(
       { type: 'DELETE_FILES', payload: { paths: ['src/app.ts'] } },
@@ -63,6 +68,31 @@ describe('graph view node/file edit message', () => {
     expect(handlers.createFile).toHaveBeenCalledWith('src');
   });
 
+  it('creates folders outside timeline mode', async () => {
+    const handlers = createHandlers();
+
+    await expect(applyNodeFileEditMessage(
+      { type: 'CREATE_FOLDER', payload: { directory: 'src' } },
+      handlers,
+    )).resolves.toBe(true);
+
+    expect(handlers.createFolder).toHaveBeenCalledWith('src');
+  });
+
+  it('creates folders in timeline mode when the graph revision is mutable', async () => {
+    const handlers = createHandlers({
+      timelineActive: true,
+      canMutateGraphRevision: true,
+    });
+
+    await expect(applyNodeFileEditMessage(
+      { type: 'CREATE_FOLDER', payload: { directory: 'src' } },
+      handlers,
+    )).resolves.toBe(true);
+
+    expect(handlers.createFolder).toHaveBeenCalledWith('src');
+  });
+
   it('toggles favorites even in timeline mode', async () => {
     const handlers = createHandlers({ timelineActive: true });
 
@@ -85,8 +115,11 @@ describe('graph view node/file edit message', () => {
     expect(handlers.addToExclude).toHaveBeenCalledWith(['dist/**']);
   });
 
-  it('skips exclude updates while timeline mode is active', async () => {
-    const handlers = createHandlers({ timelineActive: true });
+  it('skips exclude updates when the graph revision is not mutable', async () => {
+    const handlers = createHandlers({
+      timelineActive: true,
+      canMutateGraphRevision: false,
+    });
 
     await applyNodeFileEditMessage(
       { type: 'ADD_TO_EXCLUDE', payload: { patterns: ['dist/**'] } },

--- a/packages/extension/tests/extension/graphView/webview/nodeFile/router.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/nodeFile/router.test.ts
@@ -9,6 +9,7 @@ function createHandlers(
 ): GraphViewNodeFileHandlers {
   return {
     timelineActive: false,
+    canMutateGraphRevision: true,
     currentCommitSha: undefined,
     setFocusedFile: vi.fn(),
     openSelectedNode: vi.fn(() => Promise.resolve()),
@@ -20,6 +21,7 @@ function createHandlers(
     deleteFiles: vi.fn(() => Promise.resolve()),
     renameFile: vi.fn(() => Promise.resolve()),
     createFile: vi.fn(() => Promise.resolve()),
+    createFolder: vi.fn(() => Promise.resolve()),
     toggleFavorites: vi.fn(() => Promise.resolve()),
     addToExclude: vi.fn(() => Promise.resolve()),
     indexGraph: vi.fn(() => Promise.resolve()),
@@ -33,6 +35,7 @@ describe('graph view node/file router', () => {
   it('opens files at the current commit when timeline mode is active', async () => {
     const handlers = createHandlers({
       timelineActive: true,
+      canMutateGraphRevision: false,
       currentCommitSha: 'abc123',
     });
 
@@ -50,6 +53,7 @@ describe('graph view node/file router', () => {
   it('skips destructive file edits while timeline mode is active', async () => {
     const handlers = createHandlers({
       timelineActive: true,
+      canMutateGraphRevision: false,
       currentCommitSha: 'abc123',
     });
 
@@ -73,6 +77,12 @@ describe('graph view node/file router', () => {
     ).resolves.toBe(true);
     await expect(
       applyNodeFileMessage(
+        { type: 'CREATE_FOLDER', payload: { directory: 'src' } },
+        handlers,
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      applyNodeFileMessage(
         { type: 'ADD_TO_EXCLUDE', payload: { patterns: ['dist/**'] } },
         handlers,
       ),
@@ -81,6 +91,7 @@ describe('graph view node/file router', () => {
     expect(handlers.deleteFiles).not.toHaveBeenCalled();
     expect(handlers.renameFile).not.toHaveBeenCalled();
     expect(handlers.createFile).not.toHaveBeenCalled();
+    expect(handlers.createFolder).not.toHaveBeenCalled();
     expect(handlers.addToExclude).not.toHaveBeenCalled();
   });
 

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/listener.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/listener.test.ts
@@ -318,6 +318,7 @@ describe('graph view provider listener bridge', () => {
     expect(context.workspaceFolder).toEqual(workspaceFolders[0]);
     expect(context.getTimelineActive()).toBe(false);
     expect(context.getCurrentCommitSha()).toBeUndefined();
+    expect(context.getCanMutateGraphRevision()).toBe(true);
     expect(context.getUserGroups()).toEqual([]);
     expect(context.getFilterPatterns()).toEqual(['dist/**']);
     expect(context.findNode('node-1')).toEqual(source._graphData.nodes[0]);

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/primaryActions.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/primaryActions.test.ts
@@ -29,6 +29,7 @@ describe('graph view provider listener primary actions', () => {
     await actions.deleteFiles(['src/app.ts']);
     await actions.renameFile('src/app.ts');
     await actions.createFile('src');
+    await actions.createFolder('src');
     await actions.toggleFavorites(['src/app.ts']);
     await actions.addToExclude(['dist/**']);
     await actions.getFileInfo('src/app.ts');
@@ -43,6 +44,7 @@ describe('graph view provider listener primary actions', () => {
     expect(source._deleteFiles).toHaveBeenCalledWith(['src/app.ts']);
     expect(source._renameFile).toHaveBeenCalledWith('src/app.ts');
     expect(source._createFile).toHaveBeenCalledWith('src');
+    expect(source._createFolder).toHaveBeenCalledWith('src');
     expect(source._toggleFavorites).toHaveBeenCalledWith(['src/app.ts']);
     expect(source._addToExclude).toHaveBeenCalledWith(['dist/**']);
     expect(source._getFileInfo).toHaveBeenCalledWith('src/app.ts');
@@ -307,6 +309,7 @@ function createSource(overrides: Record<string, unknown> = {}) {
     _deleteFiles: vi.fn(() => Promise.resolve()),
     _renameFile: vi.fn(() => Promise.resolve()),
     _createFile: vi.fn(() => Promise.resolve()),
+    _createFolder: vi.fn(() => Promise.resolve()),
     _toggleFavorites: vi.fn(() => Promise.resolve()),
     _addToExclude: vi.fn(() => Promise.resolve()),
     _loadAndSendData: vi.fn(() => Promise.resolve()),

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/primaryActions.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/primaryActions.test.ts
@@ -50,6 +50,17 @@ describe('graph view provider listener primary actions', () => {
     expect(source._getFileInfo).toHaveBeenCalledWith('src/app.ts');
   });
 
+  it('maps the synthetic root folder node to the workspace root for creation actions', async () => {
+    const source = createSource();
+    const actions = createActions(source);
+
+    await actions.createFile('(root)');
+    await actions.createFolder('(root)');
+
+    expect(source._createFile).toHaveBeenCalledWith('.');
+    expect(source._createFolder).toHaveBeenCalledWith('.');
+  });
+
   it('delegates provider state and timeline actions', async () => {
     const source = createSource();
     const actions = createActions(source);

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/readContext.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/readContext.test.ts
@@ -22,6 +22,12 @@ describe('graph view provider listener read context', () => {
         edges: [{ id: 'edge-1', from: 'src/app.ts', to: 'src/lib.ts' , kind: 'import', sources: [] }],
       } satisfies IGraphData,
       _analyzer: analyzer,
+      _gitAnalyzer: {
+        getCachedCommitList: () => [
+          { sha: 'old', timestamp: 1, message: 'old', author: 'Ada', parents: [] },
+          { sha: 'abc123', timestamp: 2, message: 'head', author: 'Ada', parents: ['old'] },
+        ],
+      },
       _viewContext: { activePlugins: new Set(['plugin.enabled']), focusedFile: 'src/app.ts' },
     };
     const dependencies = {
@@ -37,6 +43,7 @@ describe('graph view provider listener read context', () => {
 
     expect(context.getTimelineActive()).toBe(true);
     expect(context.getCurrentCommitSha()).toBe('abc123');
+    expect(context.getCanMutateGraphRevision()).toBe(true);
     expect(context.getUserGroups()).toEqual(source._userGroups);
     expect(context.getDepthMode()).toBe(true);
     expect(context.getDisabledPlugins()).toBe(source._disabledPlugins);
@@ -71,15 +78,42 @@ describe('graph view provider listener read context', () => {
         _filterPatterns: [],
         _graphData: { nodes: [], edges: [] } satisfies IGraphData,
         _analyzer: undefined,
+        _gitAnalyzer: undefined,
         _viewContext: { activePlugins: new Set(), focusedFile: undefined },
       } as never,
       { workspace: { workspaceFolders: undefined } } as never,
     );
 
     expect(context.workspaceFolder).toBeUndefined();
+    expect(context.getCanMutateGraphRevision()).toBe(true);
     expect(context.getAnalyzer()).toBeUndefined();
     expect(context.getFocusedFile()).toBeUndefined();
     expect(context.findNode('missing')).toBeUndefined();
     expect(context.findEdge('missing')).toBeUndefined();
+  });
+
+  it('treats historical timeline snapshots as non-mutable', () => {
+    const context = createGraphViewProviderMessageReadContext(
+      {
+        _timelineActive: true,
+        _currentCommitSha: 'old',
+        _userGroups: [],
+        _depthMode: false,
+        _disabledPlugins: new Set(),
+        _filterPatterns: [],
+        _graphData: { nodes: [], edges: [] } satisfies IGraphData,
+        _analyzer: undefined,
+        _gitAnalyzer: {
+          getCachedCommitList: () => [
+            { sha: 'old', timestamp: 1, message: 'old', author: 'Ada', parents: [] },
+            { sha: 'head', timestamp: 2, message: 'head', author: 'Ada', parents: ['old'] },
+          ],
+        },
+        _viewContext: { activePlugins: new Set(), focusedFile: undefined },
+      } as never,
+      { workspace: { workspaceFolders: undefined } } as never,
+    );
+
+    expect(context.getCanMutateGraphRevision()).toBe(false);
   });
 });

--- a/packages/extension/tests/extension/pipeline/analysis/analyze.test.ts
+++ b/packages/extension/tests/extension/pipeline/analysis/analyze.test.ts
@@ -30,6 +30,7 @@ function createSource() {
       edges: [{ id: 'src/index.ts->src/utils.ts#import', from: 'src/index.ts', to: 'src/utils.ts' , kind: 'import', sources: [] }],
     } satisfies IGraphData)),
     _eventBus: { emit },
+    _lastDiscoveredDirectories: [] as string[],
     _lastDiscoveredFiles: [] as IDiscoveredFile[],
     _lastFileAnalysis: new Map(),
     _lastFileConnections: new Map<string, IProjectedConnection[]>(),
@@ -42,6 +43,7 @@ function createSource() {
 function createDependencies() {
   return {
     discover: vi.fn(async () => ({
+      directories: [] as string[],
       durationMs: 3,
       files: [] as IDiscoveredFile[],
       limitReached: false,
@@ -110,6 +112,7 @@ describe('pipeline/analysis/analyze', () => {
     };
 
     dependencies.discover.mockResolvedValue({
+      directories: ['src/new-folder'],
       durationMs: 4,
       files,
       limitReached: false,
@@ -159,6 +162,7 @@ describe('pipeline/analysis/analyze', () => {
       new Set<string>(['plugin.python']),
     );
     expect(source._lastDiscoveredFiles).toEqual(files);
+    expect(source._lastDiscoveredDirectories).toEqual(['src/new-folder']);
     expect(source._lastFileAnalysis).toBe(fileAnalysis);
     expect(source._lastFileConnections).toBe(fileConnections);
     expect(source._lastWorkspaceRoot).toBe('/workspace');
@@ -193,6 +197,7 @@ describe('pipeline/analysis/analyze', () => {
     const dependencies = createDependencies();
 
     dependencies.discover.mockResolvedValue({
+      directories: [],
       durationMs: 5,
       files: [] as IDiscoveredFile[],
       limitReached: true,
@@ -213,6 +218,7 @@ describe('pipeline/analysis/analyze', () => {
     (dependencies as { sendProgress?: (progress: { phase: string; current: number; total: number }) => void }).sendProgress = undefined;
 
     dependencies.discover.mockResolvedValue({
+      directories: [],
       durationMs: 2,
       files: [] as IDiscoveredFile[],
       limitReached: false,

--- a/packages/extension/tests/extension/pipeline/analysis/state.test.ts
+++ b/packages/extension/tests/extension/pipeline/analysis/state.test.ts
@@ -60,6 +60,7 @@ describe('pipeline/analysis/state', () => {
           _buildGraphData: vi.fn(() => ({ nodes: [], edges: [] })),
           _lastFileAnalysis: new Map(),
           _lastFileConnections: new Map([['src/index.ts', []]]),
+          _lastDiscoveredDirectories: [],
           _lastWorkspaceRoot: '/workspace',
         },
         new Set(['plugin.python']),

--- a/packages/extension/tests/extension/pipeline/analysisSource.test.ts
+++ b/packages/extension/tests/extension/pipeline/analysisSource.test.ts
@@ -6,6 +6,7 @@ describe('pipeline/analysisSource', () => {
   it('adapts analyzer state and delegates for the analysis runner', async () => {
     const analyzer = {
       _eventBus: { emit: vi.fn() },
+      _lastDiscoveredDirectories: [],
       _lastDiscoveredFiles: [],
       _lastFileAnalysis: new Map(),
       _lastFileConnections: new Map(),
@@ -38,11 +39,13 @@ describe('pipeline/analysisSource', () => {
     ).toEqual({ nodes: [], edges: [] });
 
     source._lastDiscoveredFiles = files as never;
+    source._lastDiscoveredDirectories = ['src/new-folder'];
     source._lastFileAnalysis = new Map([['a.ts', { filePath: '/workspace/a.ts', relations: [] }]]);
     source._lastFileConnections = new Map([['b.ts', []]]);
     source._lastWorkspaceRoot = '/workspace';
 
     expect(analyzer._lastDiscoveredFiles).toEqual(files);
+    expect(analyzer._lastDiscoveredDirectories).toEqual(['src/new-folder']);
     expect(analyzer._lastFileAnalysis).toEqual(
       new Map([['a.ts', { filePath: '/workspace/a.ts', relations: [] }]]),
     );
@@ -54,6 +57,7 @@ describe('pipeline/analysisSource', () => {
     const analyzer = {
       _lastFileAnalysis: new Map([['a.ts', { filePath: '/workspace/a.ts', relations: [] }]]),
       _lastFileConnections: new Map([['a.ts', []]]),
+      _lastDiscoveredDirectories: ['src/new-folder'],
       _lastWorkspaceRoot: '/workspace',
       _buildGraphDataFromAnalysis: vi.fn(() => ({ nodes: [], edges: [] })),
       _buildGraphData: vi.fn(() => ({ nodes: [], edges: [] })),
@@ -65,6 +69,7 @@ describe('pipeline/analysisSource', () => {
       new Map([['a.ts', { filePath: '/workspace/a.ts', relations: [] }]]),
     );
     expect(source._lastFileConnections).toEqual(new Map([['a.ts', []]]));
+    expect(source._lastDiscoveredDirectories).toEqual(['src/new-folder']);
     expect(source._lastWorkspaceRoot).toBe('/workspace');
     expect(
       source._buildGraphDataFromAnalysis(

--- a/packages/extension/tests/extension/pipeline/graph/build.test.ts
+++ b/packages/extension/tests/extension/pipeline/graph/build.test.ts
@@ -32,6 +32,7 @@ describe('pipeline/graph', () => {
 
     expect(workspaceGraphDataModule.buildWorkspaceGraphData).toHaveBeenCalledWith({
       cacheFiles: {},
+      directoryPaths: [],
       disabledPlugins: new Set<string>(['plugin.python']),
       fileConnections: new Map([['src/index.ts', []]]),
       getPluginForFile: expect.any(Function),
@@ -53,6 +54,7 @@ describe('pipeline/graph', () => {
           _context: {
             workspaceState: createWorkspaceState({ 'src/index.ts': 1 }),
           },
+          _lastDiscoveredDirectories: ['src/new-folder'],
           _registry: { getPluginForFile: vi.fn() },
         } as never,
         new Map([['src/index.ts', []]]),
@@ -62,6 +64,15 @@ describe('pipeline/graph', () => {
       ),
     ).toEqual({ nodes: [], edges: [] });
 
-    expect(buildWorkspaceGraphDataSpy).toHaveBeenCalledOnce();
+    expect(buildWorkspaceGraphDataSpy).toHaveBeenCalledWith({
+      cacheFiles: { 'src/index.ts': { size: 5 } },
+      directoryPaths: ['src/new-folder'],
+      disabledPlugins: new Set(),
+      fileConnections: new Map([['src/index.ts', []]]),
+      getPluginForFile: expect.any(Function),
+      showOrphans: true,
+      visitCounts: { 'src/index.ts': 1 },
+      workspaceRoot: '/workspace',
+    });
   });
 });

--- a/packages/extension/tests/extension/pipeline/graph/data.test.ts
+++ b/packages/extension/tests/extension/pipeline/graph/data.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { IProjectedConnection, IPlugin } from '../../../../src/core/plugins/types/contracts';
-import { DEFAULT_NODE_COLOR } from '../../../../src/shared/fileColors';
+import { DEFAULT_FOLDER_NODE_COLOR, DEFAULT_NODE_COLOR } from '../../../../src/shared/fileColors';
 import { buildWorkspaceGraphData } from '../../../../src/extension/pipeline/graph/data';
 
 function createPlugin(id: string): IPlugin {
@@ -356,6 +356,39 @@ describe('pipeline/graph/data', () => {
             label: 'ES6 import',
           },
         ],
+      },
+    ]);
+  });
+
+  it('materializes discovered directories that have no file node descendants as folder nodes', () => {
+    const graph = buildWorkspaceGraphData({
+      cacheFiles: {
+        'src/app.ts': { size: 10 },
+      },
+      directoryPaths: ['src', 'src/new-folder'],
+      disabledPlugins: new Set(),
+      fileConnections: new Map<string, IProjectedConnection[]>([
+        ['src/app.ts', []],
+      ]),
+      showOrphans: true,
+      visitCounts: {},
+      workspaceRoot: '/workspace',
+      getPluginForFile: () => createPlugin('plugin.typescript'),
+    });
+
+    expect(graph.nodes).toEqual([
+      {
+        id: 'src/app.ts',
+        label: 'app.ts',
+        color: DEFAULT_NODE_COLOR,
+        fileSize: 10,
+        accessCount: 0,
+      },
+      {
+        id: 'src/new-folder',
+        label: 'new-folder',
+        color: DEFAULT_FOLDER_NODE_COLOR,
+        nodeType: 'folder',
       },
     ]);
   });

--- a/packages/extension/tests/extension/pipeline/service.refreshChangedFiles.test.ts
+++ b/packages/extension/tests/extension/pipeline/service.refreshChangedFiles.test.ts
@@ -260,4 +260,24 @@ describe('WorkspacePipeline refreshChangedFiles', () => {
       expect.any(Function),
     );
   });
+
+  it('invalidates discovered empty directories below a deleted directory path', () => {
+    const analyzer = new WorkspacePipeline(
+      createContext() as unknown as vscode.ExtensionContext,
+    );
+    const analyzerPrivate = analyzer as unknown as {
+      _lastDiscoveredDirectories: string[];
+    };
+
+    analyzerPrivate._lastDiscoveredDirectories = [
+      'src',
+      'src/keep',
+      'test',
+      'test/nested',
+    ];
+
+    analyzer.invalidateWorkspaceFiles(['/workspace/test']);
+
+    expect(analyzerPrivate._lastDiscoveredDirectories).toEqual(['src', 'src/keep']);
+  });
 });

--- a/packages/extension/tests/extension/pipeline/service/base/internal.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/base/internal.test.ts
@@ -130,7 +130,12 @@ class TestInternalBase extends WorkspacePipelineInternalBase {
     showOrphans: boolean,
     disabledPlugins?: Set<string>,
   ) {
-    return this._buildGraphData(fileConnections as never, workspaceRoot, showOrphans, disabledPlugins);
+    return this._buildGraphData(
+      fileConnections as never,
+      workspaceRoot,
+      showOrphans,
+      disabledPlugins,
+    );
   }
 
   public buildGraphDataFromAnalysis(
@@ -139,7 +144,16 @@ class TestInternalBase extends WorkspacePipelineInternalBase {
     showOrphans: boolean,
     disabledPlugins?: Set<string>,
   ) {
-    return this._buildGraphDataFromAnalysis(fileAnalysis as never, workspaceRoot, showOrphans, disabledPlugins);
+    return this._buildGraphDataFromAnalysis(
+      fileAnalysis as never,
+      workspaceRoot,
+      showOrphans,
+      disabledPlugins,
+    );
+  }
+
+  public setLastDiscoveredDirectories(directoryPaths: string[]): void {
+    this._lastDiscoveredDirectories = directoryPaths;
   }
 
   public getFileStat(filePath: string) {
@@ -294,6 +308,8 @@ describe('extension/pipeline/service/internalBase', () => {
     const fileConnections = new Map([['src/a.ts', [{ from: 'a', to: 'b' }]]]);
     const fileAnalysis = new Map([['src/a.ts', { filePath: 'src/a.ts' }]]);
     const disabledPlugins = new Set(['plugin.disabled']);
+    const discoveredDirectories = ['src/generated'];
+    source.setLastDiscoveredDirectories(discoveredDirectories);
 
     expect(
       source.buildGraphData(fileConnections, '/workspace', true, disabledPlugins),
@@ -309,6 +325,7 @@ describe('extension/pipeline/service/internalBase', () => {
       '/workspace',
       true,
       disabledPlugins,
+      discoveredDirectories,
     );
 
     expect(
@@ -330,6 +347,7 @@ describe('extension/pipeline/service/internalBase', () => {
       '/workspace',
       false,
       disabledPlugins,
+      discoveredDirectories,
     );
   });
 

--- a/packages/extension/tests/extension/pipeline/service/base/state.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/base/state.test.ts
@@ -47,12 +47,14 @@ describe('extension/pipeline/service/stateBase', () => {
     const state = new TestWorkspacePipelineState(createContext()) as TestWorkspacePipelineState & {
       _cache: unknown;
       _eventBus?: EventBus;
+      _lastDiscoveredDirectories: string[];
       _lastDiscoveredFiles: unknown[];
       _lastWorkspaceRoot: string;
     };
 
     expect(state.registry).toBeInstanceOf(PluginRegistry);
     expect(state.lastFileAnalysis).toEqual(new Map());
+    expect(state._lastDiscoveredDirectories).toEqual([]);
     expect(state._lastDiscoveredFiles).toEqual([]);
     expect(state._lastWorkspaceRoot).toBe('');
     expect(state.readStructuredAnalysisSnapshot()).toEqual({

--- a/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
@@ -96,9 +96,11 @@ describe('pipeline/service/discoveryFacade', () => {
   const discoveryState = (
     facade: TestDiscoveryFacade,
   ): {
+    _lastDiscoveredDirectories: string[];
     _lastDiscoveredFiles: IDiscoveredFile[];
     _lastWorkspaceRoot: string;
   } => facade as unknown as {
+    _lastDiscoveredDirectories: string[];
     _lastDiscoveredFiles: IDiscoveredFile[];
     _lastWorkspaceRoot: string;
   };
@@ -107,6 +109,7 @@ describe('pipeline/service/discoveryFacade', () => {
     vi.clearAllMocks();
     vi.mocked(createWorkspacePipelineDiscoveryDependencies).mockReturnValue('discovery-deps' as never);
     vi.mocked(discoverWorkspacePipelineFilesWithWarnings).mockResolvedValue({
+      directories: ['src/new-folder'],
       files: [
         { absolutePath: '/workspace/src/a.ts', relativePath: 'src/a.ts' },
         { absolutePath: '/workspace/src/b.ts', relativePath: 'src/b.ts' },
@@ -193,6 +196,7 @@ describe('pipeline/service/discoveryFacade', () => {
       { absolutePath: '/workspace/src/a.ts', relativePath: 'src/a.ts' },
       { absolutePath: '/workspace/src/b.ts', relativePath: 'src/b.ts' },
     ]);
+    expect(discoveryState(facade)._lastDiscoveredDirectories).toEqual(['src/new-folder']);
     expect(discoveryState(facade)._lastWorkspaceRoot).toBe('/workspace');
     expect(buildGraphData).toHaveBeenCalledWith(
       new Map([

--- a/packages/extension/tests/extension/pipeline/service/runtime/discovery.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/runtime/discovery.test.ts
@@ -21,6 +21,7 @@ describe('pipeline/service/discovery', () => {
   it('normalizes discovery results and falls back totalFound to the file count', async () => {
     const discovery = {
       discover: vi.fn(async () => ({
+        directories: ['src/new-folder'],
         durationMs: 12,
         files: [{ relativePath: 'src/a.ts' }],
         limitReached: false,
@@ -33,6 +34,7 @@ describe('pipeline/service/discovery', () => {
 
     expect(discovery.discover).toHaveBeenCalledWith({ workspaceRoot: '/workspace' });
     expect(result).toEqual({
+      directories: ['src/new-folder'],
       durationMs: 12,
       files: [{ relativePath: 'src/a.ts' }],
       limitReached: false,

--- a/packages/extension/tests/extension/workspaceFiles/fileSystemListeners.test.ts
+++ b/packages/extension/tests/extension/workspaceFiles/fileSystemListeners.test.ts
@@ -181,12 +181,12 @@ describe('registerFileWatcher', () => {
     vi.clearAllMocks();
   });
 
-  it('adds three subscriptions (create, delete, watcher itself)', () => {
+  it('adds watcher and workspace file-operation subscriptions', () => {
     const context = makeContext();
     const provider = makeProvider();
 
     registerFileWatcher(context as unknown as vscode.ExtensionContext, provider as never);
 
-    expect(context.subscriptions.length).toBe(3);
+    expect(context.subscriptions.length).toBe(6);
   });
 });

--- a/packages/extension/tests/extension/workspaceFiles/fileWatcherSetup.test.ts
+++ b/packages/extension/tests/extension/workspaceFiles/fileWatcherSetup.test.ts
@@ -419,13 +419,13 @@ describe('registerFileWatcher', () => {
     vi.useRealTimers();
   });
 
-  it('adds three subscriptions (create, delete, watcher)', () => {
+  it('adds file watcher and workspace file-operation subscriptions', () => {
     const context = makeContext();
     const provider = makeProvider();
 
     registerFileWatcher(context as unknown as vscode.ExtensionContext, provider as never);
 
-    expect(context.subscriptions.length).toBe(3);
+    expect(context.subscriptions.length).toBe(6);
   });
 
   it('refreshes graph and emits event on file creation', () => {
@@ -482,6 +482,29 @@ describe('registerFileWatcher', () => {
     expect(provider.refresh).toHaveBeenCalledOnce();
     expect(provider.emitEvent).toHaveBeenCalledWith('workspace:fileDeleted', {
       filePath: '/workspace/deleted-file.ts',
+    });
+  });
+
+  it('refreshes graph and emits events when a folder is deleted through the workspace explorer', () => {
+    vi.useFakeTimers();
+    const context = makeContext();
+    const provider = makeProvider();
+
+    registerFileWatcher(context as unknown as vscode.ExtensionContext, provider as never);
+
+    const mock = vscode.workspace.onDidDeleteFiles as unknown as {
+      mock: { calls: unknown[][] };
+    };
+    const listener = mock.mock.calls[0]?.[0] as (event: {
+      files: Array<{ fsPath: string }>;
+    }) => void;
+
+    listener({ files: [{ fsPath: '/workspace/test' }] });
+    vi.advanceTimersByTime(500);
+
+    expect(provider.refresh).toHaveBeenCalledOnce();
+    expect(provider.emitEvent).toHaveBeenCalledWith('workspace:fileDeleted', {
+      filePath: '/workspace/test',
     });
   });
 

--- a/packages/extension/tests/extension/workspaceFiles/refresh.test.ts
+++ b/packages/extension/tests/extension/workspaceFiles/refresh.test.ts
@@ -171,7 +171,7 @@ describe('workspaceFiles/refresh', () => {
     registerSaveHandler(context as never, provider as never);
     registerFileWatcher(context as never, provider as never);
 
-    expect(context.subscriptions).toHaveLength(4);
+    expect(context.subscriptions).toHaveLength(7);
     expect(vscode.workspace.createFileSystemWatcher).toHaveBeenCalledWith('**/*');
   });
 });

--- a/packages/extension/tests/shared/visibleGraph/derive.test.ts
+++ b/packages/extension/tests/shared/visibleGraph/derive.test.ts
@@ -203,6 +203,32 @@ describe('shared/visibleGraph/deriveVisibleGraph', () => {
     });
   });
 
+  it('connects discovered empty folder nodes through structural projection', () => {
+    const result = deriveVisibleGraph(
+      {
+        nodes: [
+          node('src/app.ts'),
+          node('src/new-folder', 'folder'),
+        ],
+        edges: [],
+      },
+      {
+        scope: {
+          nodes: [
+            { type: 'file', enabled: true },
+            { type: 'folder', enabled: true },
+          ],
+          edges: [{ type: STRUCTURAL_NESTS_EDGE_KIND, enabled: true }],
+        },
+      },
+    );
+
+    expect(ids(result.graphData)).toEqual({
+      nodes: ['src/app.ts', 'src/new-folder', 'src'],
+      edges: ['src->src/new-folder#nests', 'src->src/app.ts#nests'],
+    });
+  });
+
   it('returns regex errors from search without throwing', () => {
     const result = deriveVisibleGraph(
       {

--- a/packages/extension/tests/webview/graph/contextActions/builders.test.ts
+++ b/packages/extension/tests/webview/graph/contextActions/builders.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createClipboardEffects,
   createCreateFileEffects,
+  createCreateFolderEffects,
   createOptionalClipboardEffects,
   createOptionalSinglePathMessageEffects,
   createPathListMessageEffects,
@@ -15,6 +16,7 @@ import {
   createOpenFileEffects,
   createPatternPromptEffects,
 } from '../../../../src/webview/components/graph/contextActions/prompts';
+import { getBuiltInContextActionEffects } from '../../../../src/webview/components/graph/contextActions/effects';
 
 describe('graph/contextActions/builders', () => {
   it('builds open-file and focus effects', () => {
@@ -59,6 +61,25 @@ describe('graph/contextActions/builders', () => {
     expect(createRefreshEffects()).toEqual([{ kind: 'postMessage', message: { type: 'REFRESH_GRAPH' } }]);
     expect(createFitViewEffects()).toEqual([{ kind: 'fitView' }]);
     expect(createCreateFileEffects()).toEqual([
+      { kind: 'postMessage', message: { type: 'CREATE_FILE', payload: { directory: '.' } } },
+    ]);
+  });
+
+  it('builds target-aware file and folder creation effects', () => {
+    expect(createCreateFileEffects('src')).toEqual([
+      { kind: 'postMessage', message: { type: 'CREATE_FILE', payload: { directory: 'src' } } },
+    ]);
+    expect(createCreateFolderEffects('src')).toEqual([
+      { kind: 'postMessage', message: { type: 'CREATE_FOLDER', payload: { directory: 'src' } } },
+    ]);
+
+    expect(getBuiltInContextActionEffects('createFile', ['src'])).toEqual([
+      { kind: 'postMessage', message: { type: 'CREATE_FILE', payload: { directory: 'src' } } },
+    ]);
+    expect(getBuiltInContextActionEffects('createFolder', ['src'])).toEqual([
+      { kind: 'postMessage', message: { type: 'CREATE_FOLDER', payload: { directory: 'src' } } },
+    ]);
+    expect(getBuiltInContextActionEffects('createFile', [])).toEqual([
       { kind: 'postMessage', message: { type: 'CREATE_FILE', payload: { directory: '.' } } },
     ]);
   });

--- a/packages/extension/tests/webview/graph/contextActions/builders.test.ts
+++ b/packages/extension/tests/webview/graph/contextActions/builders.test.ts
@@ -83,4 +83,13 @@ describe('graph/contextActions/builders', () => {
       { kind: 'postMessage', message: { type: 'CREATE_FILE', payload: { directory: '.' } } },
     ]);
   });
+
+  it('maps the synthetic root folder node to the workspace root for creation effects', () => {
+    expect(getBuiltInContextActionEffects('createFile', ['(root)'])).toEqual([
+      { kind: 'postMessage', message: { type: 'CREATE_FILE', payload: { directory: '.' } } },
+    ]);
+    expect(getBuiltInContextActionEffects('createFolder', ['(root)'])).toEqual([
+      { kind: 'postMessage', message: { type: 'CREATE_FOLDER', payload: { directory: '.' } } },
+    ]);
+  });
 });

--- a/packages/extension/tests/webview/graph/contextActions/effects.test.ts
+++ b/packages/extension/tests/webview/graph/contextActions/effects.test.ts
@@ -51,6 +51,15 @@ describe('graph/contextActions/effects', () => {
     expect(getBuiltInContextActionEffects('copyEdgeSource', [])).toEqual([]);
   });
 
+  it('opens edge source and target endpoints independently', () => {
+    expect(getBuiltInContextActionEffects('openEdgeSource', ['from.ts', 'to.ts'])).toEqual([
+      { kind: 'openFile', path: 'from.ts' },
+    ]);
+    expect(getBuiltInContextActionEffects('openEdgeTarget', ['from.ts', 'to.ts'])).toEqual([
+      { kind: 'openFile', path: 'to.ts' },
+    ]);
+  });
+
   it('copies edge target only when a second path exists', () => {
     expect(getBuiltInContextActionEffects('copyEdgeTarget', ['from.ts'])).toEqual([]);
     expect(getBuiltInContextActionEffects('copyEdgeTarget', ['from.ts', 'to.ts'])).toEqual([

--- a/packages/extension/tests/webview/graph/contextMenu/background/entries.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/background/entries.test.ts
@@ -13,15 +13,17 @@ function separatorCount(entries: GraphContextMenuEntry[]): number {
 }
 
 describe('buildBackgroundEntries', () => {
-  it('includes New File and separator when timeline is not active', () => {
+  it('includes New File, New Folder, and separator when timeline is not active', () => {
     const entries = buildBackgroundEntries(false);
     expect(itemLabels(entries)).toContain('New File...');
+    expect(itemLabels(entries)).toContain('New Folder...');
     expect(separatorCount(entries)).toBe(1);
   });
 
-  it('omits New File and separator when timeline is active', () => {
+  it('omits New File, New Folder, and separator when timeline is active', () => {
     const entries = buildBackgroundEntries(true);
     expect(itemLabels(entries)).not.toContain('New File...');
+    expect(itemLabels(entries)).not.toContain('New Folder...');
     expect(separatorCount(entries)).toBe(0);
   });
 
@@ -35,9 +37,9 @@ describe('buildBackgroundEntries', () => {
     expect(itemLabels(buildBackgroundEntries(true))).toContain('Fit All Nodes');
   });
 
-  it('returns 4 entries when timeline is not active', () => {
+  it('returns 5 entries when timeline is not active', () => {
     const entries = buildBackgroundEntries(false);
-    expect(entries).toHaveLength(4);
+    expect(entries).toHaveLength(5);
   });
 
   it('returns 2 entries when timeline is active', () => {

--- a/packages/extension/tests/webview/graph/contextMenu/background/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/background/view.test.tsx
@@ -242,6 +242,29 @@ describe('Graph context menu (background)', () => {
     expect(createMsg!.payload.directory).toBe('.');
   });
 
+  it('sends CREATE_FOLDER message when clicking New Folder...', async () => {
+    const { container } = render(<Graph data={menuData} />);
+    const graphContainer = getGraphContainer(container);
+
+    await act(async () => {
+      ForceGraph2D.simulateBackgroundRightClick();
+      fireEvent.contextMenu(graphContainer, { clientX: 300, clientY: 300 });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('New Folder...')).toBeInTheDocument();
+    });
+
+    clearSentMessages();
+    await act(async () => {
+      fireEvent.click(screen.getByText('New Folder...'));
+    });
+
+    const createMsg = findMessage('CREATE_FOLDER');
+    expect(createMsg).toBeTruthy();
+    expect(createMsg!.payload.directory).toBe('.');
+  });
+
   it('fits view in 2d when clicking Fit All Nodes', async () => {
     const methods = ForceGraph2D.getMockMethods();
     methods.zoomToFit.mockClear();

--- a/packages/extension/tests/webview/graph/contextMenu/destructiveBlock.mutations.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/destructiveBlock.mutations.test.ts
@@ -14,7 +14,7 @@ function getItems(entries: GraphContextMenuEntry[]): ItemEntry[] {
 describe('buildDestructiveBlock (mutation kill tests)', () => {
   /**
    * Kill L16:17 StringLiteral: "" — mutant replaces 'addToFilter' with ''
-   * Verify exact action string for the Add to Filter entry.
+   * Verify exact action string for the Add Filter Pattern... entry.
    */
   it('produces action "addToFilter" for single-target filter entry', () => {
     const entries = buildFilterBlock(['a.ts']);
@@ -22,7 +22,7 @@ describe('buildDestructiveBlock (mutation kill tests)', () => {
     const filterItem = items.find(item => item.id === 'node-add-filter');
 
     expect(filterItem).toBeDefined();
-    expect(filterItem!.label).toBe('Add to Filter');
+    expect(filterItem!.label).toBe('Add Filter Pattern...');
     expect(filterItem!.action).toEqual({ kind: 'builtin', action: 'addToFilter' });
   });
 
@@ -32,7 +32,7 @@ describe('buildDestructiveBlock (mutation kill tests)', () => {
     const filterItem = items.find(item => item.id === 'node-add-filter');
 
     expect(filterItem).toBeDefined();
-    expect(filterItem!.label).toBe('Add All to Filter');
+    expect(filterItem!.label).toBe('Add Filter Patterns...');
     expect(filterItem!.action).toEqual({ kind: 'builtin', action: 'addToFilter' });
   });
 

--- a/packages/extension/tests/webview/graph/contextMenu/destructiveBlock.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/destructiveBlock.test.ts
@@ -61,29 +61,40 @@ describe('filter block', () => {
     expect(entries[0]).toEqual({ kind: 'separator', id: 'node-separator-filter' });
   });
 
-  it('includes Add to Filter for single target', () => {
-    expect(itemLabels(buildFilterBlock(['a.ts']))).toContain('Add to Filter');
+  it('includes Add Filter Pattern... for single target', () => {
+    expect(itemLabels(buildFilterBlock(['a.ts']))).toContain('Add Filter Pattern...');
   });
 
-  it('includes Add All to Filter for multi-select', () => {
-    expect(itemLabels(buildFilterBlock(['a.ts', 'b.ts']))).toContain('Add All to Filter');
+  it('includes Add Filter Patterns... for multi-select', () => {
+    expect(itemLabels(buildFilterBlock(['a.ts', 'b.ts']))).toContain('Add Filter Patterns...');
   });
 
-  it('includes Add Legend Group for single target', () => {
-    expect(itemLabels(buildFilterBlock(['a.ts']))).toContain('Add Legend Group');
+  it('includes Add Legend Group... for single target', () => {
+    expect(itemLabels(buildFilterBlock(['a.ts']))).toContain('Add Legend Group...');
   });
 
-  it('omits Add Legend Group for multi-select', () => {
-    expect(itemLabels(buildFilterBlock(['a.ts', 'b.ts']))).not.toContain('Add Legend Group');
+  it('separates filter and legend actions into distinct blocks', () => {
+    const entries = buildFilterBlock(['a.ts']);
+
+    expect(entries).toEqual([
+      { kind: 'separator', id: 'node-separator-filter' },
+      expect.objectContaining({ kind: 'item', label: 'Add Filter Pattern...' }),
+      { kind: 'separator', id: 'node-separator-legend' },
+      expect.objectContaining({ kind: 'item', label: 'Add Legend Group...' }),
+    ]);
+  });
+
+  it('omits Add Legend Group... for multi-select', () => {
+    expect(itemLabels(buildFilterBlock(['a.ts', 'b.ts']))).not.toContain('Add Legend Group...');
   });
 
   it('uses addToFilter action for the filter entry', () => {
-    const entry = findItem(buildFilterBlock(['a.ts']), 'Add to Filter');
+    const entry = findItem(buildFilterBlock(['a.ts']), 'Add Filter Pattern...');
     expect(entry?.action).toMatchObject({ kind: 'builtin', action: 'addToFilter' });
   });
 
   it('uses addNodeLegend action for the add legend entry', () => {
-    const entry = findItem(buildFilterBlock(['a.ts']), 'Add Legend Group');
+    const entry = findItem(buildFilterBlock(['a.ts']), 'Add Legend Group...');
     expect(entry?.action).toMatchObject({ kind: 'builtin', action: 'addNodeLegend' });
   });
 });

--- a/packages/extension/tests/webview/graph/contextMenu/edge/entries.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/edge/entries.test.ts
@@ -18,6 +18,18 @@ function itemActions(entries: GraphContextMenuEntry[]): string[] {
 }
 
 describe('buildEdgeEntries', () => {
+  it('includes Open Source and Open Target when both endpoints are present', () => {
+    const entries = buildEdgeEntries(['a.ts', 'b.ts']);
+
+    expect(itemLabels(entries)).toEqual([
+      'Open Source',
+      'Open Target',
+      'Copy Source Path',
+      'Copy Target Path',
+      'Copy Both Paths',
+    ]);
+  });
+
   it('includes Copy Source Path when sourceId is present', () => {
     const entries = buildEdgeEntries(['a.ts', 'b.ts']);
     expect(itemLabels(entries)).toContain('Copy Source Path');
@@ -55,6 +67,12 @@ describe('buildEdgeEntries', () => {
 
   it('uses correct built-in action ids', () => {
     const entries = buildEdgeEntries(['a.ts', 'b.ts']);
-    expect(itemActions(entries)).toEqual(['copyEdgeSource', 'copyEdgeTarget', 'copyEdgeBoth']);
+    expect(itemActions(entries)).toEqual([
+      'openEdgeSource',
+      'openEdgeTarget',
+      'copyEdgeSource',
+      'copyEdgeTarget',
+      'copyEdgeBoth',
+    ]);
   });
 });

--- a/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
@@ -71,8 +71,10 @@ describe('Graph context menu (edge)', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
+      expect(screen.getByText('Open Source')).toBeInTheDocument();
     });
+    expect(screen.getByText('Open Target')).toBeInTheDocument();
+    expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
     expect(screen.getByText('Copy Target Path')).toBeInTheDocument();
     expect(screen.getByText('Copy Both Paths')).toBeInTheDocument();
   });
@@ -89,8 +91,10 @@ describe('Graph context menu (edge)', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
+      expect(screen.getByText('Open Source')).toBeInTheDocument();
     });
+    expect(screen.getByText('Open Target')).toBeInTheDocument();
+    expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
     expect(screen.getByText('Copy Target Path')).toBeInTheDocument();
     expect(screen.getByText('Copy Both Paths')).toBeInTheDocument();
   });
@@ -105,8 +109,10 @@ describe('Graph context menu (edge)', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
+        expect(screen.getByText('Open Source')).toBeInTheDocument();
       });
+      expect(screen.getByText('Open Target')).toBeInTheDocument();
+      expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
       expect(screen.getByText('Copy Target Path')).toBeInTheDocument();
       expect(screen.getByText('Copy Both Paths')).toBeInTheDocument();
     } finally {
@@ -128,8 +134,10 @@ describe('Graph context menu (edge)', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
+        expect(screen.getByText('Open Source')).toBeInTheDocument();
       });
+      expect(screen.getByText('Open Target')).toBeInTheDocument();
+      expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
       expect(screen.getByText('Copy Target Path')).toBeInTheDocument();
       expect(screen.getByText('Copy Both Paths')).toBeInTheDocument();
     } finally {
@@ -147,8 +155,10 @@ describe('Graph context menu (edge)', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
+      expect(screen.getByText('Open Source')).toBeInTheDocument();
     });
+    expect(screen.getByText('Open Target')).toBeInTheDocument();
+    expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
     expect(screen.getByText('Copy Target Path')).toBeInTheDocument();
     expect(screen.getByText('Copy Both Paths')).toBeInTheDocument();
     expect(screen.queryByText('Open File')).not.toBeInTheDocument();
@@ -166,10 +176,58 @@ describe('Graph context menu (edge)', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
+      expect(screen.getByText('Open Source')).toBeInTheDocument();
     });
+    expect(screen.getByText('Open Target')).toBeInTheDocument();
+    expect(screen.getByText('Copy Source Path')).toBeInTheDocument();
     expect(screen.getByText('Copy Target Path')).toBeInTheDocument();
     expect(screen.getByText('Copy Both Paths')).toBeInTheDocument();
+  });
+
+  it('sends OPEN_FILE source path when clicking Open Source', async () => {
+    const { container } = render(<Graph data={menuData} />);
+    const graphContainer = getGraphContainer(container);
+
+    await act(async () => {
+      ForceGraph2D.simulateLinkRightClick(edge);
+      fireEvent.contextMenu(graphContainer, { clientX: 200, clientY: 180 });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Open Source')).toBeInTheDocument();
+    });
+
+    clearSentMessages();
+    await act(async () => {
+      fireEvent.click(screen.getByText('Open Source'));
+    });
+
+    const openMsg = findMessage('OPEN_FILE');
+    expect(openMsg).toBeTruthy();
+    expect(openMsg!.payload.path).toBe('src/app.ts');
+  });
+
+  it('sends OPEN_FILE target path when clicking Open Target', async () => {
+    const { container } = render(<Graph data={menuData} />);
+    const graphContainer = getGraphContainer(container);
+
+    await act(async () => {
+      ForceGraph2D.simulateLinkRightClick(edge);
+      fireEvent.contextMenu(graphContainer, { clientX: 200, clientY: 180 });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Open Target')).toBeInTheDocument();
+    });
+
+    clearSentMessages();
+    await act(async () => {
+      fireEvent.click(screen.getByText('Open Target'));
+    });
+
+    const openMsg = findMessage('OPEN_FILE');
+    expect(openMsg).toBeTruthy();
+    expect(openMsg!.payload.path).toBe('src/utils.ts');
   });
 
   it('sends COPY_TO_CLIPBOARD source path when clicking Copy Source Path', async () => {

--- a/packages/extension/tests/webview/graph/contextMenu/favoritesDestructiveBlocks.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/favoritesDestructiveBlocks.test.ts
@@ -115,19 +115,22 @@ describe('buildFilterBlock', () => {
     expect(entries[0].id).toBe('node-separator-filter');
   });
 
-  it('includes Add to Filter for single target', () => {
+  it('includes Add Filter Pattern... for single target', () => {
     const labels = itemLabels(buildFilterBlock(['a.ts']));
-    expect(labels).toContain('Add to Filter');
+    expect(labels).toContain('Add Filter Pattern...');
   });
 
-  it('includes Add All to Filter for multi-select', () => {
+  it('includes Add Filter Patterns... for multi-select', () => {
     const labels = itemLabels(buildFilterBlock(['a.ts', 'b.ts']));
-    expect(labels).toContain('Add All to Filter');
+    expect(labels).toContain('Add Filter Patterns...');
   });
 
-  it('contains one separator in the filter block', () => {
+  it('separates filter and legend actions', () => {
     const entries = buildFilterBlock(['a.ts']);
     const separators = entries.filter(e => e.kind === 'separator');
-    expect(separators).toHaveLength(1);
+    expect(separators).toEqual([
+      { kind: 'separator', id: 'node-separator-filter' },
+      { kind: 'separator', id: 'node-separator-legend' },
+    ]);
   });
 });

--- a/packages/extension/tests/webview/graph/contextMenu/model.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/model.test.ts
@@ -64,8 +64,8 @@ describe('graph/contextMenuModel', () => {
       'Copy Absolute Path',
       'Remove from Favorites',
       'Focus Node',
-      'Add to Filter',
-      'Add Legend Group',
+      'Add Filter Pattern...',
+      'Add Legend Group...',
       'Rename...',
       'Delete File',
     ]);
@@ -82,8 +82,8 @@ describe('graph/contextMenuModel', () => {
       'Copy Absolute Path',
       'Remove from Favorites',
       'Focus Node',
-      'Add to Filter',
-      'Add Legend Group',
+      'Add Filter Pattern...',
+      'Add Legend Group...',
     ]);
   });
 
@@ -104,8 +104,10 @@ describe('graph/contextMenuModel', () => {
       'Copy Absolute Path',
       'Add to Favorites',
       'Focus Node',
-      'Add to Filter',
-      'Add Legend Group',
+      'Add Filter Pattern...',
+      'Add Legend Group...',
+      'Rename Folder...',
+      'Delete Folder',
     ]);
   });
 
@@ -121,11 +123,34 @@ describe('graph/contextMenuModel', () => {
 
     const creationEntries = menuItems(entries).filter(entry =>
       entry.action.kind === 'builtin'
-      && (entry.action.action === 'createFile' || entry.action.action === 'createFolder')
+      && (
+        entry.action.action === 'createFile'
+        || entry.action.action === 'createFolder'
+        || entry.action.action === 'rename'
+        || entry.action.action === 'delete'
+      )
     );
 
-    expect(creationEntries.map(entry => entry.label)).toEqual(['New File...', 'New Folder...']);
+    expect(creationEntries.map(entry => entry.label)).toEqual([
+      'New File...',
+      'New Folder...',
+      'Rename Folder...',
+      'Delete Folder',
+    ]);
     expect(creationEntries.every(entry => entry.disabled)).toBe(true);
+  });
+
+  it('does not show rename or delete actions for the synthetic root folder node', () => {
+    const entries = buildGraphContextMenuEntries({
+      selection: makeNodeContextSelection('(root)', new Set<string>()),
+      timelineActive: false,
+      favorites: new Set<string>(),
+      pluginItems: [],
+      nodes: [{ id: '(root)', label: '(root)', color: '#94a3b8', nodeType: 'folder' }],
+    });
+
+    expect(menuLabels(entries)).not.toContain('Rename Folder...');
+    expect(menuLabels(entries)).not.toContain('Delete Folder');
   });
 
   it('builds multi-node menu with only valid actions', () => {
@@ -140,7 +165,7 @@ describe('graph/contextMenuModel', () => {
       'Open 2 Files',
       'Copy Relative Paths',
       'Add All to Favorites',
-      'Add All to Filter',
+      'Add Filter Patterns...',
       'Delete 2 Files',
     ]);
   });
@@ -234,11 +259,15 @@ describe('graph/contextMenuModel', () => {
       pluginItems: [],
     });
     expect(menuLabels(edgeLive)).toEqual([
+      'Open Source',
+      'Open Target',
       'Copy Source Path',
       'Copy Target Path',
       'Copy Both Paths',
     ]);
     expect(builtInActions(edgeLive)).toEqual([
+      'openEdgeSource',
+      'openEdgeTarget',
       'copyEdgeSource',
       'copyEdgeTarget',
       'copyEdgeBoth',
@@ -251,6 +280,8 @@ describe('graph/contextMenuModel', () => {
       pluginItems: [],
     });
     expect(builtInActions(edgeTimeline)).toEqual([
+      'openEdgeSource',
+      'openEdgeTarget',
       'copyEdgeSource',
       'copyEdgeTarget',
       'copyEdgeBoth',

--- a/packages/extension/tests/webview/graph/contextMenu/model.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/model.test.ts
@@ -37,7 +37,7 @@ describe('graph/contextMenuModel', () => {
       favorites: new Set(),
       pluginItems: [],
     });
-    expect(menuLabels(liveEntries)).toEqual(['New File...', 'Refresh', 'Fit All Nodes']);
+    expect(menuLabels(liveEntries)).toEqual(['New File...', 'New Folder...', 'Refresh', 'Fit All Nodes']);
 
     const timelineEntries = buildGraphContextMenuEntries({
       selection: makeBackgroundContextSelection(),
@@ -152,7 +152,7 @@ describe('graph/contextMenuModel', () => {
       favorites: new Set(),
       pluginItems: [],
     });
-    expect(builtInActions(backgroundLive)).toEqual(['createFile', 'refresh', 'fitView']);
+    expect(builtInActions(backgroundLive)).toEqual(['createFile', 'createFolder', 'refresh', 'fitView']);
 
     const backgroundTimeline = buildGraphContextMenuEntries({
       selection: makeBackgroundContextSelection(),

--- a/packages/extension/tests/webview/graph/contextMenu/model.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/model.test.ts
@@ -87,6 +87,47 @@ describe('graph/contextMenuModel', () => {
     ]);
   });
 
+  it('builds single-folder-node menu with child creation actions', () => {
+    const entries = buildGraphContextMenuEntries({
+      selection: makeNodeContextSelection('src', new Set<string>()),
+      timelineActive: false,
+      favorites: new Set<string>(),
+      pluginItems: [],
+      nodes: [{ id: 'src', label: 'src', color: '#94a3b8', nodeType: 'folder' }],
+    });
+
+    expect(menuLabels(entries)).toEqual([
+      'New File...',
+      'New Folder...',
+      'Reveal in Explorer',
+      'Copy Relative Path',
+      'Copy Absolute Path',
+      'Add to Favorites',
+      'Focus Node',
+      'Add to Filter',
+      'Add Legend Group',
+    ]);
+  });
+
+  it('disables folder-node child creation actions for historical snapshots', () => {
+    const entries = buildGraphContextMenuEntries({
+      selection: makeNodeContextSelection('src', new Set<string>()),
+      timelineActive: true,
+      mutationAvailability: 'disabled',
+      favorites: new Set<string>(),
+      pluginItems: [],
+      nodes: [{ id: 'src', label: 'src', color: '#94a3b8', nodeType: 'folder' }],
+    });
+
+    const creationEntries = menuItems(entries).filter(entry =>
+      entry.action.kind === 'builtin'
+      && (entry.action.action === 'createFile' || entry.action.action === 'createFolder')
+    );
+
+    expect(creationEntries.map(entry => entry.label)).toEqual(['New File...', 'New Folder...']);
+    expect(creationEntries.every(entry => entry.disabled)).toBe(true);
+  });
+
   it('builds multi-node menu with only valid actions', () => {
     const selection = makeNodeContextSelection('src/a.ts', new Set(['src/a.ts', 'src/b.ts']));
     const entries = buildGraphContextMenuEntries({

--- a/packages/extension/tests/webview/graph/contextMenu/node.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/node.test.tsx
@@ -53,6 +53,14 @@ const selectionData: IGraphData = {
   edges: [],
 };
 
+const folderData: IGraphData = {
+  nodes: [
+    { id: 'src', label: 'src', color: '#94a3b8', nodeType: 'folder' },
+    { id: 'src/app.ts', label: 'app.ts', color: '#93C5FD' },
+  ],
+  edges: [],
+};
+
 describe('Graph context menu (node)', () => {
   const mockFavorites = new Set(['src/app.ts']);
 
@@ -162,7 +170,7 @@ describe('Graph context menu (node)', () => {
     expect(screen.getByText('Copy Relative Path')).toBeInTheDocument();
     expect(screen.getByText('Copy Absolute Path')).toBeInTheDocument();
     expect(screen.getByText('Focus Node')).toBeInTheDocument();
-    expect(screen.getByText('Add to Filter')).toBeInTheDocument();
+    expect(screen.getByText('Add Filter Pattern...')).toBeInTheDocument();
     expect(screen.getByText('Rename...')).toBeInTheDocument();
     expect(screen.getByText('Delete File')).toBeInTheDocument();
     expect(screen.queryByText('New File...')).not.toBeInTheDocument();
@@ -340,7 +348,7 @@ describe('Graph context menu (node)', () => {
     expect(methods.zoomToFit).toHaveBeenCalledWith(300, 20, expect.any(Function));
   });
 
-  it('opens the filter popover request when clicking Add to Filter for a single node', async () => {
+  it('opens the filter popover request when clicking Add Filter Pattern... for a single node', async () => {
     const onAddFilterRequested = vi.fn();
     const { container } = render(
       <Graph
@@ -356,11 +364,11 @@ describe('Graph context menu (node)', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Add to Filter')).toBeInTheDocument();
+      expect(screen.getByText('Add Filter Pattern...')).toBeInTheDocument();
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Add to Filter'));
+      fireEvent.click(screen.getByText('Add Filter Pattern...'));
     });
 
     expect(onAddFilterRequested).toHaveBeenCalledWith(['src/app.ts']);
@@ -433,6 +441,74 @@ describe('Graph context menu (node)', () => {
     expect(deleteMsg!.payload.paths).toContain('src/app.ts');
   });
 
+  it('shows folder parity actions when right-clicking a folder node', async () => {
+    const { container } = render(<Graph data={folderData} />);
+    const graphContainer = getGraphContainer(container);
+
+    await act(async () => {
+      ForceGraph2D.simulateNodeRightClick({ id: 'src' });
+      fireEvent.contextMenu(graphContainer, { clientX: 100, clientY: 100 });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('New Folder...')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('New File...')).toBeInTheDocument();
+    expect(screen.getByText('Reveal in Explorer')).toBeInTheDocument();
+    expect(screen.getByText('Copy Relative Path')).toBeInTheDocument();
+    expect(screen.getByText('Copy Absolute Path')).toBeInTheDocument();
+    expect(screen.getByText('Rename Folder...')).toBeInTheDocument();
+    expect(screen.getByText('Delete Folder')).toBeInTheDocument();
+    expect(screen.queryByText('Open File')).not.toBeInTheDocument();
+  });
+
+  it('sends RENAME_FILE message when clicking Rename Folder...', async () => {
+    const { container } = render(<Graph data={folderData} />);
+    const graphContainer = getGraphContainer(container);
+
+    await act(async () => {
+      ForceGraph2D.simulateNodeRightClick({ id: 'src' });
+      fireEvent.contextMenu(graphContainer, { clientX: 100, clientY: 100 });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Rename Folder...')).toBeInTheDocument();
+    });
+
+    clearSentMessages();
+    await act(async () => {
+      fireEvent.click(screen.getByText('Rename Folder...'));
+    });
+
+    const renameMsg = findMessage('RENAME_FILE');
+    expect(renameMsg).toBeTruthy();
+    expect(renameMsg!.payload.path).toBe('src');
+  });
+
+  it('sends DELETE_FILES message when clicking Delete Folder', async () => {
+    const { container } = render(<Graph data={folderData} />);
+    const graphContainer = getGraphContainer(container);
+
+    await act(async () => {
+      ForceGraph2D.simulateNodeRightClick({ id: 'src' });
+      fireEvent.contextMenu(graphContainer, { clientX: 100, clientY: 100 });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete Folder')).toBeInTheDocument();
+    });
+
+    clearSentMessages();
+    await act(async () => {
+      fireEvent.click(screen.getByText('Delete Folder'));
+    });
+
+    const deleteMsg = findMessage('DELETE_FILES');
+    expect(deleteMsg).toBeTruthy();
+    expect(deleteMsg!.payload.paths).toEqual(['src']);
+  });
+
   it('renders plugin node items and dispatches PLUGIN_CONTEXT_MENU_ACTION', async () => {
     const pluginItem: IPluginContextMenuItem = {
       label: 'Plugin Inspect',
@@ -497,7 +573,7 @@ describe('Graph context menu (node)', () => {
     });
     expect(screen.getByText('Copy Relative Paths')).toBeInTheDocument();
     expect(screen.getByText('Add All to Favorites')).toBeInTheDocument();
-    expect(screen.getByText('Add All to Filter')).toBeInTheDocument();
+    expect(screen.getByText('Add Filter Patterns...')).toBeInTheDocument();
     expect(screen.getByText('Delete 2 Files')).toBeInTheDocument();
     expect(screen.queryByText('Reveal in Explorer')).not.toBeInTheDocument();
     expect(screen.queryByText('Rename...')).not.toBeInTheDocument();
@@ -563,7 +639,7 @@ describe('Graph context menu (node)', () => {
     expect(favMsg!.payload.paths).toEqual(['nodeA.ts', 'nodeB.ts']);
   });
 
-  it('opens the filter popover request with all selected paths for Add All to Filter', async () => {
+  it('opens the filter popover request with all selected paths for Add Filter Patterns...', async () => {
     const onAddFilterRequested = vi.fn();
     const { container } = render(<Graph data={selectionData} onAddFilterRequested={onAddFilterRequested} />);
     const graphContainer = getGraphContainer(container);
@@ -571,11 +647,11 @@ describe('Graph context menu (node)', () => {
     await selectTwoNodesForMultiMenu(graphContainer);
 
     await waitFor(() => {
-      expect(screen.getByText('Add All to Filter')).toBeInTheDocument();
+      expect(screen.getByText('Add Filter Patterns...')).toBeInTheDocument();
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Add All to Filter'));
+      fireEvent.click(screen.getByText('Add Filter Patterns...'));
     });
 
     expect(onAddFilterRequested).toHaveBeenCalledWith(['nodeA.ts', 'nodeB.ts']);
@@ -618,8 +694,8 @@ describe('Graph context menu (node)', () => {
     expect(screen.getByText('Copy Absolute Path')).toBeInTheDocument();
     expect(screen.getByText('Focus Node')).toBeInTheDocument();
     expect(screen.queryByText('Reveal in Explorer')).not.toBeInTheDocument();
-    expect(screen.getByText('Add to Filter')).toBeInTheDocument();
-    expect(screen.getByText('Add Legend Group')).toBeInTheDocument();
+    expect(screen.getByText('Add Filter Pattern...')).toBeInTheDocument();
+    expect(screen.getByText('Add Legend Group...')).toBeInTheDocument();
     expect(screen.queryByText('Rename...')).not.toBeInTheDocument();
     expect(screen.queryByText('Delete File')).not.toBeInTheDocument();
   });
@@ -636,7 +712,7 @@ describe('Graph context menu (node)', () => {
     });
     expect(screen.getByText('Copy Relative Paths')).toBeInTheDocument();
     expect(screen.getByText('Add All to Favorites')).toBeInTheDocument();
-    expect(screen.getByText('Add All to Filter')).toBeInTheDocument();
+    expect(screen.getByText('Add Filter Patterns...')).toBeInTheDocument();
     expect(screen.queryByText('Delete 2 Files')).not.toBeInTheDocument();
   });
 

--- a/packages/extension/tests/webview/graph/contextMenu/nodeActionBlocks.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/nodeActionBlocks.test.ts
@@ -91,16 +91,16 @@ describe('graph/contextMenu/node/openCopyBlocks', () => {
   });
 
   describe('buildFilterBlock', () => {
-    it('includes Add to Filter for single target', () => {
+    it('includes Add Filter Pattern... for single target', () => {
       const labels = itemLabels(buildFilterBlock(['src/app.ts']));
-      expect(labels).toContain('Add to Filter');
-      expect(labels).toContain('Add Legend Group');
+      expect(labels).toContain('Add Filter Pattern...');
+      expect(labels).toContain('Add Legend Group...');
     });
 
-    it('shows Add All to Filter and omits Add Legend Group for multi-select', () => {
+    it('shows Add Filter Patterns... and omits Add Legend Group... for multi-select', () => {
       const labels = itemLabels(buildFilterBlock(['src/a.ts', 'src/b.ts']));
-      expect(labels).toContain('Add All to Filter');
-      expect(labels).not.toContain('Add Legend Group');
+      expect(labels).toContain('Add Filter Patterns...');
+      expect(labels).not.toContain('Add Legend Group...');
     });
   });
 

--- a/packages/extension/tests/webview/graph/interactionRuntime/handlers.test.ts
+++ b/packages/extension/tests/webview/graph/interactionRuntime/handlers.test.ts
@@ -337,7 +337,7 @@ describe('graph/interactionRuntime/handlers', () => {
     expect(createSelectionHandlers).toHaveBeenCalledWith(dependencies);
     expect(createContextMenuHandlers).toHaveBeenCalledWith(
       dependencies,
-      selectionHandlers.setSelection,
+      selectionHandlers,
     );
     expect(createViewHandlers).toHaveBeenCalledWith(dependencies);
     expect(createEffectHandlers).toHaveBeenCalledWith(dependencies, {

--- a/packages/extension/tests/webview/graph/interactionRuntime/handlers/contextMenu.test.ts
+++ b/packages/extension/tests/webview/graph/interactionRuntime/handlers/contextMenu.test.ts
@@ -4,7 +4,10 @@ import {
   createContextMenuHandlers,
   getContextMenuPointerState,
 } from '../../../../../src/webview/components/graph/interactionRuntime/handlers/contextMenu';
+import { createSelectionHandlers } from '../../../../../src/webview/components/graph/interactionRuntime/handlers/selection';
 import { createInteractionDependencies } from '../testUtils';
+import type { GraphInteractionHandlersDependencies } from '../../../../../src/webview/components/graph/interactionRuntime/handlers';
+import type { ContextMenuSelectionHandlers } from '../../../../../src/webview/components/graph/interactionRuntime/handlers/contextMenu';
 
 function spyOnDispatchEvent(container: HTMLElement | null) {
   if (!container) {
@@ -14,12 +17,25 @@ function spyOnDispatchEvent(container: HTMLElement | null) {
   return vi.spyOn(container as EventTarget, 'dispatchEvent');
 }
 
+function createContextMenuSelectionHandlers(
+  dependencies: GraphInteractionHandlersDependencies,
+  overrides: Partial<ContextMenuSelectionHandlers> = {},
+): ContextMenuSelectionHandlers {
+  return {
+    ...createSelectionHandlers(dependencies),
+    ...overrides,
+  };
+}
+
 describe('graph/contextMenuHandlers', () => {
   it('updates selection and opens the node context menu', () => {
     const dependencies = createInteractionDependencies();
     const setSelection = vi.fn();
     const dispatchEvent = spyOnDispatchEvent(dependencies.containerRef.current);
-    const handlers = createContextMenuHandlers(dependencies, setSelection);
+    const handlers = createContextMenuHandlers(
+      dependencies,
+      createContextMenuSelectionHandlers(dependencies, { setSelection }),
+    );
 
     handlers.openNodeContextMenu(
       'src/app.ts',
@@ -33,12 +49,33 @@ describe('graph/contextMenuHandlers', () => {
     expect(dispatchEvent).toHaveBeenCalledOnce();
   });
 
+  it('focuses the right-clicked node before opening its context menu', () => {
+    const dependencies = createInteractionDependencies();
+    dependencies.highlightedNodeRef.current = 'src/utils.ts';
+    const dispatchEvent = spyOnDispatchEvent(dependencies.containerRef.current);
+    const handlers = createContextMenuHandlers(
+      dependencies,
+      createContextMenuSelectionHandlers(dependencies),
+    );
+
+    handlers.openNodeContextMenu(
+      'src/app.ts',
+      new MouseEvent('contextmenu', { button: 2, buttons: 2 }),
+    );
+
+    expect(dependencies.highlightedNodeRef.current).toBe('src/app.ts');
+    expect(dispatchEvent).toHaveBeenCalledOnce();
+  });
+
   it('does not dispatch when the graph container is missing', () => {
     const dependencies = createInteractionDependencies();
     const container = dependencies.containerRef.current;
     const dispatchEvent = spyOnDispatchEvent(container);
     dependencies.containerRef.current = null;
-    const handlers = createContextMenuHandlers(dependencies, vi.fn());
+    const handlers = createContextMenuHandlers(
+      dependencies,
+      createContextMenuSelectionHandlers(dependencies),
+    );
 
     expect(() => {
       handlers.openBackgroundContextMenu(
@@ -61,7 +98,10 @@ describe('graph/contextMenuHandlers', () => {
   it('preserves pointer metadata on the synthetic context menu event', () => {
     const dependencies = createInteractionDependencies();
     const dispatchEvent = spyOnDispatchEvent(dependencies.containerRef.current);
-    const handlers = createContextMenuHandlers(dependencies, vi.fn());
+    const handlers = createContextMenuHandlers(
+      dependencies,
+      createContextMenuSelectionHandlers(dependencies),
+    );
 
     handlers.openBackgroundContextMenu(
       new MouseEvent('contextmenu', {
@@ -89,7 +129,10 @@ describe('graph/contextMenuHandlers', () => {
   it('falls back to default pointer metadata when the graph callback omits the event', () => {
     const dependencies = createInteractionDependencies();
     const dispatchEvent = spyOnDispatchEvent(dependencies.containerRef.current);
-    const handlers = createContextMenuHandlers(dependencies, vi.fn());
+    const handlers = createContextMenuHandlers(
+      dependencies,
+      createContextMenuSelectionHandlers(dependencies),
+    );
 
     handlers.openBackgroundContextMenu(undefined as unknown as MouseEvent);
 
@@ -130,7 +173,10 @@ describe('graph/contextMenuHandlers', () => {
     dependencies.selectedNodesSetRef.current = new Set(['src/app.ts', 'src/utils.ts']);
     const setSelection = vi.fn();
     const dispatchEvent = spyOnDispatchEvent(dependencies.containerRef.current);
-    const handlers = createContextMenuHandlers(dependencies, setSelection);
+    const handlers = createContextMenuHandlers(
+      dependencies,
+      createContextMenuSelectionHandlers(dependencies, { setSelection }),
+    );
 
     handlers.openNodeContextMenu(
       'src/app.ts',
@@ -148,7 +194,10 @@ describe('graph/contextMenuHandlers', () => {
   it('opens edge and background context menus', () => {
     const dependencies = createInteractionDependencies();
     const dispatchEvent = spyOnDispatchEvent(dependencies.containerRef.current);
-    const handlers = createContextMenuHandlers(dependencies, vi.fn());
+    const handlers = createContextMenuHandlers(
+      dependencies,
+      createContextMenuSelectionHandlers(dependencies),
+    );
 
     handlers.openEdgeContextMenu(
       {
@@ -178,7 +227,10 @@ describe('graph/contextMenuHandlers', () => {
   it('falls back to legacy source and target endpoints when from and to are unresolved', () => {
     const dependencies = createInteractionDependencies();
     const dispatchEvent = spyOnDispatchEvent(dependencies.containerRef.current);
-    const handlers = createContextMenuHandlers(dependencies, vi.fn());
+    const handlers = createContextMenuHandlers(
+      dependencies,
+      createContextMenuSelectionHandlers(dependencies),
+    );
 
     handlers.openEdgeContextMenu(
       {
@@ -225,7 +277,10 @@ describe('graph/contextMenuHandlers', () => {
     (_endpoint, link) => {
       const dependencies = createInteractionDependencies();
       const dispatchEvent = vi.spyOn(dependencies.containerRef.current as EventTarget, 'dispatchEvent');
-      const handlers = createContextMenuHandlers(dependencies, vi.fn());
+      const handlers = createContextMenuHandlers(
+        dependencies,
+        createContextMenuSelectionHandlers(dependencies),
+      );
 
       handlers.openEdgeContextMenu(
         link as unknown as FGLink,

--- a/packages/extension/tests/webview/graph/viewport/model.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/model.test.tsx
@@ -109,7 +109,14 @@ function createInteractions(): UseGraphInteractionRuntimeResult {
 
 function createViewState(): Pick<
 	GraphViewStoreState,
-	'dagMode' | 'favorites' | 'physicsSettings' | 'pluginContextMenuItems' | 'setGraphMode' | 'timelineActive'
+	| 'currentCommitSha'
+	| 'dagMode'
+	| 'favorites'
+	| 'physicsSettings'
+	| 'pluginContextMenuItems'
+	| 'setGraphMode'
+	| 'timelineActive'
+	| 'timelineCommits'
 > {
 	const physicsSettings: IPhysicsSettings = {
 		centerForce: 0.1,
@@ -126,6 +133,11 @@ function createViewState(): Pick<
 		pluginContextMenuItems: [],
 		setGraphMode: vi.fn(),
 		timelineActive: true,
+		timelineCommits: [
+			{ sha: 'old', timestamp: 1, message: 'old', author: 'Ada', parents: [] },
+			{ sha: 'current', timestamp: 2, message: 'current', author: 'Ada', parents: ['old'] },
+		],
+		currentCommitSha: 'current',
 	};
 }
 
@@ -177,6 +189,8 @@ describe('graph/viewport/model', () => {
 		}));
 		expect(harness.buildGraphContextMenuEntries).toHaveBeenCalledWith({
 			favorites: viewState.favorites,
+			mutationAvailability: 'enabled',
+			nodes: graphData.nodes,
 			pluginItems: [],
 			selection: { kind: 'background', targets: [] },
 			timelineActive: true,
@@ -245,6 +259,33 @@ describe('graph/viewport/model', () => {
 			damping: 0.6,
 			graphData: nextGraphData,
 			timelineActive: false,
+		}));
+	});
+
+	it('disables mutation menu actions for historical timeline snapshots', () => {
+		const graphData = createGraphData();
+		const interactions = createInteractions();
+		const handleEngineStop = vi.fn();
+		const viewState = {
+			...createViewState(),
+			currentCommitSha: 'old',
+		};
+
+		renderHook(() => useGraphViewportModel({
+			graphState: {
+				contextSelection: { kind: 'background', targets: [] },
+				graphData,
+			},
+			handleEngineStop,
+			interactions,
+			theme: 'light',
+			viewportRuntime: { containerSize: { width: 480, height: 320 } },
+			viewState,
+		}));
+
+		expect(harness.buildGraphContextMenuEntries).toHaveBeenCalledWith(expect.objectContaining({
+			mutationAvailability: 'disabled',
+			nodes: graphData.nodes,
 		}));
 	});
 });

--- a/packages/extension/tests/webview/graph/viewport/shell.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/shell.test.tsx
@@ -177,7 +177,7 @@ function createCallbacks() {
 
 function createViewState(): Pick<
 	GraphViewStoreState,
-	'bidirectionalMode' | 'dagMode' | 'depthMode' | 'directionColor' | 'directionMode' | 'favorites' | 'graphMode' | 'nodeSizeMode' | 'particleSize' | 'particleSpeed' | 'physicsPaused' | 'physicsSettings' | 'pluginContextMenuItems' | 'setGraphMode' | 'showLabels' | 'timelineActive'
+	'bidirectionalMode' | 'currentCommitSha' | 'dagMode' | 'depthMode' | 'directionColor' | 'directionMode' | 'favorites' | 'graphMode' | 'nodeSizeMode' | 'particleSize' | 'particleSpeed' | 'physicsPaused' | 'physicsSettings' | 'pluginContextMenuItems' | 'setGraphMode' | 'showLabels' | 'timelineActive' | 'timelineCommits'
 > {
 	const physicsSettings: IPhysicsSettings = {
 		centerForce: 0.1,
@@ -189,6 +189,7 @@ function createViewState(): Pick<
 
 	return {
 		bidirectionalMode: 'separate',
+		currentCommitSha: 'commit-b',
 		dagMode: 'td',
 		depthMode: false,
 		directionColor: '#22c55e',
@@ -204,6 +205,10 @@ function createViewState(): Pick<
 		setGraphMode: vi.fn(),
 		showLabels: true,
 		timelineActive: true,
+		timelineCommits: [
+			{ sha: 'commit-a', message: 'A', author: 'Ada', parents: [], timestamp: 1 },
+			{ sha: 'commit-b', message: 'B', author: 'Ada', parents: ['commit-a'], timestamp: 2 },
+		],
 	};
 }
 

--- a/packages/extension/tests/webview/graphControls/filtering.test.ts
+++ b/packages/extension/tests/webview/graphControls/filtering.test.ts
@@ -133,4 +133,49 @@ describe('webview/graphControls/filtering', () => {
       ],
     });
   });
+
+  it('connects discovered empty folder nodes through visible folder nests edges', () => {
+    const result = applyGraphControls({
+      graphData: {
+        nodes: [
+          { id: 'src/app.ts', label: 'app.ts', color: '#111111', nodeType: 'file' },
+          { id: 'src/new-folder', label: 'new-folder', color: '#222222', nodeType: 'folder' },
+        ],
+        edges: [],
+      },
+      nodeColors: {},
+      nodeVisibility: {
+        file: true,
+        folder: true,
+      },
+      edgeVisibility: {
+        [STRUCTURAL_NESTS_EDGE_KIND]: true,
+      },
+      edgeTypes: [],
+    });
+
+    expect(result.graphData).toEqual({
+      nodes: [
+        { id: 'src/app.ts', label: 'app.ts', color: '#111111', nodeType: 'file' },
+        { id: 'src/new-folder', label: 'new-folder', color: '#222222', nodeType: 'folder' },
+        { id: 'src', label: 'src', color: DEFAULT_FOLDER_NODE_COLOR, nodeType: 'folder' },
+      ],
+      edges: [
+        {
+          id: 'src->src/new-folder#nests',
+          from: 'src',
+          to: 'src/new-folder',
+          kind: 'nests',
+          sources: [],
+        },
+        {
+          id: 'src->src/app.ts#nests',
+          from: 'src',
+          to: 'src/app.ts',
+          kind: 'nests',
+          sources: [],
+        },
+      ],
+    });
+  });
 });

--- a/packages/plugin-csharp/tests/activate.test.ts
+++ b/packages/plugin-csharp/tests/activate.test.ts
@@ -75,6 +75,9 @@ vi.mock('vscode', () => ({
     getConfiguration: mockState.getConfiguration,
     onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
     onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidCreateFiles: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidDeleteFiles: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidRenameFiles: vi.fn(() => ({ dispose: vi.fn() })),
     createFileSystemWatcher: vi.fn(() => ({
       onDidCreate: vi.fn(() => ({ dispose: vi.fn() })),
       onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),

--- a/packages/plugin-godot/tests/activate.test.ts
+++ b/packages/plugin-godot/tests/activate.test.ts
@@ -106,6 +106,9 @@ vi.mock('vscode', () => ({
     getConfiguration: mockState.getConfiguration,
     onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
     onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidCreateFiles: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidDeleteFiles: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidRenameFiles: vi.fn(() => ({ dispose: vi.fn() })),
     createFileSystemWatcher: vi.fn(() => ({
       onDidCreate: vi.fn(() => ({ dispose: vi.fn() })),
       onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),

--- a/packages/plugin-python/tests/activate.test.ts
+++ b/packages/plugin-python/tests/activate.test.ts
@@ -75,6 +75,9 @@ vi.mock('vscode', () => ({
     getConfiguration: mockState.getConfiguration,
     onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
     onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidCreateFiles: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidDeleteFiles: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidRenameFiles: vi.fn(() => ({ dispose: vi.fn() })),
     createFileSystemWatcher: vi.fn(() => ({
       onDidCreate: vi.fn(() => ({ dispose: vi.fn() })),
       onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),

--- a/packages/plugin-typescript/tests/activate.test.ts
+++ b/packages/plugin-typescript/tests/activate.test.ts
@@ -78,6 +78,9 @@ vi.mock('vscode', () => ({
     getConfiguration: mockState.getConfiguration,
     onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
     onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidCreateFiles: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidDeleteFiles: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidRenameFiles: vi.fn(() => ({ dispose: vi.fn() })),
     createFileSystemWatcher: vi.fn(() => ({
       onDidCreate: vi.fn(() => ({ dispose: vi.fn() })),
       onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),


### PR DESCRIPTION
## Summary
- add a Graph Context Menu decision model for folder-node create actions
- wire New Folder from folder nodes through webview messaging to the extension action/undo path
- track discovered empty directories so newly created empty folders render as folder nodes after refresh/index
- document the Context Selection / Graph Context Menu terminology and issue plan

Trello: https://trello.com/c/GOvvj15w/128-create-new-folder-when-folder-nodes-active-in-context-window

## Verification
- pnpm --filter @codegraphy/extension exec vitest run --config vitest.config.ts packages/extension/tests/extension/pipeline/service/base/internal.test.ts
- pnpm run test
- pnpm --filter @codegraphy/extension run lint
- git diff --check
- pnpm run build
- pnpm run test:release