### PR TITLE
Add pinnable graph nodes

### DIFF
--- a/.changeset/pinnable-graph-nodes.md
+++ b/.changeset/pinnable-graph-nodes.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy/extension": minor
+---
+
+Add pinnable graph nodes with persisted graph-space positions, context menu pin controls, and a visible pinned-node badge.

--- a/packages/extension/src/extension/config/actions.ts
+++ b/packages/extension/src/extension/config/actions.ts
@@ -65,6 +65,9 @@ export function executeConfigAction(
     case 'legend':
       scheduleGroupSettingsRefresh(provider);
       break;
+    case 'layout':
+      provider.sendGraphLayout();
+      break;
     case 'general':
       executeGeneralConfigAction(event, provider);
       break;

--- a/packages/extension/src/extension/config/classify.ts
+++ b/packages/extension/src/extension/config/classify.ts
@@ -3,6 +3,7 @@ export type ConfigCategory =
   | 'toggles'
   | 'display'
   | 'legend'
+  | 'layout'
   | 'general';
 
 interface CodeGraphyConfigurationChangeLike {
@@ -38,6 +39,10 @@ export function classifyConfigChange(event: CodeGraphyConfigurationChangeLike): 
 
   if (affectsAny('codegraphy.legend')) {
     return 'legend';
+  }
+
+  if (affectsAny('codegraphy.graphLayout')) {
+    return 'layout';
   }
 
   if (event.affectsConfiguration('codegraphy')) {

--- a/packages/extension/src/extension/graphView/graphLayout/message.ts
+++ b/packages/extension/src/extension/graphView/graphLayout/message.ts
@@ -1,0 +1,19 @@
+import type { ExtensionToWebviewMessage } from '../../../shared/protocol/extensionToWebview';
+import { getCodeGraphyConfiguration } from '../../repoSettings/current';
+import {
+  createDefaultGraphLayoutSettings,
+  normalizeGraphLayoutSettings,
+} from '../../repoSettings/graphLayout/model';
+
+export function createGraphLayoutUpdatedMessage(): Extract<
+  ExtensionToWebviewMessage,
+  { type: 'GRAPH_LAYOUT_UPDATED' }
+> {
+  const configuration = getCodeGraphyConfiguration();
+  return {
+    type: 'GRAPH_LAYOUT_UPDATED',
+    payload: normalizeGraphLayoutSettings(
+      configuration.get('graphLayout', createDefaultGraphLayoutSettings()),
+    ),
+  };
+}

--- a/packages/extension/src/extension/graphView/provider/wiring/publicApi.ts
+++ b/packages/extension/src/extension/graphView/provider/wiring/publicApi.ts
@@ -7,6 +7,7 @@ import type { GraphViewExternalPluginRegistrationOptions } from '../../webview/p
 import { dispatchGraphViewProviderMessage } from '../../webview/providerMessages/dispatch';
 import type { GraphViewProviderMethodContainers } from './methodContainers';
 import type { GraphViewProviderMessageListenerSource } from '../../webview/providerMessages/listener';
+import { createGraphLayoutUpdatedMessage } from '../../graphLayout/message';
 import {
   createGraphViewProviderMethodSource,
   type GraphViewProviderMethodSourceOwner,
@@ -65,6 +66,7 @@ export interface GraphViewProviderPublicMethods {
   updateGraphData: (data: IGraphData) => void;
   getGraphData: () => IGraphData;
   sendPlaybackSpeed: () => void;
+  sendGraphLayout: () => void;
   invalidateTimelineCache: () => Promise<void>;
   registerExternalPlugin: (
     plugin: unknown,
@@ -116,6 +118,8 @@ export function assignGraphViewProviderPublicMethods(
   target.updateGraphData = data => target._methodContainers.viewContext.updateGraphData(data);
   target.getGraphData = () => target._methodContainers.viewContext.getGraphData();
   target.sendPlaybackSpeed = () => target._methodContainers.timeline.sendPlaybackSpeed();
+  target.sendGraphLayout = () =>
+    target._methodContainers.webview.sendToWebview(createGraphLayoutUpdatedMessage());
   target.invalidateTimelineCache = () => target._methodContainers.timeline.invalidateTimelineCache();
   target.registerExternalPlugin = (plugin, options) =>
     target._methodContainers.plugin.registerExternalPlugin(plugin, options);

--- a/packages/extension/src/extension/graphView/webview/dispatch/plugin.ts
+++ b/packages/extension/src/extension/graphView/webview/dispatch/plugin.ts
@@ -31,6 +31,7 @@ export interface GraphViewPluginMessageContext {
   analyzeAndSendData(): Promise<void>;
   sendFavorites(): void;
   sendSettings(): void;
+  sendGraphLayout?(): void;
   sendPhysicsSettings(): void;
   sendGroupsUpdated(): void;
   sendMessage(message: unknown): void;

--- a/packages/extension/src/extension/graphView/webview/dispatch/pluginReady.ts
+++ b/packages/extension/src/extension/graphView/webview/dispatch/pluginReady.ts
@@ -26,6 +26,7 @@ export interface GraphViewPluginReadyContext {
   loadAndSendData(): Promise<void>;
   sendFavorites(): void;
   sendSettings(): void;
+  sendGraphLayout?(): void;
   sendPhysicsSettings(): void;
   sendGroupsUpdated(): void;
   sendMessage(message: unknown): void;
@@ -68,6 +69,7 @@ export async function dispatchGraphViewPluginReadyMessage(
       loadAndSendData: () => void context.loadAndSendData(),
       sendFavorites: () => context.sendFavorites(),
       sendSettings: () => context.sendSettings(),
+      sendGraphLayout: () => context.sendGraphLayout?.(),
       sendPhysicsSettings: () => context.sendPhysicsSettings(),
       sendGroupsUpdated: () => context.sendGroupsUpdated(),
       sendMessage: message => context.sendMessage(message),

--- a/packages/extension/src/extension/graphView/webview/dispatch/routed.ts
+++ b/packages/extension/src/extension/graphView/webview/dispatch/routed.ts
@@ -5,6 +5,7 @@ import { applyNodeFileMessage } from '../nodeFile/router';
 import { applyPhysicsMessage } from '../messages/physics';
 import { applySurfaceMessage } from '../messages/surface';
 import { applyTimelineMessage } from '../messages/timeline';
+import { applyGraphLayoutMessage } from '../messages/graphLayout';
 import { createGraphViewPrimaryExportHandlers } from './exportHandlers';
 import type { GraphViewPrimaryMessageContext, GraphViewPrimaryMessageResult } from './primary';
 import { createGraphViewPrimaryNodeFileHandlers } from './primaryState';
@@ -30,6 +31,10 @@ export async function dispatchGraphViewPrimaryRouteMessage(
   }
 
   if (await applyPhysicsMessage(message, context)) {
+    return { handled: true };
+  }
+
+  if (await applyGraphLayoutMessage(message, context)) {
     return { handled: true };
   }
 

--- a/packages/extension/src/extension/graphView/webview/messages/graphLayout.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/graphLayout.ts
@@ -1,0 +1,63 @@
+import type { WebviewToExtensionMessage } from '../../../../shared/protocol/webviewToExtension';
+import type { ExtensionToWebviewMessage } from '../../../../shared/protocol/extensionToWebview';
+import {
+  clearGraphLayoutNodePin,
+  createDefaultGraphLayoutSettings,
+  normalizeGraphLayoutSettings,
+  setGraphLayoutNodePin,
+  type GraphLayoutSettings,
+} from '../../../repoSettings/graphLayout/model';
+
+export interface GraphLayoutMessageHandlers {
+  getConfig<T>(key: string, defaultValue: T): T;
+  updateConfig(key: string, value: unknown): Promise<void>;
+  sendMessage(message: ExtensionToWebviewMessage): void;
+}
+
+function readCurrentGraphLayout(handlers: Pick<GraphLayoutMessageHandlers, 'getConfig'>): GraphLayoutSettings {
+  return normalizeGraphLayoutSettings(
+    handlers.getConfig('graphLayout', createDefaultGraphLayoutSettings()),
+  );
+}
+
+async function persistAndSendGraphLayout(
+  handlers: GraphLayoutMessageHandlers,
+  graphLayout: GraphLayoutSettings,
+): Promise<void> {
+  await handlers.updateConfig('graphLayout', graphLayout);
+  handlers.sendMessage({
+    type: 'GRAPH_LAYOUT_UPDATED',
+    payload: graphLayout,
+  });
+}
+
+export async function applyGraphLayoutMessage(
+  message: WebviewToExtensionMessage,
+  handlers: GraphLayoutMessageHandlers,
+): Promise<boolean> {
+  switch (message.type) {
+    case 'UPDATE_GRAPH_LAYOUT_PIN': {
+      const nextLayout = setGraphLayoutNodePin(readCurrentGraphLayout(handlers), {
+        ...message.payload,
+        updatedAt: new Date().toISOString(),
+      });
+
+      await persistAndSendGraphLayout(handlers, nextLayout);
+      return true;
+    }
+
+    case 'CLEAR_GRAPH_LAYOUT_PIN': {
+      const nextLayout = clearGraphLayoutNodePin(
+        readCurrentGraphLayout(handlers),
+        message.payload.nodeId,
+        message.payload.graphMode,
+      );
+
+      await persistAndSendGraphLayout(handlers, nextLayout);
+      return true;
+    }
+
+    default:
+      return false;
+  }
+}

--- a/packages/extension/src/extension/graphView/webview/messages/graphLayout.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/graphLayout.ts
@@ -37,10 +37,7 @@ export async function applyGraphLayoutMessage(
 ): Promise<boolean> {
   switch (message.type) {
     case 'UPDATE_GRAPH_LAYOUT_PIN': {
-      const nextLayout = setGraphLayoutNodePin(readCurrentGraphLayout(handlers), {
-        ...message.payload,
-        updatedAt: new Date().toISOString(),
-      });
+      const nextLayout = setGraphLayoutNodePin(readCurrentGraphLayout(handlers), message.payload);
 
       await persistAndSendGraphLayout(handlers, nextLayout);
       return true;

--- a/packages/extension/src/extension/graphView/webview/messages/ready.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/ready.ts
@@ -25,6 +25,7 @@ export interface GraphViewReadyHandlers {
   loadAndSendData(): void;
   sendFavorites(): void;
   sendSettings(): void;
+  sendGraphLayout?(): void;
   sendPhysicsSettings(): void;
   sendGroupsUpdated(): void;
   sendMessage(message: { type: string; payload: unknown }): void;
@@ -50,6 +51,7 @@ export async function applyWebviewReady(
   handlers.loadAndSendData();
   handlers.sendFavorites();
   handlers.sendSettings();
+  handlers.sendGraphLayout?.();
   handlers.sendPhysicsSettings();
   handlers.sendGroupsUpdated();
   handlers.sendMessage({

--- a/packages/extension/src/extension/graphView/webview/providerMessages/pluginContext.ts
+++ b/packages/extension/src/extension/graphView/webview/providerMessages/pluginContext.ts
@@ -9,10 +9,7 @@ import {
   setPluginUserGroups,
   setPluginWebviewReadyNotified,
 } from './pluginState';
-import {
-  createDefaultGraphLayoutSettings,
-  normalizeGraphLayoutSettings,
-} from '../../../repoSettings/graphLayout/model';
+import { createGraphLayoutUpdatedMessage } from '../../graphLayout/message';
 
 type GraphViewProviderPluginContext = Pick<
   GraphViewMessageListenerContext,
@@ -67,15 +64,7 @@ export function createGraphViewProviderMessagePluginContext(
     sendGraphControls: () => source._sendGraphControls?.(),
     sendFavorites: () => source._sendFavorites(),
     sendSettings: () => source._sendSettings(),
-    sendGraphLayout: () => {
-      const configuration = dependencies.workspace.getConfiguration('codegraphy');
-      source._sendMessage({
-        type: 'GRAPH_LAYOUT_UPDATED',
-        payload: normalizeGraphLayoutSettings(
-          configuration.get('graphLayout', createDefaultGraphLayoutSettings()),
-        ),
-      });
-    },
+    sendGraphLayout: () => source._sendMessage(createGraphLayoutUpdatedMessage()),
     sendCachedTimeline: () => source._sendCachedTimeline(),
     sendDecorations: () => source._sendDecorations(),
     sendContextMenuItems: () => source._sendContextMenuItems(),

--- a/packages/extension/src/extension/graphView/webview/providerMessages/pluginContext.ts
+++ b/packages/extension/src/extension/graphView/webview/providerMessages/pluginContext.ts
@@ -9,6 +9,10 @@ import {
   setPluginUserGroups,
   setPluginWebviewReadyNotified,
 } from './pluginState';
+import {
+  createDefaultGraphLayoutSettings,
+  normalizeGraphLayoutSettings,
+} from '../../../repoSettings/graphLayout/model';
 
 type GraphViewProviderPluginContext = Pick<
   GraphViewMessageListenerContext,
@@ -22,6 +26,7 @@ type GraphViewProviderPluginContext = Pick<
   | 'sendGraphControls'
   | 'sendFavorites'
   | 'sendSettings'
+  | 'sendGraphLayout'
   | 'sendCachedTimeline'
   | 'sendDecorations'
   | 'sendContextMenuItems'
@@ -62,6 +67,15 @@ export function createGraphViewProviderMessagePluginContext(
     sendGraphControls: () => source._sendGraphControls?.(),
     sendFavorites: () => source._sendFavorites(),
     sendSettings: () => source._sendSettings(),
+    sendGraphLayout: () => {
+      const configuration = dependencies.workspace.getConfiguration('codegraphy');
+      source._sendMessage({
+        type: 'GRAPH_LAYOUT_UPDATED',
+        payload: normalizeGraphLayoutSettings(
+          configuration.get('graphLayout', createDefaultGraphLayoutSettings()),
+        ),
+      });
+    },
     sendCachedTimeline: () => source._sendCachedTimeline(),
     sendDecorations: () => source._sendDecorations(),
     sendContextMenuItems: () => source._sendContextMenuItems(),

--- a/packages/extension/src/extension/repoSettings/defaults.ts
+++ b/packages/extension/src/extension/repoSettings/defaults.ts
@@ -11,7 +11,7 @@ import {
 import {
   createDefaultGraphLayoutSettings,
   type GraphLayoutSettings,
-} from './graphLayout/model';
+} from '../../shared/settings/graphLayout';
 
 export interface ICodeGraphyRepoSettings {
   version: 1;

--- a/packages/extension/src/extension/repoSettings/defaults.ts
+++ b/packages/extension/src/extension/repoSettings/defaults.ts
@@ -8,6 +8,10 @@ import {
   createDefaultNodeColors,
   createDefaultNodeVisibility,
 } from '../../shared/graphControls/defaults/maps';
+import {
+  createDefaultGraphLayoutSettings,
+  type GraphLayoutSettings,
+} from './graphLayout/model';
 
 export interface ICodeGraphyRepoSettings {
   version: 1;
@@ -50,6 +54,7 @@ export interface ICodeGraphyRepoSettings {
     maxCommits: number;
     playbackSpeed: number;
   };
+  graphLayout: GraphLayoutSettings;
 }
 
 export function createDefaultCodeGraphyRepoSettings(): ICodeGraphyRepoSettings {
@@ -94,5 +99,6 @@ export function createDefaultCodeGraphyRepoSettings(): ICodeGraphyRepoSettings {
       maxCommits: 500,
       playbackSpeed: 1,
     },
+    graphLayout: createDefaultGraphLayoutSettings(),
   };
 }

--- a/packages/extension/src/extension/repoSettings/graphLayout/model.ts
+++ b/packages/extension/src/extension/repoSettings/graphLayout/model.ts
@@ -1,0 +1,365 @@
+import { isPlainObject } from '../store/model/plainObject';
+
+export interface GraphLayoutCoordinate2D {
+  x: number;
+  y: number;
+}
+
+export interface GraphLayoutCoordinate3D extends GraphLayoutCoordinate2D {
+  z: number;
+}
+
+export interface GraphLayoutPinnedNode {
+  nodeId: string;
+  twoDimensional?: GraphLayoutCoordinate2D;
+  threeDimensional?: GraphLayoutCoordinate3D;
+  updatedAt: string;
+}
+
+export interface GraphLayoutSection {
+  id: string;
+  label: string;
+  color: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  collapsed: boolean;
+  updatedAt: string;
+}
+
+export interface GraphLayoutOwnership {
+  itemId: string;
+  itemKind: 'node' | 'section';
+  ownerSectionId: string | null;
+  updatedAt: string;
+}
+
+export interface GraphLayoutSettings {
+  pinnedNodes: Record<string, GraphLayoutPinnedNode>;
+  sections: Record<string, GraphLayoutSection>;
+  ownership: Record<string, GraphLayoutOwnership>;
+}
+
+export function createDefaultGraphLayoutSettings(): GraphLayoutSettings {
+  return {
+    pinnedNodes: {},
+    sections: {},
+    ownership: {},
+  };
+}
+
+function readRequiredString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0
+    ? value
+    : undefined;
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function readPositiveNumber(value: unknown): number | undefined {
+  const numberValue = readFiniteNumber(value);
+  return numberValue !== undefined && numberValue > 0
+    ? numberValue
+    : undefined;
+}
+
+function readCoordinate2D(value: unknown): GraphLayoutCoordinate2D | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const x = readFiniteNumber(value.x);
+  const y = readFiniteNumber(value.y);
+  if (x === undefined || y === undefined) {
+    return undefined;
+  }
+
+  return { x, y };
+}
+
+function readCoordinate3D(value: unknown): GraphLayoutCoordinate3D | undefined {
+  const coordinate2D = readCoordinate2D(value);
+  if (!coordinate2D || !isPlainObject(value)) {
+    return undefined;
+  }
+
+  const z = readFiniteNumber(value.z);
+  if (z === undefined) {
+    return undefined;
+  }
+
+  return { ...coordinate2D, z };
+}
+
+function normalizePinnedNode(
+  key: string,
+  value: unknown,
+): GraphLayoutPinnedNode | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const nodeId = readRequiredString(value.nodeId);
+  const updatedAt = readRequiredString(value.updatedAt);
+  if (nodeId !== key || !updatedAt) {
+    return undefined;
+  }
+
+  const twoDimensional = readCoordinate2D(value.twoDimensional);
+  const threeDimensional = readCoordinate3D(value.threeDimensional);
+  if (!twoDimensional && !threeDimensional) {
+    return undefined;
+  }
+
+  return {
+    nodeId,
+    ...(twoDimensional ? { twoDimensional } : {}),
+    ...(threeDimensional ? { threeDimensional } : {}),
+    updatedAt,
+  };
+}
+
+function normalizePinnedNodes(value: unknown): Record<string, GraphLayoutPinnedNode> {
+  if (!isPlainObject(value)) {
+    return {};
+  }
+
+  const pinnedNodes: Record<string, GraphLayoutPinnedNode> = {};
+  for (const [key, entryValue] of Object.entries(value)) {
+    const pinnedNode = normalizePinnedNode(key, entryValue);
+    if (pinnedNode) {
+      pinnedNodes[key] = pinnedNode;
+    }
+  }
+
+  return pinnedNodes;
+}
+
+function normalizeSection(
+  key: string,
+  value: unknown,
+): GraphLayoutSection | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const id = readRequiredString(value.id);
+  const label = readRequiredString(value.label);
+  const color = readRequiredString(value.color);
+  const x = readFiniteNumber(value.x);
+  const y = readFiniteNumber(value.y);
+  const width = readPositiveNumber(value.width);
+  const height = readPositiveNumber(value.height);
+  const updatedAt = readRequiredString(value.updatedAt);
+
+  if (
+    id !== key
+    || !label
+    || !color
+    || x === undefined
+    || y === undefined
+    || width === undefined
+    || height === undefined
+    || typeof value.collapsed !== 'boolean'
+    || !updatedAt
+  ) {
+    return undefined;
+  }
+
+  return {
+    id,
+    label,
+    color,
+    x,
+    y,
+    width,
+    height,
+    collapsed: value.collapsed,
+    updatedAt,
+  };
+}
+
+function normalizeSections(value: unknown): Record<string, GraphLayoutSection> {
+  if (!isPlainObject(value)) {
+    return {};
+  }
+
+  const sections: Record<string, GraphLayoutSection> = {};
+  for (const [key, entryValue] of Object.entries(value)) {
+    const section = normalizeSection(key, entryValue);
+    if (section) {
+      sections[key] = section;
+    }
+  }
+
+  return sections;
+}
+
+function normalizeOwnerSectionId(
+  itemId: string,
+  itemKind: GraphLayoutOwnership['itemKind'],
+  ownerSectionId: unknown,
+  sections: Record<string, GraphLayoutSection>,
+): string | null | undefined {
+  if (ownerSectionId === null) {
+    return null;
+  }
+
+  if (typeof ownerSectionId !== 'string' || !(ownerSectionId in sections)) {
+    return undefined;
+  }
+
+  if (itemKind === 'section' && ownerSectionId === itemId) {
+    return undefined;
+  }
+
+  return ownerSectionId;
+}
+
+function normalizeOwnershipRecord(
+  key: string,
+  value: unknown,
+  sections: Record<string, GraphLayoutSection>,
+): GraphLayoutOwnership | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const itemId = readRequiredString(value.itemId);
+  const updatedAt = readRequiredString(value.updatedAt);
+  if (itemId !== key || !updatedAt) {
+    return undefined;
+  }
+
+  if (value.itemKind !== 'node' && value.itemKind !== 'section') {
+    return undefined;
+  }
+
+  if (value.itemKind === 'section' && !(itemId in sections)) {
+    return undefined;
+  }
+
+  const ownerSectionId = normalizeOwnerSectionId(
+    itemId,
+    value.itemKind,
+    value.ownerSectionId,
+    sections,
+  );
+  if (ownerSectionId === undefined) {
+    return undefined;
+  }
+
+  return {
+    itemId,
+    itemKind: value.itemKind,
+    ownerSectionId,
+    updatedAt,
+  };
+}
+
+export function wouldCreateGraphLayoutOwnershipCycle(
+  ownership: Readonly<Record<string, GraphLayoutOwnership>>,
+  sectionId: string,
+  ownerSectionId: string | null,
+): boolean {
+  let currentOwnerId = ownerSectionId;
+  const visited = new Set<string>([sectionId]);
+
+  while (currentOwnerId) {
+    if (visited.has(currentOwnerId)) {
+      return true;
+    }
+
+    visited.add(currentOwnerId);
+    const ownerRecord = ownership[currentOwnerId];
+    currentOwnerId = ownerRecord?.itemKind === 'section'
+      ? ownerRecord.ownerSectionId
+      : null;
+  }
+
+  return false;
+}
+
+function normalizeOwnership(
+  value: unknown,
+  sections: Record<string, GraphLayoutSection>,
+): Record<string, GraphLayoutOwnership> {
+  if (!isPlainObject(value)) {
+    return {};
+  }
+
+  const ownership: Record<string, GraphLayoutOwnership> = {};
+  for (const [key, entryValue] of Object.entries(value)) {
+    const record = normalizeOwnershipRecord(key, entryValue, sections);
+    if (!record) {
+      continue;
+    }
+
+    if (
+      record.itemKind === 'section'
+      && wouldCreateGraphLayoutOwnershipCycle(
+        ownership,
+        record.itemId,
+        record.ownerSectionId,
+      )
+    ) {
+      continue;
+    }
+
+    ownership[key] = record;
+  }
+
+  return ownership;
+}
+
+export function normalizeGraphLayoutSettings(value: unknown): GraphLayoutSettings {
+  if (!isPlainObject(value)) {
+    return createDefaultGraphLayoutSettings();
+  }
+
+  const sections = normalizeSections(value.sections);
+
+  return {
+    pinnedNodes: normalizePinnedNodes(value.pinnedNodes),
+    sections,
+    ownership: normalizeOwnership(value.ownership, sections),
+  };
+}
+
+export function assignGraphLayoutOwner(
+  layout: GraphLayoutSettings,
+  ownership: GraphLayoutOwnership,
+): GraphLayoutSettings {
+  const normalizedRecord = normalizeOwnershipRecord(
+    ownership.itemId,
+    ownership,
+    layout.sections,
+  );
+  if (!normalizedRecord) {
+    throw new Error('Graph Section ownership record is invalid.');
+  }
+
+  if (
+    normalizedRecord.itemKind === 'section'
+    && wouldCreateGraphLayoutOwnershipCycle(
+      layout.ownership,
+      normalizedRecord.itemId,
+      normalizedRecord.ownerSectionId,
+    )
+  ) {
+    throw new Error('Graph Section ownership cannot create a cycle.');
+  }
+
+  return {
+    ...layout,
+    ownership: {
+      ...layout.ownership,
+      [normalizedRecord.itemId]: normalizedRecord,
+    },
+  };
+}

--- a/packages/extension/src/extension/repoSettings/graphLayout/model.ts
+++ b/packages/extension/src/extension/repoSettings/graphLayout/model.ts
@@ -66,22 +66,20 @@ function normalizePinnedNode(
   }
 
   const nodeId = readRequiredString(value.nodeId);
-  const updatedAt = readRequiredString(value.updatedAt);
-  if (nodeId !== key || !updatedAt) {
+  if (nodeId !== key) {
     return undefined;
   }
 
-  const twoDimensional = readCoordinate2D(value.twoDimensional);
-  const threeDimensional = readCoordinate3D(value.threeDimensional);
+  const twoDimensional = readCoordinate2D(value['2D']);
+  const threeDimensional = readCoordinate3D(value['3D']);
   if (!twoDimensional && !threeDimensional) {
     return undefined;
   }
 
   return {
     nodeId,
-    ...(twoDimensional ? { twoDimensional } : {}),
-    ...(threeDimensional ? { threeDimensional } : {}),
-    updatedAt,
+    ...(twoDimensional ? { '2D': twoDimensional } : {}),
+    ...(threeDimensional ? { '3D': threeDimensional } : {}),
   };
 }
 
@@ -115,7 +113,6 @@ export interface GraphLayoutNodePinUpdate {
   graphMode: GraphLayoutMode;
   nodeId: string;
   position: GraphLayoutCoordinate2D | GraphLayoutCoordinate3D;
-  updatedAt: string;
 }
 
 function isCoordinate3D(
@@ -131,13 +128,12 @@ export function setGraphLayoutNodePin(
   const existing = layout.pinnedNodes[update.nodeId];
   const nextPinnedNode: GraphLayoutPinnedNode = {
     nodeId: update.nodeId,
-    twoDimensional: update.graphMode === '2d'
+    '2D': update.graphMode === '2d'
       ? { x: update.position.x, y: update.position.y }
-      : existing?.twoDimensional,
-    threeDimensional: update.graphMode === '3d' && isCoordinate3D(update.position)
+      : existing?.['2D'],
+    '3D': update.graphMode === '3d' && isCoordinate3D(update.position)
       ? { x: update.position.x, y: update.position.y, z: update.position.z }
-      : existing?.threeDimensional,
-    updatedAt: update.updatedAt,
+      : existing?.['3D'],
   };
 
   return normalizeGraphLayoutSettings({
@@ -162,11 +158,11 @@ export function clearGraphLayoutNodePin(
   const nextPinnedNodes = { ...layout.pinnedNodes };
   const nextPinnedNode: GraphLayoutPinnedNode = {
     ...existing,
-    ...(graphMode === '2d' ? { twoDimensional: undefined } : {}),
-    ...(graphMode === '3d' ? { threeDimensional: undefined } : {}),
+    ...(graphMode === '2d' ? { '2D': undefined } : {}),
+    ...(graphMode === '3d' ? { '3D': undefined } : {}),
   };
 
-  if (!nextPinnedNode.twoDimensional && !nextPinnedNode.threeDimensional) {
+  if (!nextPinnedNode['2D'] && !nextPinnedNode['3D']) {
     delete nextPinnedNodes[nodeId];
   } else {
     nextPinnedNodes[nodeId] = nextPinnedNode;

--- a/packages/extension/src/extension/repoSettings/graphLayout/model.ts
+++ b/packages/extension/src/extension/repoSettings/graphLayout/model.ts
@@ -4,9 +4,7 @@ import {
   type GraphLayoutCoordinate2D,
   type GraphLayoutCoordinate3D,
   type GraphLayoutMode,
-  type GraphLayoutOwnership,
   type GraphLayoutPinnedNode,
-  type GraphLayoutSection,
   type GraphLayoutSettings,
 } from '../../../shared/settings/graphLayout';
 
@@ -15,9 +13,7 @@ export type {
   GraphLayoutCoordinate2D,
   GraphLayoutCoordinate3D,
   GraphLayoutMode,
-  GraphLayoutOwnership,
   GraphLayoutPinnedNode,
-  GraphLayoutSection,
   GraphLayoutSettings,
 };
 
@@ -30,13 +26,6 @@ function readRequiredString(value: unknown): string | undefined {
 function readFiniteNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value)
     ? value
-    : undefined;
-}
-
-function readPositiveNumber(value: unknown): number | undefined {
-  const numberValue = readFiniteNumber(value);
-  return numberValue !== undefined && numberValue > 0
-    ? numberValue
     : undefined;
 }
 
@@ -112,227 +101,13 @@ function normalizePinnedNodes(value: unknown): Record<string, GraphLayoutPinnedN
   return pinnedNodes;
 }
 
-function normalizeSection(
-  key: string,
-  value: unknown,
-): GraphLayoutSection | undefined {
-  if (!isPlainObject(value)) {
-    return undefined;
-  }
-
-  const id = readRequiredString(value.id);
-  const label = readRequiredString(value.label);
-  const color = readRequiredString(value.color);
-  const x = readFiniteNumber(value.x);
-  const y = readFiniteNumber(value.y);
-  const width = readPositiveNumber(value.width);
-  const height = readPositiveNumber(value.height);
-  const updatedAt = readRequiredString(value.updatedAt);
-
-  if (
-    id !== key
-    || !label
-    || !color
-    || x === undefined
-    || y === undefined
-    || width === undefined
-    || height === undefined
-    || typeof value.collapsed !== 'boolean'
-    || !updatedAt
-  ) {
-    return undefined;
-  }
-
-  return {
-    id,
-    label,
-    color,
-    x,
-    y,
-    width,
-    height,
-    collapsed: value.collapsed,
-    updatedAt,
-  };
-}
-
-function normalizeSections(value: unknown): Record<string, GraphLayoutSection> {
-  if (!isPlainObject(value)) {
-    return {};
-  }
-
-  const sections: Record<string, GraphLayoutSection> = {};
-  for (const [key, entryValue] of Object.entries(value)) {
-    const section = normalizeSection(key, entryValue);
-    if (section) {
-      sections[key] = section;
-    }
-  }
-
-  return sections;
-}
-
-function normalizeOwnerSectionId(
-  itemId: string,
-  itemKind: GraphLayoutOwnership['itemKind'],
-  ownerSectionId: unknown,
-  sections: Record<string, GraphLayoutSection>,
-): string | null | undefined {
-  if (ownerSectionId === null) {
-    return null;
-  }
-
-  if (typeof ownerSectionId !== 'string' || !(ownerSectionId in sections)) {
-    return undefined;
-  }
-
-  if (itemKind === 'section' && ownerSectionId === itemId) {
-    return undefined;
-  }
-
-  return ownerSectionId;
-}
-
-function normalizeOwnershipRecord(
-  key: string,
-  value: unknown,
-  sections: Record<string, GraphLayoutSection>,
-): GraphLayoutOwnership | undefined {
-  if (!isPlainObject(value)) {
-    return undefined;
-  }
-
-  const itemId = readRequiredString(value.itemId);
-  const updatedAt = readRequiredString(value.updatedAt);
-  if (itemId !== key || !updatedAt) {
-    return undefined;
-  }
-
-  if (value.itemKind !== 'node' && value.itemKind !== 'section') {
-    return undefined;
-  }
-
-  if (value.itemKind === 'section' && !(itemId in sections)) {
-    return undefined;
-  }
-
-  const ownerSectionId = normalizeOwnerSectionId(
-    itemId,
-    value.itemKind,
-    value.ownerSectionId,
-    sections,
-  );
-  if (ownerSectionId === undefined) {
-    return undefined;
-  }
-
-  return {
-    itemId,
-    itemKind: value.itemKind,
-    ownerSectionId,
-    updatedAt,
-  };
-}
-
-export function wouldCreateGraphLayoutOwnershipCycle(
-  ownership: Readonly<Record<string, GraphLayoutOwnership>>,
-  sectionId: string,
-  ownerSectionId: string | null,
-): boolean {
-  let currentOwnerId = ownerSectionId;
-  const visited = new Set<string>([sectionId]);
-
-  while (currentOwnerId) {
-    if (visited.has(currentOwnerId)) {
-      return true;
-    }
-
-    visited.add(currentOwnerId);
-    const ownerRecord = ownership[currentOwnerId];
-    currentOwnerId = ownerRecord?.itemKind === 'section'
-      ? ownerRecord.ownerSectionId
-      : null;
-  }
-
-  return false;
-}
-
-function normalizeOwnership(
-  value: unknown,
-  sections: Record<string, GraphLayoutSection>,
-): Record<string, GraphLayoutOwnership> {
-  if (!isPlainObject(value)) {
-    return {};
-  }
-
-  const ownership: Record<string, GraphLayoutOwnership> = {};
-  for (const [key, entryValue] of Object.entries(value)) {
-    const record = normalizeOwnershipRecord(key, entryValue, sections);
-    if (!record) {
-      continue;
-    }
-
-    if (
-      record.itemKind === 'section'
-      && wouldCreateGraphLayoutOwnershipCycle(
-        ownership,
-        record.itemId,
-        record.ownerSectionId,
-      )
-    ) {
-      continue;
-    }
-
-    ownership[key] = record;
-  }
-
-  return ownership;
-}
-
 export function normalizeGraphLayoutSettings(value: unknown): GraphLayoutSettings {
   if (!isPlainObject(value)) {
     return createDefaultGraphLayoutSettings();
   }
 
-  const sections = normalizeSections(value.sections);
-
   return {
     pinnedNodes: normalizePinnedNodes(value.pinnedNodes),
-    sections,
-    ownership: normalizeOwnership(value.ownership, sections),
-  };
-}
-
-export function assignGraphLayoutOwner(
-  layout: GraphLayoutSettings,
-  ownership: GraphLayoutOwnership,
-): GraphLayoutSettings {
-  const normalizedRecord = normalizeOwnershipRecord(
-    ownership.itemId,
-    ownership,
-    layout.sections,
-  );
-  if (!normalizedRecord) {
-    throw new Error('Graph Section ownership record is invalid.');
-  }
-
-  if (
-    normalizedRecord.itemKind === 'section'
-    && wouldCreateGraphLayoutOwnershipCycle(
-      layout.ownership,
-      normalizedRecord.itemId,
-      normalizedRecord.ownerSectionId,
-    )
-  ) {
-    throw new Error('Graph Section ownership cannot create a cycle.');
-  }
-
-  return {
-    ...layout,
-    ownership: {
-      ...layout.ownership,
-      [normalizedRecord.itemId]: normalizedRecord,
-    },
   };
 }
 

--- a/packages/extension/src/extension/repoSettings/graphLayout/model.ts
+++ b/packages/extension/src/extension/repoSettings/graphLayout/model.ts
@@ -1,53 +1,25 @@
 import { isPlainObject } from '../store/model/plainObject';
+import {
+  createDefaultGraphLayoutSettings,
+  type GraphLayoutCoordinate2D,
+  type GraphLayoutCoordinate3D,
+  type GraphLayoutMode,
+  type GraphLayoutOwnership,
+  type GraphLayoutPinnedNode,
+  type GraphLayoutSection,
+  type GraphLayoutSettings,
+} from '../../../shared/settings/graphLayout';
 
-export interface GraphLayoutCoordinate2D {
-  x: number;
-  y: number;
-}
-
-export interface GraphLayoutCoordinate3D extends GraphLayoutCoordinate2D {
-  z: number;
-}
-
-export interface GraphLayoutPinnedNode {
-  nodeId: string;
-  twoDimensional?: GraphLayoutCoordinate2D;
-  threeDimensional?: GraphLayoutCoordinate3D;
-  updatedAt: string;
-}
-
-export interface GraphLayoutSection {
-  id: string;
-  label: string;
-  color: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  collapsed: boolean;
-  updatedAt: string;
-}
-
-export interface GraphLayoutOwnership {
-  itemId: string;
-  itemKind: 'node' | 'section';
-  ownerSectionId: string | null;
-  updatedAt: string;
-}
-
-export interface GraphLayoutSettings {
-  pinnedNodes: Record<string, GraphLayoutPinnedNode>;
-  sections: Record<string, GraphLayoutSection>;
-  ownership: Record<string, GraphLayoutOwnership>;
-}
-
-export function createDefaultGraphLayoutSettings(): GraphLayoutSettings {
-  return {
-    pinnedNodes: {},
-    sections: {},
-    ownership: {},
-  };
-}
+export { createDefaultGraphLayoutSettings };
+export type {
+  GraphLayoutCoordinate2D,
+  GraphLayoutCoordinate3D,
+  GraphLayoutMode,
+  GraphLayoutOwnership,
+  GraphLayoutPinnedNode,
+  GraphLayoutSection,
+  GraphLayoutSettings,
+};
 
 function readRequiredString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0
@@ -362,4 +334,71 @@ export function assignGraphLayoutOwner(
       [normalizedRecord.itemId]: normalizedRecord,
     },
   };
+}
+
+export interface GraphLayoutNodePinUpdate {
+  graphMode: GraphLayoutMode;
+  nodeId: string;
+  position: GraphLayoutCoordinate2D | GraphLayoutCoordinate3D;
+  updatedAt: string;
+}
+
+function isCoordinate3D(
+  position: GraphLayoutCoordinate2D | GraphLayoutCoordinate3D,
+): position is GraphLayoutCoordinate3D {
+  return 'z' in position;
+}
+
+export function setGraphLayoutNodePin(
+  layout: GraphLayoutSettings,
+  update: GraphLayoutNodePinUpdate,
+): GraphLayoutSettings {
+  const existing = layout.pinnedNodes[update.nodeId];
+  const nextPinnedNode: GraphLayoutPinnedNode = {
+    nodeId: update.nodeId,
+    twoDimensional: update.graphMode === '2d'
+      ? { x: update.position.x, y: update.position.y }
+      : existing?.twoDimensional,
+    threeDimensional: update.graphMode === '3d' && isCoordinate3D(update.position)
+      ? { x: update.position.x, y: update.position.y, z: update.position.z }
+      : existing?.threeDimensional,
+    updatedAt: update.updatedAt,
+  };
+
+  return normalizeGraphLayoutSettings({
+    ...layout,
+    pinnedNodes: {
+      ...layout.pinnedNodes,
+      [update.nodeId]: nextPinnedNode,
+    },
+  });
+}
+
+export function clearGraphLayoutNodePin(
+  layout: GraphLayoutSettings,
+  nodeId: string,
+  graphMode: GraphLayoutMode,
+): GraphLayoutSettings {
+  const existing = layout.pinnedNodes[nodeId];
+  if (!existing) {
+    return layout;
+  }
+
+  const nextPinnedNodes = { ...layout.pinnedNodes };
+  const nextPinnedNode: GraphLayoutPinnedNode = {
+    ...existing,
+    ...(graphMode === '2d' ? { twoDimensional: undefined } : {}),
+    ...(graphMode === '3d' ? { threeDimensional: undefined } : {}),
+  };
+
+  if (!nextPinnedNode.twoDimensional && !nextPinnedNode.threeDimensional) {
+    delete nextPinnedNodes[nodeId];
+  } else {
+    nextPinnedNodes[nodeId] = nextPinnedNode;
+  }
+
+  return normalizeGraphLayoutSettings({
+    ...layout,
+    pinnedNodes: nextPinnedNodes,
+  });
 }

--- a/packages/extension/src/extension/repoSettings/store/model/persistedShape.ts
+++ b/packages/extension/src/extension/repoSettings/store/model/persistedShape.ts
@@ -1,4 +1,5 @@
 import { isPlainObject } from './plainObject';
+import { normalizeGraphLayoutSettings } from '../../graphLayout/model';
 
 const TOP_LEVEL_SETTINGS_KEYS = new Set([
   'version',
@@ -31,6 +32,7 @@ const TOP_LEVEL_SETTINGS_KEYS = new Set([
   'nodeSizeMode',
   'physics',
   'timeline',
+  'graphLayout',
 ]);
 
 const PHYSICS_SETTINGS_KEYS = new Set([
@@ -138,6 +140,12 @@ function normalizePersistedLegend(normalized: Record<string, unknown>): void {
   }
 }
 
+function normalizePersistedGraphLayout(normalized: Record<string, unknown>): void {
+  if ('graphLayout' in normalized) {
+    normalized.graphLayout = normalizeGraphLayoutSettings(normalized.graphLayout);
+  }
+}
+
 export function normalizePersistedSettingsShape(
   value: unknown,
 ): Record<string, unknown> {
@@ -148,5 +156,6 @@ export function normalizePersistedSettingsShape(
   const normalized = pickTopLevelSettings(value);
   normalizePersistedFilterPatterns(normalized);
   normalizePersistedLegend(normalized);
+  normalizePersistedGraphLayout(normalized);
   return normalized;
 }

--- a/packages/extension/src/shared/protocol/extensionToWebview.ts
+++ b/packages/extension/src/shared/protocol/extensionToWebview.ts
@@ -14,6 +14,7 @@ import type {
 } from '../settings/modes';
 import type { IPhysicsSettings } from '../settings/physics';
 import type { IGroup } from '../settings/groups';
+import type { GraphLayoutSettings } from '../settings/graphLayout';
 import type { ITimelineData } from '../timeline/contracts';
 
 export interface IPluginFilterPatternGroup {
@@ -38,6 +39,7 @@ export type ExtensionToWebviewMessage =
   | { type: 'ZOOM_IN' }
   | { type: 'ZOOM_OUT' }
   | { type: 'FAVORITES_UPDATED'; payload: { favorites: string[] } }
+  | { type: 'GRAPH_LAYOUT_UPDATED'; payload: GraphLayoutSettings }
   | { type: 'THEME_CHANGED'; payload: { kind: 'light' | 'dark' | 'high-contrast' } }
   | { type: 'FILE_INFO'; payload: IFileInfo }
   | {

--- a/packages/extension/src/shared/protocol/webviewToExtension.ts
+++ b/packages/extension/src/shared/protocol/webviewToExtension.ts
@@ -6,6 +6,11 @@ import type {
   NodeSizeMode,
 } from '../settings/modes';
 import type { IPhysicsSettings } from '../settings/physics';
+import type {
+  GraphLayoutCoordinate2D,
+  GraphLayoutCoordinate3D,
+  GraphLayoutMode,
+} from '../settings/graphLayout';
 
 export interface LegendIconImport {
   imagePath: string;
@@ -26,6 +31,21 @@ export type WebviewToExtensionMessage =
   | { type: 'CREATE_FILE'; payload: { directory: string } }
   | { type: 'CREATE_FOLDER'; payload: { directory: string } }
   | { type: 'TOGGLE_FAVORITE'; payload: { paths: string[] } }
+  | {
+      type: 'UPDATE_GRAPH_LAYOUT_PIN';
+      payload: {
+        graphMode: GraphLayoutMode;
+        nodeId: string;
+        position: GraphLayoutCoordinate2D | GraphLayoutCoordinate3D;
+      };
+    }
+  | {
+      type: 'CLEAR_GRAPH_LAYOUT_PIN';
+      payload: {
+        graphMode: GraphLayoutMode;
+        nodeId: string;
+      };
+    }
   | { type: 'ADD_TO_EXCLUDE'; payload: { patterns: string[] } }
   | { type: 'REFRESH_GRAPH' }
   | { type: 'INDEX_GRAPH' }

--- a/packages/extension/src/shared/settings/graphLayout.ts
+++ b/packages/extension/src/shared/settings/graphLayout.ts
@@ -11,9 +11,8 @@ export interface GraphLayoutCoordinate3D extends GraphLayoutCoordinate2D {
 
 export interface GraphLayoutPinnedNode {
   nodeId: string;
-  twoDimensional?: GraphLayoutCoordinate2D;
-  threeDimensional?: GraphLayoutCoordinate3D;
-  updatedAt: string;
+  '2D'?: GraphLayoutCoordinate2D;
+  '3D'?: GraphLayoutCoordinate3D;
 }
 
 export interface GraphLayoutSettings {
@@ -31,6 +30,6 @@ export function getGraphLayoutPinCoordinate(
   graphMode: GraphLayoutMode,
 ): GraphLayoutCoordinate2D | GraphLayoutCoordinate3D | undefined {
   return graphMode === '2d'
-    ? pinnedNode?.twoDimensional
-    : pinnedNode?.threeDimensional;
+    ? pinnedNode?.['2D']
+    : pinnedNode?.['3D'];
 }

--- a/packages/extension/src/shared/settings/graphLayout.ts
+++ b/packages/extension/src/shared/settings/graphLayout.ts
@@ -1,0 +1,59 @@
+export type GraphLayoutMode = '2d' | '3d';
+
+export interface GraphLayoutCoordinate2D {
+  x: number;
+  y: number;
+}
+
+export interface GraphLayoutCoordinate3D extends GraphLayoutCoordinate2D {
+  z: number;
+}
+
+export interface GraphLayoutPinnedNode {
+  nodeId: string;
+  twoDimensional?: GraphLayoutCoordinate2D;
+  threeDimensional?: GraphLayoutCoordinate3D;
+  updatedAt: string;
+}
+
+export interface GraphLayoutSection {
+  id: string;
+  label: string;
+  color: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  collapsed: boolean;
+  updatedAt: string;
+}
+
+export interface GraphLayoutOwnership {
+  itemId: string;
+  itemKind: 'node' | 'section';
+  ownerSectionId: string | null;
+  updatedAt: string;
+}
+
+export interface GraphLayoutSettings {
+  pinnedNodes: Record<string, GraphLayoutPinnedNode>;
+  sections: Record<string, GraphLayoutSection>;
+  ownership: Record<string, GraphLayoutOwnership>;
+}
+
+export function createDefaultGraphLayoutSettings(): GraphLayoutSettings {
+  return {
+    pinnedNodes: {},
+    sections: {},
+    ownership: {},
+  };
+}
+
+export function getGraphLayoutPinCoordinate(
+  pinnedNode: GraphLayoutPinnedNode | undefined,
+  graphMode: GraphLayoutMode,
+): GraphLayoutCoordinate2D | GraphLayoutCoordinate3D | undefined {
+  return graphMode === '2d'
+    ? pinnedNode?.twoDimensional
+    : pinnedNode?.threeDimensional;
+}

--- a/packages/extension/src/shared/settings/graphLayout.ts
+++ b/packages/extension/src/shared/settings/graphLayout.ts
@@ -16,36 +16,13 @@ export interface GraphLayoutPinnedNode {
   updatedAt: string;
 }
 
-export interface GraphLayoutSection {
-  id: string;
-  label: string;
-  color: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  collapsed: boolean;
-  updatedAt: string;
-}
-
-export interface GraphLayoutOwnership {
-  itemId: string;
-  itemKind: 'node' | 'section';
-  ownerSectionId: string | null;
-  updatedAt: string;
-}
-
 export interface GraphLayoutSettings {
   pinnedNodes: Record<string, GraphLayoutPinnedNode>;
-  sections: Record<string, GraphLayoutSection>;
-  ownership: Record<string, GraphLayoutOwnership>;
 }
 
 export function createDefaultGraphLayoutSettings(): GraphLayoutSettings {
   return {
     pinnedNodes: {},
-    sections: {},
-    ownership: {},
   };
 }
 

--- a/packages/extension/src/webview/components/graph/contextActions/builtin/effects.ts
+++ b/packages/extension/src/webview/components/graph/contextActions/builtin/effects.ts
@@ -5,9 +5,11 @@ import {
   createClipboardEffects,
   createCreateFileEffects,
   createCreateFolderEffects,
+  createClearPinNodeEffects,
   createOptionalClipboardEffects,
   createOptionalSinglePathMessageEffects,
   createPathListMessageEffects,
+  createPinNodeEffects,
   createRefreshEffects,
 } from '../messages';
 import {
@@ -38,6 +40,8 @@ const BUILT_IN_CONTEXT_ACTION_EFFECTS = {
     createClipboardEffects(context.targetIds.join('\n')),
   toggleFavorite: (context: GraphContextActionContext) =>
     createPathListMessageEffects('TOGGLE_FAVORITE', context.targetIds),
+  pinNode: (context: GraphContextActionContext) => createPinNodeEffects(context),
+  unpinNode: (context: GraphContextActionContext) => createClearPinNodeEffects(context),
   focus: (context: GraphContextActionContext) => createFocusEffects(context.primaryTargetId),
   addToFilter: (context: GraphContextActionContext) =>
     createPatternPromptEffects(context.targetIds),

--- a/packages/extension/src/webview/components/graph/contextActions/context.ts
+++ b/packages/extension/src/webview/components/graph/contextActions/context.ts
@@ -1,4 +1,19 @@
 import type { GraphContextSelection } from '../contextMenu/contracts';
+import type { GraphLayoutMode } from '../../../../shared/settings/graphLayout';
+
+export interface GraphContextNodePosition2D {
+  x: number;
+  y: number;
+}
+
+export interface GraphContextNodePosition3D extends GraphContextNodePosition2D {
+  z: number;
+}
+
+export interface ResolveGraphContextActionOptions {
+  graphMode?: GraphLayoutMode;
+  nodePositions?: ReadonlyMap<string, GraphContextNodePosition2D | GraphContextNodePosition3D>;
+}
 
 export interface GraphContextActionContext {
   selectionKind: GraphContextSelection['kind'];
@@ -6,11 +21,14 @@ export interface GraphContextActionContext {
   primaryTargetId?: string;
   edgeSourceId?: string;
   edgeTargetId?: string;
+  graphMode: GraphLayoutMode;
   mutationDirectory: string;
+  nodePositions: ReadonlyMap<string, GraphContextNodePosition2D | GraphContextNodePosition3D>;
 }
 
 export function resolveGraphContextActionContext(
-  selection: GraphContextSelection
+  selection: GraphContextSelection,
+  options: ResolveGraphContextActionOptions = {},
 ): GraphContextActionContext {
   const [primaryTargetId, secondaryTargetId] = selection.targets;
   const isEdgeSelection = selection.kind === 'edge';
@@ -21,7 +39,9 @@ export function resolveGraphContextActionContext(
     primaryTargetId,
     edgeSourceId: isEdgeSelection ? primaryTargetId : undefined,
     edgeTargetId: isEdgeSelection ? secondaryTargetId : undefined,
+    graphMode: options.graphMode ?? '2d',
     mutationDirectory: resolveMutationDirectory(primaryTargetId),
+    nodePositions: options.nodePositions ?? new Map(),
   };
 }
 

--- a/packages/extension/src/webview/components/graph/contextActions/messages.ts
+++ b/packages/extension/src/webview/components/graph/contextActions/messages.ts
@@ -1,4 +1,5 @@
 import type { WebviewToExtensionMessage } from '../../../../shared/protocol/webviewToExtension';
+import type { GraphContextActionContext } from './context';
 import type { GraphContextEffect } from './effects';
 
 type SinglePathMessageType = 'REVEAL_IN_EXPLORER' | 'RENAME_FILE';
@@ -47,4 +48,53 @@ export function createCreateFileEffects(directory = '.'): GraphContextEffect[] {
 
 export function createCreateFolderEffects(directory = '.'): GraphContextEffect[] {
   return [createPostMessageEffect({ type: 'CREATE_FOLDER', payload: { directory } })];
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function createPinNodeEffects(context: GraphContextActionContext): GraphContextEffect[] {
+  const nodeId = context.primaryTargetId;
+  if (!nodeId) {
+    return [];
+  }
+
+  const position = context.nodePositions.get(nodeId);
+  if (!position || !isFiniteNumber(position.x) || !isFiniteNumber(position.y)) {
+    return [];
+  }
+
+  if (context.graphMode === '3d') {
+    if (!('z' in position) || !isFiniteNumber(position.z)) {
+      return [];
+    }
+
+    return [createPostMessageEffect({
+      type: 'UPDATE_GRAPH_LAYOUT_PIN',
+      payload: {
+        graphMode: context.graphMode,
+        nodeId,
+        position: { x: position.x, y: position.y, z: position.z },
+      },
+    })];
+  }
+
+  return [createPostMessageEffect({
+    type: 'UPDATE_GRAPH_LAYOUT_PIN',
+    payload: {
+      graphMode: context.graphMode,
+      nodeId,
+      position: { x: position.x, y: position.y },
+    },
+  })];
+}
+
+export function createClearPinNodeEffects(context: GraphContextActionContext): GraphContextEffect[] {
+  return context.primaryTargetId
+    ? [createPostMessageEffect({
+      type: 'CLEAR_GRAPH_LAYOUT_PIN',
+      payload: { graphMode: context.graphMode, nodeId: context.primaryTargetId },
+    })]
+    : [];
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/build/entries.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/build/entries.ts
@@ -30,17 +30,36 @@ function getNodeTargetIds(
 export function buildGraphContextMenuEntries(
   options: BuildGraphContextMenuOptions
 ): GraphContextMenuEntry[] {
-  const { selection, timelineActive, favorites, pluginItems, nodes } = options;
+  const {
+    selection,
+    timelineActive,
+    favorites,
+    pinnedNodeIds = new Set<string>(),
+    pluginItems,
+    nodes,
+  } = options;
   const mutationAvailability = options.mutationAvailability ?? DEFAULT_GRAPH_CONTEXT_MUTATION_AVAILABILITY;
   const decision = decideGraphContextMenu(selection, nodes);
   const baseEntries = decision.kind === 'background'
     ? buildBackgroundEntries(mutationAvailability)
     : decision.kind === 'singleFolderNode'
-      ? buildSingleFolderNodeEntries(decision.target.id, mutationAvailability, favorites)
+      ? buildSingleFolderNodeEntries(
+        decision.target.id,
+        timelineActive,
+        mutationAvailability,
+        favorites,
+        pinnedNodeIds,
+      )
       : decision.kind === 'edge'
         ? buildEdgeEntries(decision.targets)
         : decision.kind === 'emptyNodeSelection'
           ? []
-          : buildNodeEntries(getNodeTargetIds(decision), timelineActive, mutationAvailability, favorites);
+          : buildNodeEntries(
+            getNodeTargetIds(decision),
+            timelineActive,
+            mutationAvailability,
+            favorites,
+            pinnedNodeIds,
+          );
   return [...baseEntries, ...buildPluginEntriesForDecision(decision, pluginItems)];
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
@@ -16,6 +16,8 @@ export type BuiltInContextMenuAction =
   | 'copyEdgeTarget'
   | 'copyEdgeBoth'
   | 'toggleFavorite'
+  | 'pinNode'
+  | 'unpinNode'
   | 'focus'
   | 'addToFilter'
   | 'addNodeLegend'
@@ -63,6 +65,7 @@ export interface BuildGraphContextMenuOptions {
   timelineActive: boolean;
   mutationAvailability?: GraphContextMutationAvailability;
   favorites: ReadonlySet<string>;
+  pinnedNodeIds?: ReadonlySet<string>;
   pluginItems: readonly IPluginContextMenuItem[];
   nodes?: readonly GraphContextMenuNode[];
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/node/entries.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/node/entries.ts
@@ -5,6 +5,7 @@ import {
   buildCopyBlock,
 } from './openCopyBlocks';
 import { buildFavoriteBlock } from './destructive/favoritesBlocks';
+import { buildPinBlock } from './pin/block';
 import {
   buildDestructiveBlock,
   buildFilterBlock,
@@ -15,12 +16,14 @@ export function buildNodeEntries(
   targets: readonly string[],
   timelineActive: boolean,
   mutationAvailability: GraphContextMutationAvailability,
-  favorites: ReadonlySet<string>
+  favorites: ReadonlySet<string>,
+  pinnedNodeIds: ReadonlySet<string> = new Set(),
 ): GraphContextMenuEntry[] {
   const entries: GraphContextMenuEntry[] = [
     ...buildOpenBlock(targets, timelineActive),
     ...buildCopyBlock(targets),
     ...buildFavoriteBlock(targets, favorites),
+    ...(timelineActive ? [] : buildPinBlock(targets, pinnedNodeIds)),
     ...buildFilterBlock(targets),
   ];
 
@@ -33,8 +36,10 @@ export function buildNodeEntries(
 
 export function buildSingleFolderNodeEntries(
   target: string,
+  timelineActive: boolean,
   mutationAvailability: GraphContextMutationAvailability,
-  favorites: ReadonlySet<string>
+  favorites: ReadonlySet<string>,
+  pinnedNodeIds: ReadonlySet<string> = new Set(),
 ): GraphContextMenuEntry[] {
   const targets = [target];
   const entries: GraphContextMenuEntry[] = [];
@@ -52,6 +57,7 @@ export function buildSingleFolderNodeEntries(
     builtInItem('node-reveal', 'Reveal in Explorer', 'reveal'),
     ...buildCopyBlock(targets),
     ...buildFavoriteBlock(targets, favorites),
+    ...(timelineActive ? [] : buildPinBlock(targets, pinnedNodeIds)),
     ...buildFilterBlock(targets),
   );
 

--- a/packages/extension/src/webview/components/graph/contextMenu/node/pin/block.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/node/pin/block.ts
@@ -1,0 +1,22 @@
+import { builtInItem } from '../../common/entryFactories';
+import type { GraphContextMenuEntry } from '../../contracts';
+
+export function buildPinBlock(
+  targets: readonly string[],
+  pinnedNodeIds: ReadonlySet<string>,
+): GraphContextMenuEntry[] {
+  if (targets.length !== 1) {
+    return [];
+  }
+
+  const [target] = targets;
+  const pinned = pinnedNodeIds.has(target);
+
+  return [
+    builtInItem(
+      'node-toggle-pin',
+      pinned ? 'Unpin Node' : 'Pin Node',
+      pinned ? 'unpinNode' : 'pinNode',
+    ),
+  ];
+}

--- a/packages/extension/src/webview/components/graph/model/build.ts
+++ b/packages/extension/src/webview/components/graph/model/build.ts
@@ -1,6 +1,7 @@
 import type { LinkObject, NodeObject } from 'react-force-graph-2d';
 import type { IGraphData } from '../../../../shared/graph/contracts';
 import type { BidirectionalEdgeMode, NodeShape2D, NodeShape3D, NodeSizeMode } from '../../../../shared/settings/modes';
+import type { GraphLayoutMode, GraphLayoutSettings } from '../../../../shared/settings/graphLayout';
 import type { ThemeKind } from '../../../theme/useTheme';
 import { DEFAULT_GRAPH_APPEARANCE, type GraphAppearance } from '../appearance/model';
 import type { NodeType } from '../../../../shared/graph/contracts';
@@ -20,6 +21,7 @@ export type FGNode = NodeObject & {
   borderWidth: number;
   baseOpacity: number;
   isFavorite: boolean;
+  isPinned: boolean;
   nodeType?: NodeType;
   shape2D?: NodeShape2D;
   shape3D?: NodeShape3D;
@@ -53,6 +55,8 @@ export interface BuildGraphDataOptions {
   nodeSizeMode: NodeSizeMode;
   theme: ThemeKind;
   favorites: Set<string>;
+  graphLayout?: GraphLayoutSettings;
+  graphMode?: GraphLayoutMode;
   bidirectionalMode: BidirectionalEdgeMode;
   timelineActive: boolean;
   previousNodes?: Array<Pick<FGNode, 'id' | 'fx' | 'fy' | 'fz' | 'vx' | 'vy' | 'vz' | 'x' | 'y' | 'z'>>;
@@ -69,6 +73,8 @@ export function buildGraphData(options: BuildGraphDataOptions): { nodes: FGNode[
     nodeSizes,
     theme: options.theme,
     favorites: options.favorites,
+    graphLayout: options.graphLayout,
+    graphMode: options.graphMode,
     timelineActive: options.timelineActive,
     previousNodes: options.previousNodes,
     random: options.random,

--- a/packages/extension/src/webview/components/graph/model/node/build.ts
+++ b/packages/extension/src/webview/components/graph/model/node/build.ts
@@ -1,4 +1,10 @@
 import type { IGraphEdge, IGraphNode } from '../../../../../shared/graph/contracts';
+import {
+  createDefaultGraphLayoutSettings,
+  getGraphLayoutPinCoordinate,
+  type GraphLayoutMode,
+  type GraphLayoutSettings,
+} from '../../../../../shared/settings/graphLayout';
 import type { ThemeKind } from '../../../../theme/useTheme';
 import { adjustColorForLightTheme } from '../../../../theme/useTheme';
 import { DEFAULT_GRAPH_APPEARANCE, type GraphAppearance } from '../../appearance/model';
@@ -18,6 +24,8 @@ export interface BuildGraphNodesOptions {
   nodeSizes: Map<string, number>;
   theme: ThemeKind;
   favorites: Set<string>;
+  graphLayout?: GraphLayoutSettings;
+  graphMode?: GraphLayoutMode;
   timelineActive: boolean;
   previousNodes?: Array<Pick<FGNode, 'id' | 'fx' | 'fy' | 'fz' | 'vx' | 'vy' | 'vz' | 'x' | 'y' | 'z'>>;
   random?: () => number;
@@ -77,7 +85,10 @@ function createGraphNode(
   options: {
     appearance: GraphAppearance;
     favorites: ReadonlySet<string>;
+    graphLayout: GraphLayoutSettings;
+    graphMode: GraphLayoutMode;
     nodeSizes: ReadonlyMap<string, number>;
+    timelineActive: boolean;
   },
   isLight: boolean,
   previousNodeStates: ReadonlyMap<string, PreviousNodeState>,
@@ -87,6 +98,14 @@ function createGraphNode(
   const isFocused = node.depthLevel === 0;
   const size = (options.nodeSizes.get(node.id) ?? DEFAULT_NODE_SIZE) * getDepthSizeMultiplier(node.depthLevel);
   const previous = previousNodeStates.get(node.id);
+  const pinCoordinate = options.timelineActive
+    ? undefined
+    : getGraphLayoutPinCoordinate(options.graphLayout.pinnedNodes[node.id], options.graphMode);
+  const x = pinCoordinate?.x ?? node.x ?? previous?.x;
+  const y = pinCoordinate?.y ?? node.y ?? previous?.y;
+  const z = options.graphMode === '3d' && pinCoordinate && 'z' in pinCoordinate
+    ? pinCoordinate.z
+    : previous?.z;
 
   return {
     id: node.id,
@@ -97,19 +116,22 @@ function createGraphNode(
     borderWidth: getNodeBorderWidth(isFocused, isFavorite),
     baseOpacity: getDepthOpacity(node.depthLevel),
     isFavorite,
+    isPinned: !!pinCoordinate,
     nodeType: node.nodeType,
     shape2D: node.shape2D,
     shape3D: node.shape3D,
     imageUrl: node.imageUrl,
-    fx: previous?.fx,
-    fy: previous?.fy,
-    fz: previous?.fz,
+    fx: pinCoordinate?.x,
+    fy: pinCoordinate?.y,
+    fz: options.graphMode === '3d' && pinCoordinate && 'z' in pinCoordinate
+      ? pinCoordinate.z
+      : undefined,
     vx: previous?.vx,
     vy: previous?.vy,
     vz: previous?.vz,
-    x: node.x ?? previous?.x,
-    y: node.y ?? previous?.y,
-    z: previous?.z,
+    x,
+    y,
+    z,
   } as FGNode;
 }
 
@@ -121,6 +143,8 @@ export function buildGraphNodes(options: BuildGraphNodesOptions): FGNode[] {
     nodeSizes,
     theme,
     favorites,
+    graphLayout = createDefaultGraphLayoutSettings(),
+    graphMode = '2d',
     timelineActive,
     previousNodes = [],
     random = Math.random,
@@ -129,7 +153,7 @@ export function buildGraphNodes(options: BuildGraphNodesOptions): FGNode[] {
   const previousNodeStates = createPreviousNodeStateMap(previousNodes);
   const graphNodes = nodes.map(node => createGraphNode(
     node,
-    { appearance, nodeSizes, favorites },
+    { appearance, nodeSizes, favorites, graphLayout, graphMode, timelineActive },
     isLight,
     previousNodeStates,
   ));

--- a/packages/extension/src/webview/components/graph/rendering/node/pinBadge.ts
+++ b/packages/extension/src/webview/components/graph/rendering/node/pinBadge.ts
@@ -1,0 +1,41 @@
+import type { GraphAppearance } from '../../appearance/model';
+import type { FGNode } from '../../model/build';
+
+export interface RenderNodePinBadgeOptions {
+  appearance: Pick<GraphAppearance, 'nodeSelectionBorder'>;
+  ctx: CanvasRenderingContext2D;
+  globalScale: number;
+  node: FGNode;
+}
+
+export function renderNodePinBadge({
+  appearance,
+  ctx,
+  globalScale,
+  node,
+}: RenderNodePinBadgeOptions): void {
+  if (!node.isPinned || node.x === undefined || node.y === undefined) {
+    return;
+  }
+
+  const radius = 5 / globalScale;
+  const centerX = node.x + node.size * 0.7;
+  const centerY = node.y - node.size * 0.7;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+  ctx.fillStyle = appearance.nodeSelectionBorder;
+  ctx.fill();
+  ctx.strokeStyle = node.borderColor;
+  ctx.lineWidth = Math.max(1, 1.25 / globalScale);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo(centerX, centerY - radius * 0.45);
+  ctx.lineTo(centerX, centerY + radius * 0.3);
+  ctx.strokeStyle = node.color;
+  ctx.lineWidth = Math.max(1, 1.5 / globalScale);
+  ctx.stroke();
+  ctx.restore();
+}

--- a/packages/extension/src/webview/components/graph/rendering/node/pinBadge.ts
+++ b/packages/extension/src/webview/components/graph/rendering/node/pinBadge.ts
@@ -6,6 +6,8 @@ import type { FGNode } from '../../model/build';
 const MATERIAL_ICON_VIEWBOX_SIZE = 24;
 const PIN_BADGE_ICON_COLOR = '#ffffff';
 const PIN_BADGE_BACKGROUND_DARKEN_FACTOR = 0.48;
+const PIN_BADGE_HIDDEN_NODE_RADIUS_PX = 5;
+const PIN_BADGE_FULL_OPACITY_NODE_RADIUS_PX = 9;
 let pinIconPath: Path2D | undefined;
 
 function getPinIconPath(): Path2D {
@@ -19,7 +21,21 @@ function createPinnedNodeBadgeBackground(nodeColor: string, fallbackColor: strin
     return fallbackColor;
   }
 
-  return `rgb(${Math.round(color.r * PIN_BADGE_BACKGROUND_DARKEN_FACTOR)}, ${Math.round(color.g * PIN_BADGE_BACKGROUND_DARKEN_FACTOR)}, ${Math.round(color.b * PIN_BADGE_BACKGROUND_DARKEN_FACTOR)})`;
+  const red = Math.round(color.r * PIN_BADGE_BACKGROUND_DARKEN_FACTOR);
+  const green = Math.round(color.g * PIN_BADGE_BACKGROUND_DARKEN_FACTOR);
+  const blue = Math.round(color.b * PIN_BADGE_BACKGROUND_DARKEN_FACTOR);
+
+  return `rgb(${red}, ${green}, ${blue})`;
+}
+
+function getPinnedNodeBadgeOpacity(node: FGNode, globalScale: number): number {
+  const nodeRadiusPx = node.size * globalScale;
+  const fadeDistance = PIN_BADGE_FULL_OPACITY_NODE_RADIUS_PX - PIN_BADGE_HIDDEN_NODE_RADIUS_PX;
+
+  return Math.min(
+    1,
+    Math.max(0, (nodeRadiusPx - PIN_BADGE_HIDDEN_NODE_RADIUS_PX) / fadeDistance),
+  );
 }
 
 export interface RenderNodePinBadgeOptions {
@@ -39,6 +55,11 @@ export function renderNodePinBadge({
     return;
   }
 
+  const badgeOpacity = getPinnedNodeBadgeOpacity(node, globalScale);
+  if (badgeOpacity <= 0.01) {
+    return;
+  }
+
   const radius = Math.max(7 / globalScale, node.size * 0.18);
   const centerX = node.x + node.size * 0.7;
   const centerY = node.y - node.size * 0.7;
@@ -47,6 +68,7 @@ export function renderNodePinBadge({
   const badgeBackground = createPinnedNodeBadgeBackground(node.color, appearance.nodeSelectionBorder);
 
   ctx.save();
+  ctx.globalAlpha *= badgeOpacity;
   ctx.beginPath();
   ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
   ctx.fillStyle = badgeBackground;

--- a/packages/extension/src/webview/components/graph/rendering/node/pinBadge.ts
+++ b/packages/extension/src/webview/components/graph/rendering/node/pinBadge.ts
@@ -1,13 +1,25 @@
 import { mdiPin } from '@mdi/js';
+import { parseColor } from '../../../../colorParsing';
 import type { GraphAppearance } from '../../appearance/model';
 import type { FGNode } from '../../model/build';
 
 const MATERIAL_ICON_VIEWBOX_SIZE = 24;
+const PIN_BADGE_ICON_COLOR = '#ffffff';
+const PIN_BADGE_BACKGROUND_DARKEN_FACTOR = 0.48;
 let pinIconPath: Path2D | undefined;
 
 function getPinIconPath(): Path2D {
   pinIconPath ??= new Path2D(mdiPin);
   return pinIconPath;
+}
+
+function createPinnedNodeBadgeBackground(nodeColor: string, fallbackColor: string): string {
+  const color = parseColor(nodeColor);
+  if (!color) {
+    return fallbackColor;
+  }
+
+  return `rgb(${Math.round(color.r * PIN_BADGE_BACKGROUND_DARKEN_FACTOR)}, ${Math.round(color.g * PIN_BADGE_BACKGROUND_DARKEN_FACTOR)}, ${Math.round(color.b * PIN_BADGE_BACKGROUND_DARKEN_FACTOR)})`;
 }
 
 export interface RenderNodePinBadgeOptions {
@@ -32,11 +44,12 @@ export function renderNodePinBadge({
   const centerY = node.y - node.size * 0.7;
   const iconSize = radius * 1.55;
   const iconScale = iconSize / MATERIAL_ICON_VIEWBOX_SIZE;
+  const badgeBackground = createPinnedNodeBadgeBackground(node.color, appearance.nodeSelectionBorder);
 
   ctx.save();
   ctx.beginPath();
   ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
-  ctx.fillStyle = appearance.nodeSelectionBorder;
+  ctx.fillStyle = badgeBackground;
   ctx.fill();
   ctx.strokeStyle = node.borderColor;
   ctx.lineWidth = Math.max(1, 1.25 / globalScale);
@@ -44,7 +57,7 @@ export function renderNodePinBadge({
 
   ctx.translate(centerX - iconSize / 2, centerY - iconSize / 2);
   ctx.scale(iconScale, iconScale);
-  ctx.fillStyle = node.color;
+  ctx.fillStyle = PIN_BADGE_ICON_COLOR;
   ctx.fill(getPinIconPath());
   ctx.restore();
 }

--- a/packages/extension/src/webview/components/graph/rendering/node/pinBadge.ts
+++ b/packages/extension/src/webview/components/graph/rendering/node/pinBadge.ts
@@ -1,5 +1,14 @@
+import { mdiPin } from '@mdi/js';
 import type { GraphAppearance } from '../../appearance/model';
 import type { FGNode } from '../../model/build';
+
+const MATERIAL_ICON_VIEWBOX_SIZE = 24;
+let pinIconPath: Path2D | undefined;
+
+function getPinIconPath(): Path2D {
+  pinIconPath ??= new Path2D(mdiPin);
+  return pinIconPath;
+}
 
 export interface RenderNodePinBadgeOptions {
   appearance: Pick<GraphAppearance, 'nodeSelectionBorder'>;
@@ -18,9 +27,11 @@ export function renderNodePinBadge({
     return;
   }
 
-  const radius = 5 / globalScale;
+  const radius = Math.max(7 / globalScale, node.size * 0.18);
   const centerX = node.x + node.size * 0.7;
   const centerY = node.y - node.size * 0.7;
+  const iconSize = radius * 1.55;
+  const iconScale = iconSize / MATERIAL_ICON_VIEWBOX_SIZE;
 
   ctx.save();
   ctx.beginPath();
@@ -31,11 +42,9 @@ export function renderNodePinBadge({
   ctx.lineWidth = Math.max(1, 1.25 / globalScale);
   ctx.stroke();
 
-  ctx.beginPath();
-  ctx.moveTo(centerX, centerY - radius * 0.45);
-  ctx.lineTo(centerX, centerY + radius * 0.3);
-  ctx.strokeStyle = node.color;
-  ctx.lineWidth = Math.max(1, 1.5 / globalScale);
-  ctx.stroke();
+  ctx.translate(centerX - iconSize / 2, centerY - iconSize / 2);
+  ctx.scale(iconScale, iconScale);
+  ctx.fillStyle = node.color;
+  ctx.fill(getPinIconPath());
   ctx.restore();
 }

--- a/packages/extension/src/webview/components/graph/rendering/nodes/canvas2d.ts
+++ b/packages/extension/src/webview/components/graph/rendering/nodes/canvas2d.ts
@@ -1,6 +1,7 @@
 import { renderNodeBody } from '../node/body';
 import { renderNodeLabel } from '../node/label';
 import { renderNodeImageOverlay, renderNodePluginOverlay } from '../node/media';
+import { renderNodePinBadge } from '../node/pinBadge';
 import { paintNodePointerArea } from '../node/pointer';
 import type { NodeCanvasRendererDependencies } from '../node/canvasShared';
 import { type FGNode } from '../../model/build';
@@ -34,6 +35,12 @@ export function renderNodeCanvas(
     opacity,
   });
   renderNodeImageOverlay(ctx, node, dependencies.triggerImageRerender);
+  renderNodePinBadge({
+    appearance,
+    ctx,
+    globalScale,
+    node,
+  });
   if (dependencies.showLabelsRef.current) {
     renderNodeLabel({
       appearance,

--- a/packages/extension/src/webview/components/graph/rendering/surface/sharedProps.ts
+++ b/packages/extension/src/webview/components/graph/rendering/surface/sharedProps.ts
@@ -22,6 +22,7 @@ export interface GraphSurfaceSharedProps {
   onLinkClick(this: void, link: LinkObject, event: MouseEvent): void;
   onLinkRightClick(this: void, link: LinkObject, event: MouseEvent): void;
   onNodeClick(this: void, node: NodeObject, event: MouseEvent): void;
+  onNodeDragEnd(this: void, node: NodeObject): void;
   onNodeHover(this: void, node: NodeObject | null): void;
   onNodeRightClick(this: void, node: NodeObject, event: MouseEvent): void;
   warmupTicks: number;
@@ -38,6 +39,7 @@ export interface BuildSharedGraphPropsOptions {
   onLinkClick(this: void, link: FGLink, event: MouseEvent): void;
   onLinkRightClick(this: void, link: FGLink, event: MouseEvent): void;
   onNodeClick(this: void, node: FGNode, event: MouseEvent): void;
+  onNodeDragEnd(this: void, node: FGNode): void;
   onNodeHover(this: void, node: FGNode | null): void;
   onNodeRightClick(this: void, node: FGNode, event: MouseEvent): void;
   damping: number;
@@ -56,6 +58,7 @@ export function buildSharedGraphProps(
     width: normalizeGraphDimension(options.containerSize.width),
     height: normalizeGraphDimension(options.containerSize.height),
     onNodeClick: (node, event) => options.onNodeClick(node as FGNode, event),
+    onNodeDragEnd: node => options.onNodeDragEnd(node as FGNode),
     onNodeRightClick: (node, event) => options.onNodeRightClick(node as FGNode, event),
     onLinkClick: (link, event) => options.onLinkClick(link as FGLink, event),
     onLinkRightClick: (link, event) => options.onLinkRightClick(link as FGLink, event),

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction.ts
@@ -6,9 +6,13 @@ import {
   type SetStateAction,
 } from 'react';
 import type { IGraphData } from '../../../../../shared/graph/contracts';
+import type { WebviewToExtensionMessage } from '../../../../../shared/protocol/webviewToExtension';
+import type { GraphLayoutMode } from '../../../../../shared/settings/graphLayout';
 import type { GraphContextMenuAction, GraphContextSelection } from '../../contextMenu/contracts';
 import {
   resolveGraphContextActionContext,
+  type GraphContextNodePosition2D,
+  type GraphContextNodePosition3D,
 } from '../../contextActions/context';
 import {
   createGraphContextMenuOpeningRuntime,
@@ -69,6 +73,7 @@ export interface UseGraphInteractionRuntimeResult {
   handleMouseMoveCapture: GraphContextMenuOpeningRuntime['handleMouseMoveCapture'];
   handleMouseUpCapture: GraphContextMenuOpeningRuntime['handleMouseUpCapture'];
   handleNodeHover(this: void, node: FGNode | null): void;
+  handleNodeDragEnd(this: void, node: FGNode): void;
   handleNodeRightClick: GraphContextMenuOpeningRuntime['handleNodeRightClick'];
   hoveredNodeRef: MutableRefObject<FGNode | null>;
   interactionHandlers: ReturnType<typeof createGraphInteractionHandlers>;
@@ -91,6 +96,66 @@ function buildTooltipInteractionHandlers(
 
 function handleGraphEngineStop(): void {
   postMessage({ type: 'PHYSICS_STABILIZED' });
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function readNodePosition(
+  node: FGNode,
+  graphMode: GraphLayoutMode,
+): GraphContextNodePosition2D | GraphContextNodePosition3D | undefined {
+  if (!isFiniteNumber(node.x) || !isFiniteNumber(node.y)) {
+    return undefined;
+  }
+
+  if (graphMode === '3d') {
+    return isFiniteNumber(node.z)
+      ? { x: node.x, y: node.y, z: node.z }
+      : undefined;
+  }
+
+  return { x: node.x, y: node.y };
+}
+
+function createGraphNodePositionMap(
+  nodes: readonly FGNode[],
+  graphMode: GraphLayoutMode,
+): Map<string, GraphContextNodePosition2D | GraphContextNodePosition3D> {
+  const positions = new Map<string, GraphContextNodePosition2D | GraphContextNodePosition3D>();
+
+  for (const node of nodes) {
+    const position = readNodePosition(node, graphMode);
+    if (position) {
+      positions.set(node.id, position);
+    }
+  }
+
+  return positions;
+}
+
+function createPinnedNodeDragMessage(
+  node: FGNode,
+  graphMode: GraphLayoutMode,
+): WebviewToExtensionMessage | undefined {
+  if (!node.isPinned) {
+    return undefined;
+  }
+
+  const position = readNodePosition(node, graphMode);
+  if (!position) {
+    return undefined;
+  }
+
+  return {
+    type: 'UPDATE_GRAPH_LAYOUT_PIN',
+    payload: {
+      graphMode,
+      nodeId: node.id,
+      position,
+    },
+  };
 }
 
 export function useGraphInteractionRuntime({
@@ -177,9 +242,19 @@ export function useGraphInteractionRuntime({
   });
 
   const actionContext = useMemo(
-    () => resolveGraphContextActionContext(graphContextSelection),
-    [graphContextSelection],
+    () => resolveGraphContextActionContext(graphContextSelection, {
+      graphMode,
+      nodePositions: createGraphNodePositionMap(graphDataRef.current.nodes, graphMode),
+    }),
+    [graphContextSelection, graphDataRef, graphMode],
   );
+
+  function handleNodeDragEnd(node: FGNode): void {
+    const message = createPinnedNodeDragMessage(node, graphMode);
+    if (message) {
+      postMessage(message);
+    }
+  }
 
   const contextMenuOpeningRuntime = useMemo(
     () => createGraphContextMenuOpeningRuntime({
@@ -235,6 +310,7 @@ export function useGraphInteractionRuntime({
     handleEngineStop: handleGraphEngineStop,
     handleMouseLeave,
     handleNodeHover,
+    handleNodeDragEnd,
     hoveredNodeRef,
     interactionHandlers,
     setTooltipData,

--- a/packages/extension/src/webview/components/graph/runtime/use/state.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/state.ts
@@ -15,6 +15,7 @@ import type { IFileInfo } from '../../../../../shared/files/info';
 import type { IGraphData } from '../../../../../shared/graph/contracts';
 import type { EdgeDecorationPayload, NodeDecorationPayload } from '../../../../../shared/plugins/decorations';
 import type { BidirectionalEdgeMode, DirectionMode, NodeSizeMode } from '../../../../../shared/settings/modes';
+import type { GraphLayoutMode, GraphLayoutSettings } from '../../../../../shared/settings/graphLayout';
 import type {
   GraphContextSelection,
 } from '../../contextMenu/contracts';
@@ -46,6 +47,8 @@ export interface UseGraphStateOptions {
   directionMode: DirectionMode;
   edgeDecorations?: Record<string, EdgeDecorationPayload>;
   favorites: Set<string>;
+  graphLayout?: GraphLayoutSettings;
+  graphMode?: GraphLayoutMode;
   nodeDecorations?: Record<string, NodeDecorationPayload>;
   nodeSizeMode: NodeSizeMode;
   showLabels: boolean;
@@ -120,6 +123,8 @@ export function useGraphState({
   directionMode,
   edgeDecorations,
   favorites,
+  graphLayout,
+  graphMode,
   nodeDecorations,
   nodeSizeMode,
   showLabels,
@@ -179,20 +184,23 @@ export function useGraphState({
   }
 
   const graphData = useMemo(() => {
+    const resolvedGraphMode = graphMode ?? '2d';
     const nextGraphData = buildGraphData({
       data,
       appearance,
       nodeSizeMode: nodeSizeModeRef.current,
       theme: themeRef.current,
       favorites: favoritesRef.current,
+      graphLayout,
+      graphMode: resolvedGraphMode,
       bidirectionalMode,
-      timelineActive: timelineActiveRef.current,
+      timelineActive,
       previousNodes: graphDataRef.current.nodes,
     });
 
     graphDataRef.current = nextGraphData;
     return nextGraphData;
-  }, [appearance, bidirectionalMode, data]);
+  }, [appearance, bidirectionalMode, data, graphLayout, graphMode, timelineActive]);
 
   useEffect(() => {
     if (!timelineActive) return;

--- a/packages/extension/src/webview/components/graph/view/component.tsx
+++ b/packages/extension/src/webview/components/graph/view/component.tsx
@@ -56,6 +56,8 @@ export default function Graph({
     directionMode: viewState.directionMode,
     edgeDecorations,
     favorites: viewState.favorites,
+    graphLayout: viewState.graphLayout,
+    graphMode: viewState.graphMode,
     nodeDecorations,
     nodeSizeMode: viewState.nodeSizeMode,
     showLabels: viewState.showLabels,

--- a/packages/extension/src/webview/components/graph/view/sharedPropsOptions.ts
+++ b/packages/extension/src/webview/components/graph/view/sharedPropsOptions.ts
@@ -31,6 +31,7 @@ export function buildGraphSharedPropsOptions({
     onLinkClick: interactions.interactionHandlers.handleLinkClick,
     onLinkRightClick: interactions.handleLinkRightClick,
     onNodeClick: interactions.interactionHandlers.handleNodeClick,
+    onNodeDragEnd: interactions.handleNodeDragEnd,
     onNodeHover: interactions.handleNodeHover,
     onNodeRightClick: interactions.handleNodeRightClick,
     timelineActive,

--- a/packages/extension/src/webview/components/graph/view/store.ts
+++ b/packages/extension/src/webview/components/graph/view/store.ts
@@ -8,6 +8,7 @@ export type GraphViewStoreState = Pick<
   | 'dagMode'
   | 'directionMode'
   | 'favorites'
+  | 'graphLayout'
   | 'graphMode'
   | 'nodeSizeMode'
   | 'particleSize'
@@ -30,6 +31,7 @@ export function useGraphViewStoreState(): GraphViewStoreState {
     depthMode: useGraphStore(state => state.depthMode),
     directionMode: useGraphStore(state => state.directionMode),
     favorites: useGraphStore(state => state.favorites),
+    graphLayout: useGraphStore(state => state.graphLayout),
     graphMode: useGraphStore(state => state.graphMode),
     nodeSizeMode: useGraphStore(state => state.nodeSizeMode),
     particleSize: useGraphStore(state => state.particleSize),

--- a/packages/extension/src/webview/components/graph/viewport/model.ts
+++ b/packages/extension/src/webview/components/graph/viewport/model.ts
@@ -15,6 +15,7 @@ import { getGraphSurfaceColors } from '../rendering/surface/colors';
 import type { ThemeKind } from '../../../theme/useTheme';
 import type { GraphAppearance } from '../appearance/model';
 import { postMessage } from '../../../vscodeApi';
+import { getGraphLayoutPinCoordinate } from '../../../../shared/settings/graphLayout';
 
 export interface GraphViewportModel {
   canvasBackgroundColor: string;
@@ -37,12 +38,28 @@ export interface GraphViewportModelOptions {
     | 'currentCommitSha'
     | 'dagMode'
     | 'favorites'
+    | 'graphLayout'
+    | 'graphMode'
     | 'physicsSettings'
     | 'pluginContextMenuItems'
     | 'setGraphMode'
     | 'timelineActive'
     | 'timelineCommits'
   >;
+}
+
+function getActivePinnedNodeIds(
+  viewState: Pick<GraphViewStoreState, 'graphLayout' | 'graphMode'>,
+): Set<string> {
+  const pinnedNodeIds = new Set<string>();
+
+  for (const [nodeId, pinnedNode] of Object.entries(viewState.graphLayout.pinnedNodes)) {
+    if (getGraphLayoutPinCoordinate(pinnedNode, viewState.graphMode)) {
+      pinnedNodeIds.add(nodeId);
+    }
+  }
+
+  return pinnedNodeIds;
 }
 
 export function getGraphContextMutationAvailability(
@@ -92,6 +109,7 @@ export function useGraphViewportModel({
     timelineActive: viewState.timelineActive,
     mutationAvailability: getGraphContextMutationAvailability(viewState),
     favorites: viewState.favorites,
+    pinnedNodeIds: getActivePinnedNodeIds(viewState),
     pluginItems: viewState.pluginContextMenuItems,
     nodes: graphState.graphData.nodes,
   });

--- a/packages/extension/src/webview/store/initialState.ts
+++ b/packages/extension/src/webview/store/initialState.ts
@@ -2,6 +2,7 @@ import type { GraphStateFields } from './state';
 import { DEFAULT_PHYSICS, DEFAULT_SEARCH_OPTIONS } from './defaults';
 import { DEFAULT_DIRECTION_COLOR } from '../../shared/fileColors';
 import { DEFAULT_MAX_FILES } from '../../shared/settings/defaults';
+import { createDefaultGraphLayoutSettings } from '../../shared/settings/graphLayout';
 
 export const INITIAL_STATE: GraphStateFields = {
   graphData: null,
@@ -23,6 +24,7 @@ export const INITIAL_STATE: GraphStateFields = {
   physicsPaused: false,
   showLabels: true,
   graphMode: '2d' as const,
+  graphLayout: createDefaultGraphLayoutSettings(),
   nodeSizeMode: 'connections' as const,
   physicsSettings: DEFAULT_PHYSICS,
   depthMode: false,

--- a/packages/extension/src/webview/store/messageHandlers/graph.ts
+++ b/packages/extension/src/webview/store/messageHandlers/graph.ts
@@ -55,6 +55,12 @@ export function handleFavoritesUpdated(
   return { favorites: new Set(message.payload.favorites) };
 }
 
+export function handleGraphLayoutUpdated(
+  message: Extract<ExtensionToWebviewMessage, { type: 'GRAPH_LAYOUT_UPDATED' }>,
+): PartialState {
+  return { graphLayout: message.payload };
+}
+
 export function handleSettingsUpdated(
   message: Extract<ExtensionToWebviewMessage, { type: 'SETTINGS_UPDATED' }>,
 ): PartialState {

--- a/packages/extension/src/webview/store/messageTypes.ts
+++ b/packages/extension/src/webview/store/messageTypes.ts
@@ -14,6 +14,7 @@ import type {
 import type { IGroup } from '../../shared/settings/groups';
 import type { BidirectionalEdgeMode, DagMode, DirectionMode, NodeSizeMode } from '../../shared/settings/modes';
 import type { IPhysicsSettings } from '../../shared/settings/physics';
+import type { GraphLayoutSettings } from '../../shared/settings/graphLayout';
 import type { ICommitInfo } from '../../shared/timeline/contracts';
 import type {
   PendingGroupUpdates,
@@ -40,6 +41,7 @@ export interface IStoreFields {
   particleSize: number;
   showLabels: boolean;
   graphMode: '2d' | '3d';
+  graphLayout: GraphLayoutSettings;
   nodeSizeMode: NodeSizeMode;
   physicsSettings: IPhysicsSettings;
   depthMode: boolean;

--- a/packages/extension/src/webview/store/messages.ts
+++ b/packages/extension/src/webview/store/messages.ts
@@ -5,6 +5,7 @@ import {
   handleGraphIndexStatusUpdated,
   handleGraphControlsUpdated,
   handleFavoritesUpdated,
+  handleGraphLayoutUpdated,
   handleSettingsUpdated,
   handleLegendsUpdated,
   handleFilterPatternsUpdated,
@@ -61,6 +62,10 @@ export const MESSAGE_HANDLERS: Record<
     ),
   FAVORITES_UPDATED: (msg) =>
     handleFavoritesUpdated(msg as Extract<ExtensionToWebviewMessage, { type: 'FAVORITES_UPDATED' }>),
+  GRAPH_LAYOUT_UPDATED: (msg) =>
+    handleGraphLayoutUpdated(
+      msg as Extract<ExtensionToWebviewMessage, { type: 'GRAPH_LAYOUT_UPDATED' }>
+    ),
   SETTINGS_UPDATED: (msg) =>
     handleSettingsUpdated(msg as Extract<ExtensionToWebviewMessage, { type: 'SETTINGS_UPDATED' }>),
   DEPTH_MODE_UPDATED: (msg) =>

--- a/packages/extension/src/webview/store/state.ts
+++ b/packages/extension/src/webview/store/state.ts
@@ -18,6 +18,7 @@ import type {
 import type { IGroup } from '../../shared/settings/groups';
 import type { BidirectionalEdgeMode, DagMode, DirectionMode, NodeSizeMode } from '../../shared/settings/modes';
 import type { IPhysicsSettings } from '../../shared/settings/physics';
+import type { GraphLayoutSettings } from '../../shared/settings/graphLayout';
 import type { ICommitInfo } from '../../shared/timeline/contracts';
 import type {
   PendingGroupUpdates,
@@ -44,6 +45,7 @@ export interface GraphState {
   physicsPaused: boolean;
   showLabels: boolean;
   graphMode: '2d' | '3d';
+  graphLayout: GraphLayoutSettings;
   nodeSizeMode: NodeSizeMode;
   physicsSettings: IPhysicsSettings;
   depthMode: boolean;

--- a/packages/extension/tests/extension/config/configActions.test.ts
+++ b/packages/extension/tests/extension/config/configActions.test.ts
@@ -11,6 +11,7 @@ function makeProvider() {
     emitEvent: vi.fn(),
     invalidateTimelineCache: vi.fn().mockResolvedValue(undefined),
     sendPlaybackSpeed: vi.fn(),
+    sendGraphLayout: vi.fn(),
   };
 }
 
@@ -79,6 +80,35 @@ describe('executeConfigAction', () => {
     vi.useRealTimers();
   });
 
+  it('does not clear a missing legend refresh timer on the first legend sync', () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const provider = makeProvider();
+    const event = makeEvent();
+
+    try {
+      executeConfigAction('legend', event as never, provider as never);
+
+      expect(clearTimeoutSpy).not.toHaveBeenCalled();
+
+      vi.runOnlyPendingTimers();
+    } finally {
+      clearTimeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('sends graph layout without refreshing for layout category changes', () => {
+    const provider = makeProvider();
+    const event = makeEvent('codegraphy.graphLayout');
+
+    executeConfigAction('layout', event as never, provider as never);
+
+    expect(provider.sendGraphLayout).toHaveBeenCalledOnce();
+    expect(provider.refresh).not.toHaveBeenCalled();
+    expect(provider.refreshGroupSettings).not.toHaveBeenCalled();
+  });
+
   describe('general category', () => {
     it('syncs the full settings snapshot before refreshing for general category changes', () => {
       const provider = makeProvider();
@@ -96,20 +126,44 @@ describe('executeConfigAction', () => {
     it('calls refresh and emitEvent for general category', () => {
       const provider = makeProvider();
       const event = makeEvent();
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
-      executeConfigAction('general', event as never, provider as never);
+      try {
+        executeConfigAction('general', event as never, provider as never);
 
-      expect(provider.refresh).toHaveBeenCalledOnce();
-      expect(provider.emitEvent).toHaveBeenCalledWith('workspace:configChanged', {
-        key: 'codegraphy',
-        value: undefined,
-        old: undefined,
-      });
+        expect(logSpy).toHaveBeenCalledWith('[CodeGraphy] Configuration changed, refreshing graph');
+        expect(provider.refresh).toHaveBeenCalledOnce();
+        expect(provider.emitEvent).toHaveBeenCalledWith('workspace:configChanged', {
+          key: 'codegraphy',
+          value: undefined,
+          old: undefined,
+        });
+      } finally {
+        logSpy.mockRestore();
+      }
     });
 
     it('invalidates timeline cache when filterPatterns changes', () => {
       const provider = makeProvider();
       const event = makeEvent('codegraphy.filterPatterns');
+
+      executeConfigAction('general', event as never, provider as never);
+
+      expect(provider.invalidateTimelineCache).toHaveBeenCalledOnce();
+    });
+
+    it('invalidates timeline cache when disabledCustomFilterPatterns changes', () => {
+      const provider = makeProvider();
+      const event = makeEvent('codegraphy.disabledCustomFilterPatterns');
+
+      executeConfigAction('general', event as never, provider as never);
+
+      expect(provider.invalidateTimelineCache).toHaveBeenCalledOnce();
+    });
+
+    it('invalidates timeline cache when disabledPluginFilterPatterns changes', () => {
+      const provider = makeProvider();
+      const event = makeEvent('codegraphy.disabledPluginFilterPatterns');
 
       executeConfigAction('general', event as never, provider as never);
 

--- a/packages/extension/tests/extension/config/configChangeDetection.test.ts
+++ b/packages/extension/tests/extension/config/configChangeDetection.test.ts
@@ -68,6 +68,21 @@ describe('classifyConfigChange', () => {
       const event = makeEvent('codegraphy.bidirectionalEdges');
       expect(classifyConfigChange(event)).toBe('display');
     });
+
+    it('returns display when codegraphy.nodeColors is affected', () => {
+      const event = makeEvent('codegraphy.nodeColors');
+      expect(classifyConfigChange(event)).toBe('display');
+    });
+
+    it('returns display when codegraphy.nodeVisibility is affected', () => {
+      const event = makeEvent('codegraphy.nodeVisibility');
+      expect(classifyConfigChange(event)).toBe('display');
+    });
+
+    it('returns display when codegraphy.edgeVisibility is affected', () => {
+      const event = makeEvent('codegraphy.edgeVisibility');
+      expect(classifyConfigChange(event)).toBe('display');
+    });
   });
 
   describe('legend category', () => {
@@ -76,6 +91,13 @@ describe('classifyConfigChange', () => {
       expect(classifyConfigChange(event)).toBe('legend');
     });
 
+  });
+
+  describe('layout category', () => {
+    it('returns layout when codegraphy.graphLayout is affected', () => {
+      const event = makeEvent('codegraphy.graphLayout', 'codegraphy');
+      expect(classifyConfigChange(event)).toBe('layout');
+    });
   });
 
   describe('general category', () => {

--- a/packages/extension/tests/extension/config/configListener.test.ts
+++ b/packages/extension/tests/extension/config/configListener.test.ts
@@ -12,6 +12,7 @@ function makeProvider() {
     emitEvent: vi.fn(),
     invalidateTimelineCache: vi.fn().mockResolvedValue(undefined),
     sendPlaybackSpeed: vi.fn(),
+    sendGraphLayout: vi.fn(),
   };
 }
 
@@ -141,6 +142,24 @@ describe('configListener', () => {
     expect(provider.refreshGroupSettings).toHaveBeenCalledOnce();
 
     vi.useRealTimers();
+  });
+
+  it('syncs graph layout without reloading the graph when layout changes', () => {
+    const context = makeContext();
+    const provider = makeProvider();
+
+    registerConfigHandler(context as unknown as vscode.ExtensionContext, provider as never);
+
+    const listener = getConfigListener();
+    listener({
+      affectsConfiguration: (key) =>
+        key === 'codegraphy' ||
+        key === 'codegraphy.graphLayout',
+    });
+
+    expect(provider.sendGraphLayout).toHaveBeenCalledOnce();
+    expect(provider.refresh).not.toHaveBeenCalled();
+    expect(provider.refreshGroupSettings).not.toHaveBeenCalled();
   });
 
   it('triggers full refresh for unrecognized codegraphy settings', () => {

--- a/packages/extension/tests/extension/config/configReaders.test.ts
+++ b/packages/extension/tests/extension/config/configReaders.test.ts
@@ -89,6 +89,39 @@ describe('Configuration (configReaders)', () => {
     });
   });
 
+  describe('pluginOrder', () => {
+    it('returns the configured plugin order', () => {
+      mockConfig['pluginOrder'] = ['codegraphy.typescript', 'codegraphy.markdown'];
+      expect(new Configuration().pluginOrder).toEqual(['codegraphy.typescript', 'codegraphy.markdown']);
+    });
+
+    it('defaults to empty array', () => {
+      expect(new Configuration().pluginOrder).toEqual([]);
+    });
+  });
+
+  describe('disabledCustomFilterPatterns', () => {
+    it('returns the configured disabled custom filter patterns', () => {
+      mockConfig['disabledCustomFilterPatterns'] = ['**/*.generated.ts'];
+      expect(new Configuration().disabledCustomFilterPatterns).toEqual(['**/*.generated.ts']);
+    });
+
+    it('defaults to empty array', () => {
+      expect(new Configuration().disabledCustomFilterPatterns).toEqual([]);
+    });
+  });
+
+  describe('disabledPluginFilterPatterns', () => {
+    it('returns the configured disabled plugin filter patterns', () => {
+      mockConfig['disabledPluginFilterPatterns'] = ['codegraphy.typescript:**/*.d.ts'];
+      expect(new Configuration().disabledPluginFilterPatterns).toEqual(['codegraphy.typescript:**/*.d.ts']);
+    });
+
+    it('defaults to empty array', () => {
+      expect(new Configuration().disabledPluginFilterPatterns).toEqual([]);
+    });
+  });
+
   describe('timelineMaxCommits', () => {
     it('returns the configured value', () => {
       mockConfig['timeline.maxCommits'] = 200;

--- a/packages/extension/tests/extension/graphView/graphLayout/message.test.ts
+++ b/packages/extension/tests/extension/graphView/graphLayout/message.test.ts
@@ -16,27 +16,8 @@ describe('createGraphLayoutUpdatedMessage', () => {
           updatedAt: '2026-05-07T23:00:00.000Z',
         },
       },
-      sections: {
-        'section-1': {
-          id: 'section-1',
-          label: 'Section 1',
-          color: '#60a5fa',
-          x: 1,
-          y: 2,
-          width: 300,
-          height: 200,
-          collapsed: false,
-          updatedAt: '2026-05-07T23:01:00.000Z',
-        },
-      },
-      ownership: {
-        'src/app.ts': {
-          itemId: 'src/app.ts',
-          itemKind: 'node',
-          ownerSectionId: 'section-1',
-          updatedAt: '2026-05-07T23:02:00.000Z',
-        },
-      },
+      sections: { ignored: true },
+      ownership: { ignored: true },
     };
     const configuration = {
       get: vi.fn((_key: string, _fallback: unknown) => graphLayout),
@@ -45,12 +26,12 @@ describe('createGraphLayoutUpdatedMessage', () => {
 
     expect(createGraphLayoutUpdatedMessage()).toEqual({
       type: 'GRAPH_LAYOUT_UPDATED',
-      payload: graphLayout,
+      payload: {
+        pinnedNodes: graphLayout.pinnedNodes,
+      },
     });
     expect(configuration.get).toHaveBeenCalledWith('graphLayout', {
       pinnedNodes: {},
-      sections: {},
-      ownership: {},
     });
   });
 });

--- a/packages/extension/tests/extension/graphView/graphLayout/message.test.ts
+++ b/packages/extension/tests/extension/graphView/graphLayout/message.test.ts
@@ -12,8 +12,7 @@ describe('createGraphLayoutUpdatedMessage', () => {
       pinnedNodes: {
         'src/app.ts': {
           nodeId: 'src/app.ts',
-          twoDimensional: { x: 10, y: 20 },
-          updatedAt: '2026-05-07T23:00:00.000Z',
+          '2D': { x: 10, y: 20 },
         },
       },
       sections: { ignored: true },

--- a/packages/extension/tests/extension/graphView/graphLayout/message.test.ts
+++ b/packages/extension/tests/extension/graphView/graphLayout/message.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGraphLayoutUpdatedMessage } from '../../../../src/extension/graphView/graphLayout/message';
+import { getCodeGraphyConfiguration } from '../../../../src/extension/repoSettings/current';
+
+vi.mock('../../../../src/extension/repoSettings/current', () => ({
+  getCodeGraphyConfiguration: vi.fn(),
+}));
+
+describe('createGraphLayoutUpdatedMessage', () => {
+  it('reads the current CodeGraphy graph layout and normalizes it for the webview', () => {
+    const graphLayout = {
+      pinnedNodes: {
+        'src/app.ts': {
+          nodeId: 'src/app.ts',
+          twoDimensional: { x: 10, y: 20 },
+          updatedAt: '2026-05-07T23:00:00.000Z',
+        },
+      },
+      sections: {
+        'section-1': {
+          id: 'section-1',
+          label: 'Section 1',
+          color: '#60a5fa',
+          x: 1,
+          y: 2,
+          width: 300,
+          height: 200,
+          collapsed: false,
+          updatedAt: '2026-05-07T23:01:00.000Z',
+        },
+      },
+      ownership: {
+        'src/app.ts': {
+          itemId: 'src/app.ts',
+          itemKind: 'node',
+          ownerSectionId: 'section-1',
+          updatedAt: '2026-05-07T23:02:00.000Z',
+        },
+      },
+    };
+    const configuration = {
+      get: vi.fn((_key: string, _fallback: unknown) => graphLayout),
+    };
+    vi.mocked(getCodeGraphyConfiguration).mockReturnValue(configuration as never);
+
+    expect(createGraphLayoutUpdatedMessage()).toEqual({
+      type: 'GRAPH_LAYOUT_UPDATED',
+      payload: graphLayout,
+    });
+    expect(configuration.get).toHaveBeenCalledWith('graphLayout', {
+      pinnedNodes: {},
+      sections: {},
+      ownership: {},
+    });
+  });
+});

--- a/packages/extension/tests/extension/graphView/provider/wiring/publicApi.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/wiring/publicApi.test.ts
@@ -204,8 +204,6 @@ describe('assignGraphViewProviderPublicMethods', () => {
       type: 'GRAPH_LAYOUT_UPDATED',
       payload: {
         pinnedNodes: {},
-        sections: {},
-        ownership: {},
       },
     });
     expect(target._methodContainers.timeline.invalidateTimelineCache).toHaveBeenCalledTimes(1);

--- a/packages/extension/tests/extension/graphView/provider/wiring/publicApi.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/wiring/publicApi.test.ts
@@ -88,6 +88,7 @@ function createTarget() {
     updateGraphData: vi.fn(),
     getGraphData,
     sendPlaybackSpeed: vi.fn(),
+    sendGraphLayout: vi.fn(),
     invalidateTimelineCache: vi.fn(async () => undefined),
     registerExternalPlugin: vi.fn(),
     queryGraph: vi.fn(),
@@ -110,7 +111,7 @@ function createTarget() {
     },
   } as unknown as GraphViewProviderPublicMethodsTarget;
 
-  return { target, graphData, disposable, getGraphData, onWebviewMessage, queryMethods };
+  return { target, graphData, disposable, getGraphData, onWebviewMessage, queryMethods, webviewMethods };
 }
 
 describe('assignGraphViewProviderPublicMethods', () => {
@@ -166,7 +167,13 @@ describe('assignGraphViewProviderPublicMethods', () => {
   });
 
   it('assigns graph, timeline, plugin, and selection delegates', async () => {
-    const { target, graphData: previousGraphData, getGraphData, queryMethods } = createTarget();
+    const {
+      target,
+      graphData: previousGraphData,
+      getGraphData,
+      queryMethods,
+      webviewMethods,
+    } = createTarget();
     const graphData: IGraphData = {
       nodes: [{ id: 'src/feature.ts', label: 'feature.ts', color: '#123456' }],
       edges: [],
@@ -178,6 +185,7 @@ describe('assignGraphViewProviderPublicMethods', () => {
     target.updateGraphData(graphData);
     expect(target.getGraphData()).toBe(previousGraphData);
     target.sendPlaybackSpeed();
+    target.sendGraphLayout();
     await target.invalidateTimelineCache();
     target.registerExternalPlugin({ id: 'plugin.test' });
     expect(target.queryGraph(query)).toEqual({
@@ -192,6 +200,14 @@ describe('assignGraphViewProviderPublicMethods', () => {
     expect(target._methodContainers.viewContext.updateGraphData).toHaveBeenCalledWith(graphData);
     expect(getGraphData).toHaveBeenCalledTimes(1);
     expect(target._methodContainers.timeline.sendPlaybackSpeed).toHaveBeenCalledTimes(1);
+    expect(webviewMethods.sendToWebview).toHaveBeenCalledWith({
+      type: 'GRAPH_LAYOUT_UPDATED',
+      payload: {
+        pinnedNodes: {},
+        sections: {},
+        ownership: {},
+      },
+    });
     expect(target._methodContainers.timeline.invalidateTimelineCache).toHaveBeenCalledTimes(1);
     expect(target._methodContainers.plugin.registerExternalPlugin).toHaveBeenCalledWith(
       { id: 'plugin.test' },

--- a/packages/extension/tests/extension/graphView/webview/dispatch/primary/graphLayout.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/primary/graphLayout.test.ts
@@ -29,8 +29,7 @@ describe('graphView/webview/dispatch/primary graph layout', () => {
       pinnedNodes: {
         'src/app.ts': {
           nodeId: 'src/app.ts',
-          twoDimensional: { x: 12, y: -24 },
-          updatedAt: expect.any(String),
+          '2D': { x: 12, y: -24 },
         },
       },
     });
@@ -40,8 +39,7 @@ describe('graphView/webview/dispatch/primary graph layout', () => {
         pinnedNodes: {
           'src/app.ts': {
             nodeId: 'src/app.ts',
-            twoDimensional: { x: 12, y: -24 },
-            updatedAt: expect.any(String),
+            '2D': { x: 12, y: -24 },
           },
         },
       },
@@ -56,8 +54,7 @@ describe('graphView/webview/dispatch/primary graph layout', () => {
             pinnedNodes: {
               'src/app.ts': {
                 nodeId: 'src/app.ts',
-                twoDimensional: { x: 12, y: -24 },
-                updatedAt: '2026-05-07T08:00:00.000Z',
+                '2D': { x: 12, y: -24 },
               },
             },
           } as T;

--- a/packages/extension/tests/extension/graphView/webview/dispatch/primary/graphLayout.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/primary/graphLayout.test.ts
@@ -9,8 +9,6 @@ describe('graphView/webview/dispatch/primary graph layout', () => {
         if (key === 'graphLayout') {
           return {
             pinnedNodes: {},
-            sections: {},
-            ownership: {},
           } as T;
         }
 
@@ -35,8 +33,6 @@ describe('graphView/webview/dispatch/primary graph layout', () => {
           updatedAt: expect.any(String),
         },
       },
-      sections: {},
-      ownership: {},
     });
     expect(context.sendMessage).toHaveBeenCalledWith({
       type: 'GRAPH_LAYOUT_UPDATED',
@@ -48,8 +44,6 @@ describe('graphView/webview/dispatch/primary graph layout', () => {
             updatedAt: expect.any(String),
           },
         },
-        sections: {},
-        ownership: {},
       },
     });
   });
@@ -66,8 +60,6 @@ describe('graphView/webview/dispatch/primary graph layout', () => {
                 updatedAt: '2026-05-07T08:00:00.000Z',
               },
             },
-            sections: {},
-            ownership: {},
           } as T;
         }
 
@@ -85,15 +77,11 @@ describe('graphView/webview/dispatch/primary graph layout', () => {
 
     expect(context.updateConfig).toHaveBeenCalledWith('graphLayout', {
       pinnedNodes: {},
-      sections: {},
-      ownership: {},
     });
     expect(context.sendMessage).toHaveBeenCalledWith({
       type: 'GRAPH_LAYOUT_UPDATED',
       payload: {
         pinnedNodes: {},
-        sections: {},
-        ownership: {},
       },
     });
   });

--- a/packages/extension/tests/extension/graphView/webview/dispatch/primary/graphLayout.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/primary/graphLayout.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { dispatchGraphViewPrimaryMessage } from '../../../../../../src/extension/graphView/webview/dispatch/primary';
+import { createPrimaryMessageContext } from '../context';
+
+describe('graphView/webview/dispatch/primary graph layout', () => {
+  it('persists an active-mode node pin and echoes the updated graph layout', async () => {
+    const context = createPrimaryMessageContext({
+      getConfig: vi.fn(<T>(key: string, defaultValue: T): T => {
+        if (key === 'graphLayout') {
+          return {
+            pinnedNodes: {},
+            sections: {},
+            ownership: {},
+          } as T;
+        }
+
+        return defaultValue;
+      }),
+    });
+
+    await expect(dispatchGraphViewPrimaryMessage({
+      type: 'UPDATE_GRAPH_LAYOUT_PIN',
+      payload: {
+        graphMode: '2d',
+        nodeId: 'src/app.ts',
+        position: { x: 12, y: -24 },
+      },
+    }, context)).resolves.toEqual({ handled: true });
+
+    expect(context.updateConfig).toHaveBeenCalledWith('graphLayout', {
+      pinnedNodes: {
+        'src/app.ts': {
+          nodeId: 'src/app.ts',
+          twoDimensional: { x: 12, y: -24 },
+          updatedAt: expect.any(String),
+        },
+      },
+      sections: {},
+      ownership: {},
+    });
+    expect(context.sendMessage).toHaveBeenCalledWith({
+      type: 'GRAPH_LAYOUT_UPDATED',
+      payload: {
+        pinnedNodes: {
+          'src/app.ts': {
+            nodeId: 'src/app.ts',
+            twoDimensional: { x: 12, y: -24 },
+            updatedAt: expect.any(String),
+          },
+        },
+        sections: {},
+        ownership: {},
+      },
+    });
+  });
+
+  it('clears only the active-mode pin and removes empty pin records', async () => {
+    const context = createPrimaryMessageContext({
+      getConfig: vi.fn(<T>(key: string, defaultValue: T): T => {
+        if (key === 'graphLayout') {
+          return {
+            pinnedNodes: {
+              'src/app.ts': {
+                nodeId: 'src/app.ts',
+                twoDimensional: { x: 12, y: -24 },
+                updatedAt: '2026-05-07T08:00:00.000Z',
+              },
+            },
+            sections: {},
+            ownership: {},
+          } as T;
+        }
+
+        return defaultValue;
+      }),
+    });
+
+    await expect(dispatchGraphViewPrimaryMessage({
+      type: 'CLEAR_GRAPH_LAYOUT_PIN',
+      payload: {
+        graphMode: '2d',
+        nodeId: 'src/app.ts',
+      },
+    }, context)).resolves.toEqual({ handled: true });
+
+    expect(context.updateConfig).toHaveBeenCalledWith('graphLayout', {
+      pinnedNodes: {},
+      sections: {},
+      ownership: {},
+    });
+    expect(context.sendMessage).toHaveBeenCalledWith({
+      type: 'GRAPH_LAYOUT_UPDATED',
+      payload: {
+        pinnedNodes: {},
+        sections: {},
+        ownership: {},
+      },
+    });
+  });
+});

--- a/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
@@ -13,6 +13,7 @@ function createHandlers() {
     loadAndSendData: vi.fn(),
     sendFavorites: vi.fn(),
     sendSettings: vi.fn(),
+    sendGraphLayout: vi.fn(),
     sendPhysicsSettings: vi.fn(),
     sendGroupsUpdated: vi.fn(),
     sendMessage: vi.fn(),
@@ -52,6 +53,7 @@ describe('graph view ready message', () => {
     expect(handlers.loadAndSendData).toHaveBeenCalledOnce();
     expect(handlers.sendFavorites).toHaveBeenCalledOnce();
     expect(handlers.sendSettings).toHaveBeenCalledOnce();
+    expect(handlers.sendGraphLayout).toHaveBeenCalledOnce();
     expect(handlers.sendPhysicsSettings).toHaveBeenCalledOnce();
     expect(handlers.sendGroupsUpdated).toHaveBeenCalledOnce();
     expect(handlers.sendCachedTimeline).toHaveBeenCalledOnce();

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/pluginContext.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/pluginContext.test.ts
@@ -172,8 +172,6 @@ describe('graph view provider listener plugin context', () => {
       type: 'GRAPH_LAYOUT_UPDATED',
       payload: {
         pinnedNodes: {},
-        sections: {},
-        ownership: {},
       },
     });
     expect(source._sendCachedTimeline).toHaveBeenCalledOnce();

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/pluginContext.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/pluginContext.test.ts
@@ -150,6 +150,7 @@ describe('graph view provider listener plugin context', () => {
     context.sendGraphControls?.();
     context.sendFavorites();
     context.sendSettings();
+    context.sendGraphLayout?.();
     context.sendCachedTimeline();
     context.sendDecorations();
     context.sendContextMenuItems();
@@ -167,6 +168,14 @@ describe('graph view provider listener plugin context', () => {
     expect(source._sendGraphControls).toHaveBeenCalledOnce();
     expect(source._sendFavorites).toHaveBeenCalledOnce();
     expect(source._sendSettings).toHaveBeenCalledOnce();
+    expect(source._sendMessage).toHaveBeenCalledWith({
+      type: 'GRAPH_LAYOUT_UPDATED',
+      payload: {
+        pinnedNodes: {},
+        sections: {},
+        ownership: {},
+      },
+    });
     expect(source._sendCachedTimeline).toHaveBeenCalledOnce();
     expect(source._sendDecorations).toHaveBeenCalledOnce();
     expect(source._sendContextMenuItems).toHaveBeenCalledOnce();

--- a/packages/extension/tests/extension/repoSettings/defaults.test.ts
+++ b/packages/extension/tests/extension/repoSettings/defaults.test.ts
@@ -52,6 +52,11 @@ describe('extension/repoSettings/defaults', () => {
         maxCommits: 500,
         playbackSpeed: 1,
       },
+      graphLayout: {
+        pinnedNodes: {},
+        sections: {},
+        ownership: {},
+      },
     });
   });
 
@@ -72,5 +77,9 @@ describe('extension/repoSettings/defaults', () => {
     expect(second.filterPatterns).not.toBe(first.filterPatterns);
     expect(second.physics).not.toBe(first.physics);
     expect(second.timeline).not.toBe(first.timeline);
+    expect(second.graphLayout).not.toBe(first.graphLayout);
+    expect(second.graphLayout.pinnedNodes).not.toBe(first.graphLayout.pinnedNodes);
+    expect(second.graphLayout.sections).not.toBe(first.graphLayout.sections);
+    expect(second.graphLayout.ownership).not.toBe(first.graphLayout.ownership);
   });
 });

--- a/packages/extension/tests/extension/repoSettings/defaults.test.ts
+++ b/packages/extension/tests/extension/repoSettings/defaults.test.ts
@@ -54,8 +54,6 @@ describe('extension/repoSettings/defaults', () => {
       },
       graphLayout: {
         pinnedNodes: {},
-        sections: {},
-        ownership: {},
       },
     });
   });
@@ -79,7 +77,5 @@ describe('extension/repoSettings/defaults', () => {
     expect(second.timeline).not.toBe(first.timeline);
     expect(second.graphLayout).not.toBe(first.graphLayout);
     expect(second.graphLayout.pinnedNodes).not.toBe(first.graphLayout.pinnedNodes);
-    expect(second.graphLayout.sections).not.toBe(first.graphLayout.sections);
-    expect(second.graphLayout.ownership).not.toBe(first.graphLayout.ownership);
   });
 });

--- a/packages/extension/tests/extension/repoSettings/graphLayout/model.test.ts
+++ b/packages/extension/tests/extension/repoSettings/graphLayout/model.test.ts
@@ -1,21 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
-  assignGraphLayoutOwner,
+  clearGraphLayoutNodePin,
   createDefaultGraphLayoutSettings,
   normalizeGraphLayoutSettings,
-  wouldCreateGraphLayoutOwnershipCycle,
+  setGraphLayoutNodePin,
 } from '../../../../src/extension/repoSettings/graphLayout/model';
 
 describe('extension/repoSettings/graphLayout/model', () => {
-  it('creates empty layout state for pins, sections, and ownership', () => {
+  it('creates empty layout state for pinned nodes', () => {
     expect(createDefaultGraphLayoutSettings()).toEqual({
       pinnedNodes: {},
-      sections: {},
-      ownership: {},
     });
   });
 
-  it('keeps dormant pin and node ownership records without requiring visible graph nodes', () => {
+  it('keeps dormant pin records without requiring visible graph nodes', () => {
     expect(normalizeGraphLayoutSettings({
       pinnedNodes: {
         'src/missing.ts': {
@@ -25,27 +23,7 @@ describe('extension/repoSettings/graphLayout/model', () => {
           updatedAt: '2026-05-07T08:00:00.000Z',
         },
       },
-      sections: {
-        'section-a': {
-          id: 'section-a',
-          label: 'UI Layer',
-          color: '#4488ff',
-          x: 10,
-          y: 20,
-          width: 300,
-          height: 180,
-          collapsed: false,
-          updatedAt: '2026-05-07T08:01:00.000Z',
-        },
-      },
-      ownership: {
-        'src/missing.ts': {
-          itemId: 'src/missing.ts',
-          itemKind: 'node',
-          ownerSectionId: 'section-a',
-          updatedAt: '2026-05-07T08:02:00.000Z',
-        },
-      },
+      stray: true,
     })).toEqual({
       pinnedNodes: {
         'src/missing.ts': {
@@ -55,31 +33,10 @@ describe('extension/repoSettings/graphLayout/model', () => {
           updatedAt: '2026-05-07T08:00:00.000Z',
         },
       },
-      sections: {
-        'section-a': {
-          id: 'section-a',
-          label: 'UI Layer',
-          color: '#4488ff',
-          x: 10,
-          y: 20,
-          width: 300,
-          height: 180,
-          collapsed: false,
-          updatedAt: '2026-05-07T08:01:00.000Z',
-        },
-      },
-      ownership: {
-        'src/missing.ts': {
-          itemId: 'src/missing.ts',
-          itemKind: 'node',
-          ownerSectionId: 'section-a',
-          updatedAt: '2026-05-07T08:02:00.000Z',
-        },
-      },
     });
   });
 
-  it('normalizes malformed layout records before settings are persisted', () => {
+  it('normalizes malformed pin records before settings are persisted', () => {
     expect(normalizeGraphLayoutSettings({
       pinnedNodes: {
         good: {
@@ -98,46 +55,11 @@ describe('extension/repoSettings/graphLayout/model', () => {
           twoDimensional: { x: Number.POSITIVE_INFINITY, y: 2 },
           updatedAt: '2026-05-07T08:00:00.000Z',
         },
-      },
-      sections: {
-        'section-a': {
-          id: 'section-a',
-          label: 'Section A',
-          color: '#223344',
-          x: 0,
-          y: 0,
-          width: 120,
-          height: 100,
-          collapsed: true,
-          updatedAt: '2026-05-07T08:01:00.000Z',
-        },
-        'bad-section': {
-          id: 'bad-section',
-          label: '',
-          color: '#223344',
-          x: 0,
-          y: 0,
-          width: 0,
-          height: 100,
-          collapsed: false,
-          updatedAt: '2026-05-07T08:01:00.000Z',
+        noCoordinates: {
+          nodeId: 'noCoordinates',
+          updatedAt: '2026-05-07T08:00:00.000Z',
         },
       },
-      ownership: {
-        good: {
-          itemId: 'good',
-          itemKind: 'node',
-          ownerSectionId: 'section-a',
-          updatedAt: '2026-05-07T08:02:00.000Z',
-        },
-        orphanedOwner: {
-          itemId: 'orphanedOwner',
-          itemKind: 'node',
-          ownerSectionId: 'missing-section',
-          updatedAt: '2026-05-07T08:02:00.000Z',
-        },
-      },
-      stray: true,
     })).toEqual({
       pinnedNodes: {
         good: {
@@ -147,99 +69,36 @@ describe('extension/repoSettings/graphLayout/model', () => {
           updatedAt: '2026-05-07T08:00:00.000Z',
         },
       },
-      sections: {
-        'section-a': {
-          id: 'section-a',
-          label: 'Section A',
-          color: '#223344',
-          x: 0,
-          y: 0,
-          width: 120,
-          height: 100,
-          collapsed: true,
-          updatedAt: '2026-05-07T08:01:00.000Z',
-        },
-      },
-      ownership: {
-        good: {
-          itemId: 'good',
-          itemKind: 'node',
-          ownerSectionId: 'section-a',
-          updatedAt: '2026-05-07T08:02:00.000Z',
-        },
-      },
     });
   });
 
-  it('prevents section ownership cycles', () => {
-    const ownership = {
-      'section-a': {
-        itemId: 'section-a',
-        itemKind: 'section' as const,
-        ownerSectionId: 'section-b',
-        updatedAt: '2026-05-07T08:02:00.000Z',
-      },
-      'section-b': {
-        itemId: 'section-b',
-        itemKind: 'section' as const,
-        ownerSectionId: null,
-        updatedAt: '2026-05-07T08:03:00.000Z',
-      },
-    };
-
-    expect(wouldCreateGraphLayoutOwnershipCycle(
-      ownership,
-      'section-b',
-      'section-a',
-    )).toBe(true);
-    expect(wouldCreateGraphLayoutOwnershipCycle(
-      ownership,
-      'section-b',
-      null,
-    )).toBe(false);
-  });
-
-  it('throws instead of assigning a section to its own descendant', () => {
-    const layout = normalizeGraphLayoutSettings({
-      sections: {
-        'section-a': {
-          id: 'section-a',
-          label: 'Section A',
-          color: '#223344',
-          x: 0,
-          y: 0,
-          width: 120,
-          height: 100,
-          collapsed: false,
-          updatedAt: '2026-05-07T08:01:00.000Z',
-        },
-        'section-b': {
-          id: 'section-b',
-          label: 'Section B',
-          color: '#446688',
-          x: 20,
-          y: 20,
-          width: 120,
-          height: 100,
-          collapsed: false,
-          updatedAt: '2026-05-07T08:01:00.000Z',
-        },
-      },
-      ownership: {
-        'section-b': {
-          itemId: 'section-b',
-          itemKind: 'section',
-          ownerSectionId: 'section-a',
-          updatedAt: '2026-05-07T08:02:00.000Z',
-        },
-      },
+  it('sets and clears 2D and 3D pins independently', () => {
+    const pinned2d = setGraphLayoutNodePin(createDefaultGraphLayoutSettings(), {
+      graphMode: '2d',
+      nodeId: 'src/app.ts',
+      position: { x: 10, y: 20 },
+      updatedAt: '2026-05-07T08:00:00.000Z',
     });
+    const pinnedBoth = setGraphLayoutNodePin(pinned2d, {
+      graphMode: '3d',
+      nodeId: 'src/app.ts',
+      position: { x: 1, y: 2, z: 3 },
+      updatedAt: '2026-05-07T08:01:00.000Z',
+    });
+    const only3d = clearGraphLayoutNodePin(pinnedBoth, 'src/app.ts', '2d');
+    const cleared = clearGraphLayoutNodePin(only3d, 'src/app.ts', '3d');
 
-    expect(() => assignGraphLayoutOwner(layout, {
-      itemId: 'section-a',
-      itemKind: 'section',
-      ownerSectionId: 'section-b',
-      updatedAt: '2026-05-07T08:03:00.000Z',
-    })).toThrow('Graph Section ownership cannot create a cycle.');
+    expect(pinnedBoth.pinnedNodes['src/app.ts']).toEqual({
+      nodeId: 'src/app.ts',
+      twoDimensional: { x: 10, y: 20 },
+      threeDimensional: { x: 1, y: 2, z: 3 },
+      updatedAt: '2026-05-07T08:01:00.000Z',
+    });
+    expect(only3d.pinnedNodes['src/app.ts']).toEqual({
+      nodeId: 'src/app.ts',
+      threeDimensional: { x: 1, y: 2, z: 3 },
+      updatedAt: '2026-05-07T08:01:00.000Z',
+    });
+    expect(cleared.pinnedNodes).toEqual({});
   });
 });

--- a/packages/extension/tests/extension/repoSettings/graphLayout/model.test.ts
+++ b/packages/extension/tests/extension/repoSettings/graphLayout/model.test.ts
@@ -18,9 +18,8 @@ describe('extension/repoSettings/graphLayout/model', () => {
       pinnedNodes: {
         'src/missing.ts': {
           nodeId: 'src/missing.ts',
-          twoDimensional: { x: 120, y: -40 },
-          threeDimensional: { x: 12, y: 24, z: -6 },
-          updatedAt: '2026-05-07T08:00:00.000Z',
+          '2D': { x: 120, y: -40 },
+          '3D': { x: 12, y: 24, z: -6 },
         },
       },
       stray: true,
@@ -28,9 +27,8 @@ describe('extension/repoSettings/graphLayout/model', () => {
       pinnedNodes: {
         'src/missing.ts': {
           nodeId: 'src/missing.ts',
-          twoDimensional: { x: 120, y: -40 },
-          threeDimensional: { x: 12, y: 24, z: -6 },
-          updatedAt: '2026-05-07T08:00:00.000Z',
+          '2D': { x: 120, y: -40 },
+          '3D': { x: 12, y: 24, z: -6 },
         },
       },
     });
@@ -41,32 +39,27 @@ describe('extension/repoSettings/graphLayout/model', () => {
       pinnedNodes: {
         good: {
           nodeId: 'good',
-          twoDimensional: { x: 1, y: 2 },
-          threeDimensional: { x: 3, y: 4, z: 5 },
-          updatedAt: '2026-05-07T08:00:00.000Z',
+          '2D': { x: 1, y: 2 },
+          '3D': { x: 3, y: 4, z: 5 },
         },
         mismatch: {
           nodeId: 'other-id',
-          twoDimensional: { x: 1, y: 2 },
-          updatedAt: '2026-05-07T08:00:00.000Z',
+          '2D': { x: 1, y: 2 },
         },
         invalidCoordinate: {
           nodeId: 'invalidCoordinate',
-          twoDimensional: { x: Number.POSITIVE_INFINITY, y: 2 },
-          updatedAt: '2026-05-07T08:00:00.000Z',
+          '2D': { x: Number.POSITIVE_INFINITY, y: 2 },
         },
         noCoordinates: {
           nodeId: 'noCoordinates',
-          updatedAt: '2026-05-07T08:00:00.000Z',
         },
       },
     })).toEqual({
       pinnedNodes: {
         good: {
           nodeId: 'good',
-          twoDimensional: { x: 1, y: 2 },
-          threeDimensional: { x: 3, y: 4, z: 5 },
-          updatedAt: '2026-05-07T08:00:00.000Z',
+          '2D': { x: 1, y: 2 },
+          '3D': { x: 3, y: 4, z: 5 },
         },
       },
     });
@@ -77,27 +70,23 @@ describe('extension/repoSettings/graphLayout/model', () => {
       graphMode: '2d',
       nodeId: 'src/app.ts',
       position: { x: 10, y: 20 },
-      updatedAt: '2026-05-07T08:00:00.000Z',
     });
     const pinnedBoth = setGraphLayoutNodePin(pinned2d, {
       graphMode: '3d',
       nodeId: 'src/app.ts',
       position: { x: 1, y: 2, z: 3 },
-      updatedAt: '2026-05-07T08:01:00.000Z',
     });
     const only3d = clearGraphLayoutNodePin(pinnedBoth, 'src/app.ts', '2d');
     const cleared = clearGraphLayoutNodePin(only3d, 'src/app.ts', '3d');
 
     expect(pinnedBoth.pinnedNodes['src/app.ts']).toEqual({
       nodeId: 'src/app.ts',
-      twoDimensional: { x: 10, y: 20 },
-      threeDimensional: { x: 1, y: 2, z: 3 },
-      updatedAt: '2026-05-07T08:01:00.000Z',
+      '2D': { x: 10, y: 20 },
+      '3D': { x: 1, y: 2, z: 3 },
     });
     expect(only3d.pinnedNodes['src/app.ts']).toEqual({
       nodeId: 'src/app.ts',
-      threeDimensional: { x: 1, y: 2, z: 3 },
-      updatedAt: '2026-05-07T08:01:00.000Z',
+      '3D': { x: 1, y: 2, z: 3 },
     });
     expect(cleared.pinnedNodes).toEqual({});
   });

--- a/packages/extension/tests/extension/repoSettings/graphLayout/model.test.ts
+++ b/packages/extension/tests/extension/repoSettings/graphLayout/model.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assignGraphLayoutOwner,
+  createDefaultGraphLayoutSettings,
+  normalizeGraphLayoutSettings,
+  wouldCreateGraphLayoutOwnershipCycle,
+} from '../../../../src/extension/repoSettings/graphLayout/model';
+
+describe('extension/repoSettings/graphLayout/model', () => {
+  it('creates empty layout state for pins, sections, and ownership', () => {
+    expect(createDefaultGraphLayoutSettings()).toEqual({
+      pinnedNodes: {},
+      sections: {},
+      ownership: {},
+    });
+  });
+
+  it('keeps dormant pin and node ownership records without requiring visible graph nodes', () => {
+    expect(normalizeGraphLayoutSettings({
+      pinnedNodes: {
+        'src/missing.ts': {
+          nodeId: 'src/missing.ts',
+          twoDimensional: { x: 120, y: -40 },
+          threeDimensional: { x: 12, y: 24, z: -6 },
+          updatedAt: '2026-05-07T08:00:00.000Z',
+        },
+      },
+      sections: {
+        'section-a': {
+          id: 'section-a',
+          label: 'UI Layer',
+          color: '#4488ff',
+          x: 10,
+          y: 20,
+          width: 300,
+          height: 180,
+          collapsed: false,
+          updatedAt: '2026-05-07T08:01:00.000Z',
+        },
+      },
+      ownership: {
+        'src/missing.ts': {
+          itemId: 'src/missing.ts',
+          itemKind: 'node',
+          ownerSectionId: 'section-a',
+          updatedAt: '2026-05-07T08:02:00.000Z',
+        },
+      },
+    })).toEqual({
+      pinnedNodes: {
+        'src/missing.ts': {
+          nodeId: 'src/missing.ts',
+          twoDimensional: { x: 120, y: -40 },
+          threeDimensional: { x: 12, y: 24, z: -6 },
+          updatedAt: '2026-05-07T08:00:00.000Z',
+        },
+      },
+      sections: {
+        'section-a': {
+          id: 'section-a',
+          label: 'UI Layer',
+          color: '#4488ff',
+          x: 10,
+          y: 20,
+          width: 300,
+          height: 180,
+          collapsed: false,
+          updatedAt: '2026-05-07T08:01:00.000Z',
+        },
+      },
+      ownership: {
+        'src/missing.ts': {
+          itemId: 'src/missing.ts',
+          itemKind: 'node',
+          ownerSectionId: 'section-a',
+          updatedAt: '2026-05-07T08:02:00.000Z',
+        },
+      },
+    });
+  });
+
+  it('normalizes malformed layout records before settings are persisted', () => {
+    expect(normalizeGraphLayoutSettings({
+      pinnedNodes: {
+        good: {
+          nodeId: 'good',
+          twoDimensional: { x: 1, y: 2 },
+          threeDimensional: { x: 3, y: 4, z: 5 },
+          updatedAt: '2026-05-07T08:00:00.000Z',
+        },
+        mismatch: {
+          nodeId: 'other-id',
+          twoDimensional: { x: 1, y: 2 },
+          updatedAt: '2026-05-07T08:00:00.000Z',
+        },
+        invalidCoordinate: {
+          nodeId: 'invalidCoordinate',
+          twoDimensional: { x: Number.POSITIVE_INFINITY, y: 2 },
+          updatedAt: '2026-05-07T08:00:00.000Z',
+        },
+      },
+      sections: {
+        'section-a': {
+          id: 'section-a',
+          label: 'Section A',
+          color: '#223344',
+          x: 0,
+          y: 0,
+          width: 120,
+          height: 100,
+          collapsed: true,
+          updatedAt: '2026-05-07T08:01:00.000Z',
+        },
+        'bad-section': {
+          id: 'bad-section',
+          label: '',
+          color: '#223344',
+          x: 0,
+          y: 0,
+          width: 0,
+          height: 100,
+          collapsed: false,
+          updatedAt: '2026-05-07T08:01:00.000Z',
+        },
+      },
+      ownership: {
+        good: {
+          itemId: 'good',
+          itemKind: 'node',
+          ownerSectionId: 'section-a',
+          updatedAt: '2026-05-07T08:02:00.000Z',
+        },
+        orphanedOwner: {
+          itemId: 'orphanedOwner',
+          itemKind: 'node',
+          ownerSectionId: 'missing-section',
+          updatedAt: '2026-05-07T08:02:00.000Z',
+        },
+      },
+      stray: true,
+    })).toEqual({
+      pinnedNodes: {
+        good: {
+          nodeId: 'good',
+          twoDimensional: { x: 1, y: 2 },
+          threeDimensional: { x: 3, y: 4, z: 5 },
+          updatedAt: '2026-05-07T08:00:00.000Z',
+        },
+      },
+      sections: {
+        'section-a': {
+          id: 'section-a',
+          label: 'Section A',
+          color: '#223344',
+          x: 0,
+          y: 0,
+          width: 120,
+          height: 100,
+          collapsed: true,
+          updatedAt: '2026-05-07T08:01:00.000Z',
+        },
+      },
+      ownership: {
+        good: {
+          itemId: 'good',
+          itemKind: 'node',
+          ownerSectionId: 'section-a',
+          updatedAt: '2026-05-07T08:02:00.000Z',
+        },
+      },
+    });
+  });
+
+  it('prevents section ownership cycles', () => {
+    const ownership = {
+      'section-a': {
+        itemId: 'section-a',
+        itemKind: 'section' as const,
+        ownerSectionId: 'section-b',
+        updatedAt: '2026-05-07T08:02:00.000Z',
+      },
+      'section-b': {
+        itemId: 'section-b',
+        itemKind: 'section' as const,
+        ownerSectionId: null,
+        updatedAt: '2026-05-07T08:03:00.000Z',
+      },
+    };
+
+    expect(wouldCreateGraphLayoutOwnershipCycle(
+      ownership,
+      'section-b',
+      'section-a',
+    )).toBe(true);
+    expect(wouldCreateGraphLayoutOwnershipCycle(
+      ownership,
+      'section-b',
+      null,
+    )).toBe(false);
+  });
+
+  it('throws instead of assigning a section to its own descendant', () => {
+    const layout = normalizeGraphLayoutSettings({
+      sections: {
+        'section-a': {
+          id: 'section-a',
+          label: 'Section A',
+          color: '#223344',
+          x: 0,
+          y: 0,
+          width: 120,
+          height: 100,
+          collapsed: false,
+          updatedAt: '2026-05-07T08:01:00.000Z',
+        },
+        'section-b': {
+          id: 'section-b',
+          label: 'Section B',
+          color: '#446688',
+          x: 20,
+          y: 20,
+          width: 120,
+          height: 100,
+          collapsed: false,
+          updatedAt: '2026-05-07T08:01:00.000Z',
+        },
+      },
+      ownership: {
+        'section-b': {
+          itemId: 'section-b',
+          itemKind: 'section',
+          ownerSectionId: 'section-a',
+          updatedAt: '2026-05-07T08:02:00.000Z',
+        },
+      },
+    });
+
+    expect(() => assignGraphLayoutOwner(layout, {
+      itemId: 'section-a',
+      itemKind: 'section',
+      ownerSectionId: 'section-b',
+      updatedAt: '2026-05-07T08:03:00.000Z',
+    })).toThrow('Graph Section ownership cannot create a cycle.');
+  });
+});

--- a/packages/extension/tests/extension/repoSettings/store/model/persistedShape.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store/model/persistedShape.test.ts
@@ -70,4 +70,76 @@ describe('extension/repoSettings/store/model/persistedShape', () => {
       timeline: { maxCommits: 1000 },
     });
   });
+
+  it('keeps normalized graph layout settings and drops invalid layout records', () => {
+    expect(normalizePersistedSettingsShape({
+      graphLayout: {
+        pinnedNodes: {
+          'src/a.ts': {
+            nodeId: 'src/a.ts',
+            twoDimensional: { x: 10, y: 20 },
+            updatedAt: '2026-05-07T08:00:00.000Z',
+          },
+          bad: {
+            nodeId: 'bad',
+            twoDimensional: { x: Number.NaN, y: 20 },
+            updatedAt: '2026-05-07T08:00:00.000Z',
+          },
+        },
+        sections: {
+          'section-a': {
+            id: 'section-a',
+            label: 'Layer A',
+            color: '#5588aa',
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 140,
+            collapsed: false,
+            updatedAt: '2026-05-07T08:01:00.000Z',
+          },
+        },
+        ownership: {
+          'src/a.ts': {
+            itemId: 'src/a.ts',
+            itemKind: 'node',
+            ownerSectionId: 'section-a',
+            updatedAt: '2026-05-07T08:02:00.000Z',
+          },
+        },
+      },
+      graphSectionDrafts: {},
+    })).toEqual({
+      graphLayout: {
+        pinnedNodes: {
+          'src/a.ts': {
+            nodeId: 'src/a.ts',
+            twoDimensional: { x: 10, y: 20 },
+            updatedAt: '2026-05-07T08:00:00.000Z',
+          },
+        },
+        sections: {
+          'section-a': {
+            id: 'section-a',
+            label: 'Layer A',
+            color: '#5588aa',
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 140,
+            collapsed: false,
+            updatedAt: '2026-05-07T08:01:00.000Z',
+          },
+        },
+        ownership: {
+          'src/a.ts': {
+            itemId: 'src/a.ts',
+            itemKind: 'node',
+            ownerSectionId: 'section-a',
+            updatedAt: '2026-05-07T08:02:00.000Z',
+          },
+        },
+      },
+    });
+  });
 });

--- a/packages/extension/tests/extension/repoSettings/store/model/persistedShape.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store/model/persistedShape.test.ts
@@ -77,13 +77,11 @@ describe('extension/repoSettings/store/model/persistedShape', () => {
         pinnedNodes: {
           'src/a.ts': {
             nodeId: 'src/a.ts',
-            twoDimensional: { x: 10, y: 20 },
-            updatedAt: '2026-05-07T08:00:00.000Z',
+            '2D': { x: 10, y: 20 },
           },
           bad: {
             nodeId: 'bad',
-            twoDimensional: { x: Number.NaN, y: 20 },
-            updatedAt: '2026-05-07T08:00:00.000Z',
+            '2D': { x: Number.NaN, y: 20 },
           },
         },
         sections: { ignored: true },
@@ -95,8 +93,7 @@ describe('extension/repoSettings/store/model/persistedShape', () => {
         pinnedNodes: {
           'src/a.ts': {
             nodeId: 'src/a.ts',
-            twoDimensional: { x: 10, y: 20 },
-            updatedAt: '2026-05-07T08:00:00.000Z',
+            '2D': { x: 10, y: 20 },
           },
         },
       },

--- a/packages/extension/tests/extension/repoSettings/store/model/persistedShape.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store/model/persistedShape.test.ts
@@ -71,7 +71,7 @@ describe('extension/repoSettings/store/model/persistedShape', () => {
     });
   });
 
-  it('keeps normalized graph layout settings and drops invalid layout records', () => {
+  it('keeps normalized graph layout pins and drops invalid layout records', () => {
     expect(normalizePersistedSettingsShape({
       graphLayout: {
         pinnedNodes: {
@@ -86,27 +86,8 @@ describe('extension/repoSettings/store/model/persistedShape', () => {
             updatedAt: '2026-05-07T08:00:00.000Z',
           },
         },
-        sections: {
-          'section-a': {
-            id: 'section-a',
-            label: 'Layer A',
-            color: '#5588aa',
-            x: 0,
-            y: 0,
-            width: 200,
-            height: 140,
-            collapsed: false,
-            updatedAt: '2026-05-07T08:01:00.000Z',
-          },
-        },
-        ownership: {
-          'src/a.ts': {
-            itemId: 'src/a.ts',
-            itemKind: 'node',
-            ownerSectionId: 'section-a',
-            updatedAt: '2026-05-07T08:02:00.000Z',
-          },
-        },
+        sections: { ignored: true },
+        ownership: { ignored: true },
       },
       graphSectionDrafts: {},
     })).toEqual({
@@ -116,27 +97,6 @@ describe('extension/repoSettings/store/model/persistedShape', () => {
             nodeId: 'src/a.ts',
             twoDimensional: { x: 10, y: 20 },
             updatedAt: '2026-05-07T08:00:00.000Z',
-          },
-        },
-        sections: {
-          'section-a': {
-            id: 'section-a',
-            label: 'Layer A',
-            color: '#5588aa',
-            x: 0,
-            y: 0,
-            width: 200,
-            height: 140,
-            collapsed: false,
-            updatedAt: '2026-05-07T08:01:00.000Z',
-          },
-        },
-        ownership: {
-          'src/a.ts': {
-            itemId: 'src/a.ts',
-            itemKind: 'node',
-            ownerSectionId: 'section-a',
-            updatedAt: '2026-05-07T08:02:00.000Z',
           },
         },
       },

--- a/packages/extension/tests/extension/repoSettings/store/persistence/serialization.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store/persistence/serialization.test.ts
@@ -72,8 +72,7 @@ describe('extension/repoSettings/store/persistence/serialization', () => {
       pinnedNodes: {
         'src/a.ts': {
           nodeId: 'src/a.ts',
-          twoDimensional: { x: 10, y: 20 },
-          updatedAt: '2026-05-07T08:00:00.000Z',
+          '2D': { x: 10, y: 20 },
         },
       },
     };

--- a/packages/extension/tests/extension/repoSettings/store/persistence/serialization.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store/persistence/serialization.test.ts
@@ -66,7 +66,7 @@ describe('extension/repoSettings/store/persistence/serialization', () => {
     ]);
   });
 
-  it('serializes graph layout pins, sections, and ownership records', () => {
+  it('serializes graph layout pin records', () => {
     const settings = createDefaultCodeGraphyRepoSettings();
     settings.graphLayout = {
       pinnedNodes: {
@@ -74,27 +74,6 @@ describe('extension/repoSettings/store/persistence/serialization', () => {
           nodeId: 'src/a.ts',
           twoDimensional: { x: 10, y: 20 },
           updatedAt: '2026-05-07T08:00:00.000Z',
-        },
-      },
-      sections: {
-        'section-a': {
-          id: 'section-a',
-          label: 'Layer A',
-          color: '#5588aa',
-          x: 0,
-          y: 0,
-          width: 200,
-          height: 140,
-          collapsed: false,
-          updatedAt: '2026-05-07T08:01:00.000Z',
-        },
-      },
-      ownership: {
-        'src/a.ts': {
-          itemId: 'src/a.ts',
-          itemKind: 'node',
-          ownerSectionId: 'section-a',
-          updatedAt: '2026-05-07T08:02:00.000Z',
         },
       },
     };

--- a/packages/extension/tests/extension/repoSettings/store/persistence/serialization.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store/persistence/serialization.test.ts
@@ -65,4 +65,42 @@ describe('extension/repoSettings/store/persistence/serialization', () => {
       { pattern: 'src/**', color: '#123456', target: 'node' },
     ]);
   });
+
+  it('serializes graph layout pins, sections, and ownership records', () => {
+    const settings = createDefaultCodeGraphyRepoSettings();
+    settings.graphLayout = {
+      pinnedNodes: {
+        'src/a.ts': {
+          nodeId: 'src/a.ts',
+          twoDimensional: { x: 10, y: 20 },
+          updatedAt: '2026-05-07T08:00:00.000Z',
+        },
+      },
+      sections: {
+        'section-a': {
+          id: 'section-a',
+          label: 'Layer A',
+          color: '#5588aa',
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 140,
+          collapsed: false,
+          updatedAt: '2026-05-07T08:01:00.000Z',
+        },
+      },
+      ownership: {
+        'src/a.ts': {
+          itemId: 'src/a.ts',
+          itemKind: 'node',
+          ownerSectionId: 'section-a',
+          updatedAt: '2026-05-07T08:02:00.000Z',
+        },
+      },
+    };
+
+    const parsed = JSON.parse(serializeSettings(settings)) as Record<string, unknown>;
+
+    expect(parsed.graphLayout).toEqual(settings.graphLayout);
+  });
 });

--- a/packages/extension/tests/webview/graph/contextActions/context.test.ts
+++ b/packages/extension/tests/webview/graph/contextActions/context.test.ts
@@ -14,7 +14,9 @@ describe('graph/contextActions/context', () => {
       primaryTargetId: 'from.ts',
       edgeSourceId: undefined,
       edgeTargetId: undefined,
+      graphMode: '2d',
       mutationDirectory: 'from.ts',
+      nodePositions: new Map(),
     });
   });
 

--- a/packages/extension/tests/webview/graph/contextActions/effects.test.ts
+++ b/packages/extension/tests/webview/graph/contextActions/effects.test.ts
@@ -9,6 +9,18 @@ function nodeContext(targets: string[]) {
   return resolveGraphContextActionContext({ kind: 'node', targets });
 }
 
+function positionedNodeContext(targets: string[]) {
+  return resolveGraphContextActionContext(
+    { kind: 'node', targets },
+    {
+      graphMode: '2d',
+      nodePositions: new Map([
+        ['src/app.ts', { x: 12, y: -24 }],
+      ]),
+    },
+  );
+}
+
 function edgeContext(targets: string[]) {
   return resolveGraphContextActionContext({ kind: 'edge', edgeId: targets.join('->'), targets });
 }
@@ -105,6 +117,36 @@ describe('graph/contextActions/effects', () => {
 
   it('returns no effect when focus has no selected path', () => {
     expect(getBuiltInContextActionEffects('focus', nodeContext([]))).toEqual([]);
+  });
+
+  it('pins and unpins the primary selected node in the active graph mode', () => {
+    expect(getBuiltInContextActionEffects('pinNode', positionedNodeContext(['src/app.ts']))).toEqual([
+      {
+        kind: 'postMessage',
+        message: {
+          type: 'UPDATE_GRAPH_LAYOUT_PIN',
+          payload: {
+            graphMode: '2d',
+            nodeId: 'src/app.ts',
+            position: { x: 12, y: -24 },
+          },
+        },
+      },
+    ]);
+
+    expect(getBuiltInContextActionEffects('unpinNode', positionedNodeContext(['src/app.ts']))).toEqual([
+      {
+        kind: 'postMessage',
+        message: {
+          type: 'CLEAR_GRAPH_LAYOUT_PIN',
+          payload: { graphMode: '2d', nodeId: 'src/app.ts' },
+        },
+      },
+    ]);
+  });
+
+  it('does not pin a node when its graph-space position is missing', () => {
+    expect(getBuiltInContextActionEffects('pinNode', nodeContext(['src/app.ts']))).toEqual([]);
   });
 
   it('returns no effect when rename has no selected path', () => {

--- a/packages/extension/tests/webview/graph/contextMenu/model.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/model.test.ts
@@ -78,6 +78,7 @@ describe('graph/contextMenuModel', () => {
       'Copy Absolute Path',
       'Remove from Favorites',
       'Focus Node',
+      'Pin Node',
       'Add Filter Pattern...',
       'Add Legend Group...',
       'Rename...',
@@ -125,6 +126,7 @@ describe('graph/contextMenuModel', () => {
       'Copy Absolute Path',
       'Add to Favorites',
       'Focus Node',
+      'Pin Node',
       'Add Filter Pattern...',
       'Add Legend Group...',
       'Rename Folder...',
@@ -183,6 +185,19 @@ describe('graph/contextMenuModel', () => {
     ]);
   });
 
+  it('shows Unpin Node for nodes pinned in the active graph mode', () => {
+    const entries = buildGraphContextMenuEntries({
+      selection: makeNodeContextSelection('src/app.ts', new Set<string>()),
+      timelineActive: false,
+      favorites: new Set<string>(),
+      pinnedNodeIds: new Set(['src/app.ts']),
+      pluginItems: [],
+    });
+
+    expect(menuLabels(entries)).toContain('Unpin Node');
+    expect(builtInActions(entries)).toContain('unpinNode');
+  });
+
   it('maps all built-in actions by context variant', () => {
     const backgroundLive = buildGraphContextMenuEntries({
       selection: makeBackgroundContextSelection(),
@@ -215,6 +230,7 @@ describe('graph/contextMenuModel', () => {
       'copyAbsolute',
       'toggleFavorite',
       'focus',
+      'pinNode',
       'addToFilter',
       'addNodeLegend',
       'rename',

--- a/packages/extension/tests/webview/graph/model/node/build.test.ts
+++ b/packages/extension/tests/webview/graph/model/node/build.test.ts
@@ -144,4 +144,108 @@ describe('graph/model/node/build', () => {
       z: undefined,
     });
   });
+
+  it('applies active-mode pins as fixed graph-space coordinates', () => {
+    const twoDimensionalNodes = buildGraphNodes({
+      nodes: [
+        { id: 'src/pinned.ts', label: 'pinned.ts', color: '#93C5FD' },
+      ],
+      edges: [],
+      nodeSizes: new Map([['src/pinned.ts', 16]]),
+      theme: 'dark',
+      favorites: new Set(),
+      graphMode: '2d',
+      graphLayout: {
+        pinnedNodes: {
+          'src/pinned.ts': {
+            nodeId: 'src/pinned.ts',
+            twoDimensional: { x: 40, y: -80 },
+            threeDimensional: { x: 1, y: 2, z: 3 },
+            updatedAt: '2026-05-07T08:00:00.000Z',
+          },
+        },
+        sections: {},
+        ownership: {},
+      },
+      timelineActive: false,
+    });
+
+    expect(twoDimensionalNodes[0]).toMatchObject({
+      fx: 40,
+      fy: -80,
+      fz: undefined,
+      isPinned: true,
+      x: 40,
+      y: -80,
+      z: undefined,
+    });
+
+    const threeDimensionalNodes = buildGraphNodes({
+      nodes: [
+        { id: 'src/pinned.ts', label: 'pinned.ts', color: '#93C5FD' },
+      ],
+      edges: [],
+      nodeSizes: new Map([['src/pinned.ts', 16]]),
+      theme: 'dark',
+      favorites: new Set(),
+      graphMode: '3d',
+      graphLayout: {
+        pinnedNodes: {
+          'src/pinned.ts': {
+            nodeId: 'src/pinned.ts',
+            twoDimensional: { x: 40, y: -80 },
+            threeDimensional: { x: 1, y: 2, z: 3 },
+            updatedAt: '2026-05-07T08:00:00.000Z',
+          },
+        },
+        sections: {},
+        ownership: {},
+      },
+      timelineActive: false,
+    });
+
+    expect(threeDimensionalNodes[0]).toMatchObject({
+      fx: 1,
+      fy: 2,
+      fz: 3,
+      isPinned: true,
+      x: 1,
+      y: 2,
+      z: 3,
+    });
+  });
+
+  it('ignores persisted pins while timeline snapshots are active', () => {
+    const nodes = buildGraphNodes({
+      nodes: [
+        { id: 'src/pinned.ts', label: 'pinned.ts', color: '#93C5FD' },
+      ],
+      edges: [],
+      nodeSizes: new Map([['src/pinned.ts', 16]]),
+      theme: 'dark',
+      favorites: new Set(),
+      graphMode: '2d',
+      graphLayout: {
+        pinnedNodes: {
+          'src/pinned.ts': {
+            nodeId: 'src/pinned.ts',
+            twoDimensional: { x: 40, y: -80 },
+            updatedAt: '2026-05-07T08:00:00.000Z',
+          },
+        },
+        sections: {},
+        ownership: {},
+      },
+      previousNodes: [{ id: 'src/pinned.ts', x: 4, y: 8 }],
+      timelineActive: true,
+    });
+
+    expect(nodes[0]).toMatchObject({
+      fx: undefined,
+      fy: undefined,
+      isPinned: false,
+      x: 4,
+      y: 8,
+    });
+  });
 });

--- a/packages/extension/tests/webview/graph/model/node/build.test.ts
+++ b/packages/extension/tests/webview/graph/model/node/build.test.ts
@@ -164,8 +164,6 @@ describe('graph/model/node/build', () => {
             updatedAt: '2026-05-07T08:00:00.000Z',
           },
         },
-        sections: {},
-        ownership: {},
       },
       timelineActive: false,
     });
@@ -198,8 +196,6 @@ describe('graph/model/node/build', () => {
             updatedAt: '2026-05-07T08:00:00.000Z',
           },
         },
-        sections: {},
-        ownership: {},
       },
       timelineActive: false,
     });
@@ -233,8 +229,6 @@ describe('graph/model/node/build', () => {
             updatedAt: '2026-05-07T08:00:00.000Z',
           },
         },
-        sections: {},
-        ownership: {},
       },
       previousNodes: [{ id: 'src/pinned.ts', x: 4, y: 8 }],
       timelineActive: true,

--- a/packages/extension/tests/webview/graph/model/node/build.test.ts
+++ b/packages/extension/tests/webview/graph/model/node/build.test.ts
@@ -159,9 +159,8 @@ describe('graph/model/node/build', () => {
         pinnedNodes: {
           'src/pinned.ts': {
             nodeId: 'src/pinned.ts',
-            twoDimensional: { x: 40, y: -80 },
-            threeDimensional: { x: 1, y: 2, z: 3 },
-            updatedAt: '2026-05-07T08:00:00.000Z',
+            '2D': { x: 40, y: -80 },
+            '3D': { x: 1, y: 2, z: 3 },
           },
         },
       },
@@ -191,9 +190,8 @@ describe('graph/model/node/build', () => {
         pinnedNodes: {
           'src/pinned.ts': {
             nodeId: 'src/pinned.ts',
-            twoDimensional: { x: 40, y: -80 },
-            threeDimensional: { x: 1, y: 2, z: 3 },
-            updatedAt: '2026-05-07T08:00:00.000Z',
+            '2D': { x: 40, y: -80 },
+            '3D': { x: 1, y: 2, z: 3 },
           },
         },
       },
@@ -225,8 +223,7 @@ describe('graph/model/node/build', () => {
         pinnedNodes: {
           'src/pinned.ts': {
             nodeId: 'src/pinned.ts',
-            twoDimensional: { x: 40, y: -80 },
-            updatedAt: '2026-05-07T08:00:00.000Z',
+            '2D': { x: 40, y: -80 },
           },
         },
       },

--- a/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
+++ b/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NodeDecorationPayload } from '../../../../../src/shared/plugins/decorations';
 import type { ThemeKind } from '../../../../../src/webview/theme/useTheme';
 
@@ -137,6 +137,8 @@ function createContext(): {
     strokeStyle: '',
     textAlign: 'left',
     textBaseline: 'alphabetic',
+    translate: vi.fn(),
+    scale: vi.fn(),
   };
 
   return {
@@ -148,6 +150,10 @@ function createContext(): {
 describe('graph/rendering/nodes/canvas2d', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('draws the node body and stroke using node styling', () => {
@@ -388,6 +394,7 @@ describe('graph/rendering/nodes/canvas2d', () => {
 
   it('renders a pin badge for pinned nodes without changing the node body', () => {
     const { ctx } = createContext();
+    vi.stubGlobal('Path2D', vi.fn());
 
     renderNodeCanvas(
       createDependencies({ showLabels: false }),
@@ -397,9 +404,13 @@ describe('graph/rendering/nodes/canvas2d', () => {
     );
 
     expect(drawShape).toHaveBeenCalledWith(ctx, 'circle', 24, 48, 16);
-    expect(ctx.arc).toHaveBeenCalledWith(35.2, 36.8, 5, 0, Math.PI * 2);
-    expect(ctx.moveTo).toHaveBeenCalledWith(35.2, 34.55);
-    expect(ctx.lineTo).toHaveBeenCalledWith(35.2, 38.3);
+    expect(ctx.arc).toHaveBeenCalledWith(35.2, 36.8, 7, 0, Math.PI * 2);
+    expect(ctx.translate).toHaveBeenCalledWith(
+      expect.closeTo(29.775),
+      expect.closeTo(31.375),
+    );
+    expect(ctx.scale).toHaveBeenCalledWith(0.45208333333333334, 0.45208333333333334);
+    expect(ctx.fill).toHaveBeenCalledWith(expect.any(Path2D));
   });
 
   it('paints the expanded pointer area around the node shape', () => {

--- a/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
+++ b/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
@@ -410,7 +410,7 @@ describe('graph/rendering/nodes/canvas2d', () => {
       expect.closeTo(31.375),
     );
     expect(ctx.scale).toHaveBeenCalledWith(0.45208333333333334, 0.45208333333333334);
-    expect(ctx.fill).toHaveBeenCalledWith(expect.any(Path2D));
+    expect(ctx.fill).toHaveBeenCalledWith(expect.anything());
     expect(operations).toContainEqual(expect.objectContaining({
       fillStyle: 'rgb(28, 62, 118)',
       kind: 'fill',
@@ -419,6 +419,44 @@ describe('graph/rendering/nodes/canvas2d', () => {
       fillStyle: '#ffffff',
       kind: 'fill',
     }));
+  });
+
+  it('fades pinned badges as small nodes zoom away', () => {
+    const { ctx, operations } = createContext();
+    vi.stubGlobal('Path2D', vi.fn());
+
+    renderNodeCanvas(
+      createDependencies({ showLabels: false }),
+      createNode({ isPinned: true }),
+      ctx,
+      0.5,
+    );
+
+    expect(ctx.fill).toHaveBeenCalledWith(expect.anything());
+    expect(operations).toContainEqual(expect.objectContaining({
+      fillStyle: 'rgb(28, 62, 118)',
+      globalAlpha: 0.75,
+      kind: 'fill',
+    }));
+    expect(operations).toContainEqual(expect.objectContaining({
+      fillStyle: '#ffffff',
+      globalAlpha: 0.75,
+      kind: 'fill',
+    }));
+  });
+
+  it('hides pinned badges when the node is too small on screen', () => {
+    const { ctx } = createContext();
+
+    renderNodeCanvas(
+      createDependencies({ showLabels: false }),
+      createNode({ isPinned: true, size: 8 }),
+      ctx,
+      0.5,
+    );
+
+    expect(drawShape).toHaveBeenCalledWith(ctx, 'circle', 24, 48, 8);
+    expect(ctx.arc).not.toHaveBeenCalled();
   });
 
   it('paints the expanded pointer area around the node shape', () => {

--- a/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
+++ b/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
@@ -86,6 +86,8 @@ function createContext(): {
 } {
   const operations: ContextOperation[] = [];
   const ctx = {
+    arc: vi.fn(),
+    beginPath: vi.fn(),
     clip: vi.fn(),
     drawImage: vi.fn(() => {
       operations.push({
@@ -115,6 +117,8 @@ function createContext(): {
         text,
       });
     }),
+    lineTo: vi.fn(),
+    moveTo: vi.fn(),
     restore: vi.fn(),
     save: vi.fn(),
     stroke: vi.fn(() => {
@@ -380,6 +384,22 @@ describe('graph/rendering/nodes/canvas2d', () => {
       lineWidth: 3,
       strokeStyle: '#ffffff',
     }));
+  });
+
+  it('renders a pin badge for pinned nodes without changing the node body', () => {
+    const { ctx } = createContext();
+
+    renderNodeCanvas(
+      createDependencies({ showLabels: false }),
+      createNode({ isPinned: true }),
+      ctx,
+      1,
+    );
+
+    expect(drawShape).toHaveBeenCalledWith(ctx, 'circle', 24, 48, 16);
+    expect(ctx.arc).toHaveBeenCalledWith(35.2, 36.8, 5, 0, Math.PI * 2);
+    expect(ctx.moveTo).toHaveBeenCalledWith(35.2, 34.55);
+    expect(ctx.lineTo).toHaveBeenCalledWith(35.2, 38.3);
   });
 
   it('paints the expanded pointer area around the node shape', () => {

--- a/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
+++ b/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
@@ -393,7 +393,7 @@ describe('graph/rendering/nodes/canvas2d', () => {
   });
 
   it('renders a pin badge for pinned nodes without changing the node body', () => {
-    const { ctx } = createContext();
+    const { ctx, operations } = createContext();
     vi.stubGlobal('Path2D', vi.fn());
 
     renderNodeCanvas(
@@ -411,6 +411,14 @@ describe('graph/rendering/nodes/canvas2d', () => {
     );
     expect(ctx.scale).toHaveBeenCalledWith(0.45208333333333334, 0.45208333333333334);
     expect(ctx.fill).toHaveBeenCalledWith(expect.any(Path2D));
+    expect(operations).toContainEqual(expect.objectContaining({
+      fillStyle: 'rgb(28, 62, 118)',
+      kind: 'fill',
+    }));
+    expect(operations).toContainEqual(expect.objectContaining({
+      fillStyle: '#ffffff',
+      kind: 'fill',
+    }));
   });
 
   it('paints the expanded pointer area around the node shape', () => {

--- a/packages/extension/tests/webview/graph/rendering/sharedProps.test.ts
+++ b/packages/extension/tests/webview/graph/rendering/sharedProps.test.ts
@@ -49,6 +49,7 @@ function createOptions(
     onLinkClick: vi.fn(),
     onLinkRightClick: vi.fn(),
     onNodeClick: vi.fn(),
+    onNodeDragEnd: vi.fn(),
     onNodeHover: vi.fn(),
     onNodeRightClick: vi.fn(),
     timelineActive: false,
@@ -116,6 +117,7 @@ describe('graph/rendering/surface/sharedProps', () => {
       onLinkClick: vi.fn(),
       onLinkRightClick: vi.fn(),
       onNodeClick: vi.fn(),
+      onNodeDragEnd: vi.fn(),
       onNodeHover: vi.fn(),
       onNodeRightClick: vi.fn(),
     };
@@ -127,6 +129,7 @@ describe('graph/rendering/surface/sharedProps', () => {
 
     props.onNodeClick(node, clickEvent);
     props.onNodeRightClick(node, contextEvent);
+    props.onNodeDragEnd(node);
     props.onLinkClick(link, clickEvent);
     props.onLinkRightClick(link, contextEvent);
     props.onBackgroundClick(clickEvent);
@@ -138,6 +141,7 @@ describe('graph/rendering/surface/sharedProps', () => {
 
     expect(handlers.onNodeClick).toHaveBeenCalledWith(node, clickEvent);
     expect(handlers.onNodeRightClick).toHaveBeenCalledWith(node, contextEvent);
+    expect(handlers.onNodeDragEnd).toHaveBeenCalledWith(node);
     expect(handlers.onLinkClick).toHaveBeenCalledWith(link, clickEvent);
     expect(handlers.onLinkRightClick).toHaveBeenCalledWith(link, contextEvent);
     expect(handlers.onBackgroundClick).toHaveBeenNthCalledWith(1, clickEvent);

--- a/packages/extension/tests/webview/graph/rendering/surface/view/threeDimensional.test.tsx
+++ b/packages/extension/tests/webview/graph/rendering/surface/view/threeDimensional.test.tsx
@@ -25,6 +25,7 @@ function createSharedProps() {
     onLinkClick: vi.fn(),
     onLinkRightClick: vi.fn(),
     onNodeClick: vi.fn(),
+    onNodeDragEnd: vi.fn(),
     onNodeHover: vi.fn(),
     onNodeRightClick: vi.fn(),
     warmupTicks: 0,

--- a/packages/extension/tests/webview/graph/rendering/surface/view/twoDimensional.test.tsx
+++ b/packages/extension/tests/webview/graph/rendering/surface/view/twoDimensional.test.tsx
@@ -20,6 +20,7 @@ function createSharedProps() {
     onLinkClick: vi.fn(),
     onLinkRightClick: vi.fn(),
     onNodeClick: vi.fn(),
+    onNodeDragEnd: vi.fn(),
     onNodeHover: vi.fn(),
     onNodeRightClick: vi.fn(),
     warmupTicks: 0,

--- a/packages/extension/tests/webview/graph/runtime/use/state.test.tsx
+++ b/packages/extension/tests/webview/graph/runtime/use/state.test.tsx
@@ -179,7 +179,7 @@ describe('graph/runtime/useGraphState', () => {
       nodeSizeMode: 'file-size',
       showLabels: false,
       theme: 'light',
-      timelineActive: true,
+      timelineActive: false,
     }));
 
     expect(graphStateHarness.buildGraphData).toHaveBeenCalledTimes(1);
@@ -192,7 +192,7 @@ describe('graph/runtime/useGraphState', () => {
     expect(result.current.showLabelsRef.current).toBe(false);
     expect(result.current.nodeDecorationsRef.current).toBe(nextNodeDecorations);
     expect(result.current.edgeDecorationsRef.current).toBe(nextEdgeDecorations);
-    expect(result.current.timelineActiveRef.current).toBe(true);
+    expect(result.current.timelineActiveRef.current).toBe(false);
   });
 
   it('rebuilds graph data when the memo inputs change and passes forward previous nodes', () => {

--- a/packages/extension/tests/webview/graph/view/sharedPropsOptions.test.ts
+++ b/packages/extension/tests/webview/graph/view/sharedPropsOptions.test.ts
@@ -7,8 +7,9 @@ describe('graph/sharedPropsOptions', () => {
     const interactions = {
       handleBackgroundRightClick: vi.fn(),
       handleLinkRightClick: vi.fn(),
-      handleNodeHover: vi.fn(),
-      handleNodeRightClick: vi.fn(),
+		handleNodeHover: vi.fn(),
+		handleNodeDragEnd: vi.fn(),
+		handleNodeRightClick: vi.fn(),
       interactionHandlers: {
         handleBackgroundClick: vi.fn(),
         handleLinkClick: vi.fn(),
@@ -36,8 +37,9 @@ describe('graph/sharedPropsOptions', () => {
       onEngineStop: handleEngineStop,
       onLinkClick: interactions.interactionHandlers.handleLinkClick,
       onLinkRightClick: interactions.handleLinkRightClick,
-      onNodeClick: interactions.interactionHandlers.handleNodeClick,
-      onNodeHover: interactions.handleNodeHover,
+			onNodeClick: interactions.interactionHandlers.handleNodeClick,
+			onNodeDragEnd: interactions.handleNodeDragEnd,
+			onNodeHover: interactions.handleNodeHover,
       onNodeRightClick: interactions.handleNodeRightClick,
       timelineActive: true,
     });

--- a/packages/extension/tests/webview/graph/viewport/model.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/model.test.tsx
@@ -135,7 +135,7 @@ function createViewState(): Pick<
 	return {
 		dagMode: 'td',
 		favorites: new Set(['src/app.ts']),
-		graphLayout: { pinnedNodes: {}, sections: {}, ownership: {} },
+		graphLayout: { pinnedNodes: {} },
 		graphMode: '2d',
 		physicsSettings,
 		pluginContextMenuItems: [],

--- a/packages/extension/tests/webview/graph/viewport/model.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/model.test.tsx
@@ -52,6 +52,7 @@ function createGraphData(): UseGraphStateResult['graphData'] {
 			color: '#93C5FD',
 			id: 'src/app.ts',
 			isFavorite: false,
+			isPinned: false,
 			label: 'app.ts',
 			size: 12,
 		}],
@@ -115,6 +116,8 @@ function createViewState(): Pick<
 	| 'currentCommitSha'
 	| 'dagMode'
 	| 'favorites'
+	| 'graphLayout'
+	| 'graphMode'
 	| 'physicsSettings'
 	| 'pluginContextMenuItems'
 	| 'setGraphMode'
@@ -132,6 +135,8 @@ function createViewState(): Pick<
 	return {
 		dagMode: 'td',
 		favorites: new Set(['src/app.ts']),
+		graphLayout: { pinnedNodes: {}, sections: {}, ownership: {} },
+		graphMode: '2d',
 		physicsSettings,
 		pluginContextMenuItems: [],
 		setGraphMode: vi.fn(),
@@ -194,6 +199,7 @@ describe('graph/viewport/model', () => {
 			favorites: viewState.favorites,
 			mutationAvailability: 'enabled',
 			nodes: graphData.nodes,
+			pinnedNodeIds: new Set(),
 			pluginItems: [],
 			selection: { kind: 'background', targets: [] },
 			timelineActive: true,

--- a/packages/extension/tests/webview/graph/viewport/shell.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/shell.test.tsx
@@ -195,7 +195,7 @@ function createViewState(): Pick<
 		depthMode: false,
 		directionMode: 'arrows',
 		favorites: new Set(['src/app.ts']),
-		graphLayout: { pinnedNodes: {}, sections: {}, ownership: {} },
+		graphLayout: { pinnedNodes: {} },
 		graphMode: '3d',
 		nodeSizeMode: 'connections',
 		particleSize: 3,

--- a/packages/extension/tests/webview/graph/viewport/shell.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/shell.test.tsx
@@ -39,6 +39,7 @@ function createGraphData(): UseGraphStateResult['graphData'] {
 				color: '#93C5FD',
 				id: 'src/app.ts',
 				isFavorite: false,
+				isPinned: false,
 				label: 'app.ts',
 				size: 12,
 			},
@@ -49,6 +50,7 @@ function createGraphData(): UseGraphStateResult['graphData'] {
 				color: '#67E8F9',
 				id: 'src/lib.ts',
 				isFavorite: false,
+				isPinned: false,
 				label: 'lib.ts',
 				size: 12,
 			},
@@ -176,7 +178,7 @@ function createCallbacks() {
 
 function createViewState(): Pick<
 	GraphViewStoreState,
-	'bidirectionalMode' | 'currentCommitSha' | 'dagMode' | 'depthMode' | 'directionMode' | 'favorites' | 'graphMode' | 'nodeSizeMode' | 'particleSize' | 'particleSpeed' | 'physicsPaused' | 'physicsSettings' | 'pluginContextMenuItems' | 'setGraphMode' | 'showLabels' | 'timelineActive' | 'timelineCommits'
+	'bidirectionalMode' | 'currentCommitSha' | 'dagMode' | 'depthMode' | 'directionMode' | 'favorites' | 'graphLayout' | 'graphMode' | 'nodeSizeMode' | 'particleSize' | 'particleSpeed' | 'physicsPaused' | 'physicsSettings' | 'pluginContextMenuItems' | 'setGraphMode' | 'showLabels' | 'timelineActive' | 'timelineCommits'
 > {
 	const physicsSettings: IPhysicsSettings = {
 		centerForce: 0.1,
@@ -193,6 +195,7 @@ function createViewState(): Pick<
 		depthMode: false,
 		directionMode: 'arrows',
 		favorites: new Set(['src/app.ts']),
+		graphLayout: { pinnedNodes: {}, sections: {}, ownership: {} },
 		graphMode: '3d',
 		nodeSizeMode: 'connections',
 		particleSize: 3,
@@ -240,6 +243,7 @@ describe('graph/viewport/shell', () => {
 				onLinkClick: vi.fn(),
 				onLinkRightClick: vi.fn(),
 				onNodeClick: vi.fn(),
+				onNodeDragEnd: vi.fn(),
 				onNodeHover: vi.fn(),
 				onNodeRightClick: vi.fn(),
 				warmupTicks: 0,

--- a/packages/extension/tests/webview/graph/viewport/tooltip.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/tooltip.test.tsx
@@ -70,6 +70,7 @@ function createSharedProps() {
     onLinkClick: vi.fn(),
     onLinkRightClick: vi.fn(),
     onNodeClick: vi.fn(),
+    onNodeDragEnd: vi.fn(),
     onNodeHover: vi.fn(),
     onNodeRightClick: vi.fn(),
     warmupTicks: 0,

--- a/packages/extension/tests/webview/graph/viewport/view.mutations.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/view.mutations.test.tsx
@@ -64,6 +64,7 @@ function createSharedProps() {
     onLinkClick: vi.fn(),
     onLinkRightClick: vi.fn(),
     onNodeClick: vi.fn(),
+    onNodeDragEnd: vi.fn(),
     onNodeHover: vi.fn(),
     onNodeRightClick: vi.fn(),
     warmupTicks: 0,

--- a/packages/extension/tests/webview/graph/viewport/view.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/view.test.tsx
@@ -84,6 +84,7 @@ function createSharedProps(): GraphSurfaceSharedProps {
     onLinkClick: vi.fn(),
     onLinkRightClick: vi.fn(),
     onNodeClick: vi.fn(),
+    onNodeDragEnd: vi.fn(),
     onNodeHover: vi.fn(),
     onNodeRightClick: vi.fn(),
     warmupTicks: 0,

--- a/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
+++ b/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
@@ -153,8 +153,7 @@ describe('webview/store/messageHandlers/graph', () => {
       pinnedNodes: {
         'src/app.ts': {
           nodeId: 'src/app.ts',
-          twoDimensional: { x: 12, y: 24 },
-          updatedAt: '2026-05-07T08:00:00.000Z',
+          '2D': { x: 12, y: 24 },
         },
       },
     };

--- a/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
+++ b/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
@@ -11,6 +11,7 @@ import {
   handleGraphDataUpdated,
   handleGraphIndexProgress,
   handleGraphIndexStatusUpdated,
+  handleGraphLayoutUpdated,
   handleLegendsUpdated,
   handleMaxFilesUpdated,
   handlePhysicsSettingsUpdated,
@@ -78,6 +79,11 @@ function createState(
     indexProgress: null,
     isPlaying: false,
     playbackSpeed: 1,
+    graphLayout: {
+      pinnedNodes: {},
+      sections: {},
+      ownership: {},
+    },
     ...overrides,
   };
 }
@@ -144,6 +150,22 @@ describe('webview/store/messageHandlers/graph', () => {
       payload: { favorites: ['src/app.ts', 'src/lib.ts'] },
     });
     expect([...favorites.favorites ?? []]).toEqual(['src/app.ts', 'src/lib.ts']);
+
+    const graphLayout = {
+      pinnedNodes: {
+        'src/app.ts': {
+          nodeId: 'src/app.ts',
+          twoDimensional: { x: 12, y: 24 },
+          updatedAt: '2026-05-07T08:00:00.000Z',
+        },
+      },
+      sections: {},
+      ownership: {},
+    };
+    expect(handleGraphLayoutUpdated({
+      type: 'GRAPH_LAYOUT_UPDATED',
+      payload: graphLayout,
+    })).toEqual({ graphLayout });
   });
 
   it('maps settings and filter payloads', () => {

--- a/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
+++ b/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
@@ -81,8 +81,6 @@ function createState(
     playbackSpeed: 1,
     graphLayout: {
       pinnedNodes: {},
-      sections: {},
-      ownership: {},
     },
     ...overrides,
   };
@@ -159,8 +157,6 @@ describe('webview/store/messageHandlers/graph', () => {
           updatedAt: '2026-05-07T08:00:00.000Z',
         },
       },
-      sections: {},
-      ownership: {},
     };
     expect(handleGraphLayoutUpdated({
       type: 'GRAPH_LAYOUT_UPDATED',


### PR DESCRIPTION
## Summary
- Adds persisted normal-node pin locations under graphLayout.pinnedNodes.
- Adds context menu pin/unpin actions and a visible pinned-node badge.
- Keeps this branch independent from graph sections: no sections or ownership settings are introduced here.

## Verification
- pnpm --filter @codegraphy/extension exec vitest run --config vitest.config.ts tests/extension/repoSettings/graphLayout/model.test.ts tests/extension/graphView/webview/dispatch/primary/graphLayout.test.ts tests/webview/graph/model/node/build.test.ts tests/webview/graph/rendering/nodes/canvas2d.test.ts tests/webview/graph/contextActions/effects.test.ts tests/webview/graph/contextMenu/model.test.ts tests/webview/store/messageHandlers/graph.test.ts tests/extension/graphView/graphLayout/message.test.ts tests/extension/repoSettings/store/model/persistedShape.test.ts tests/extension/repoSettings/store/persistence/serialization.test.ts
- pnpm run typecheck
- pnpm run lint

No mutation tests run per request.