### PR TITLE
Add desktop multi-select graph interactions

### DIFF
--- a/.changeset/multi-select-graph-nodes.md
+++ b/.changeset/multi-select-graph-nodes.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy/extension": minor
+---
+
+Add desktop-style multi-node selection with marquee drag, Shift selection extension, viewport panning, and selected group dragging.

--- a/.changeset/multi-select-graph-nodes.md
+++ b/.changeset/multi-select-graph-nodes.md
@@ -2,4 +2,4 @@
 "@codegraphy/extension": minor
 ---
 
-Add desktop-style multi-node selection with marquee drag, Shift selection extension, viewport panning, and selected group dragging.
+Add desktop-style multi-node selection with left-drag marquee selection, Shift selection extension, right-drag viewport panning, and selected group dragging.

--- a/docs/INTERACTIONS.md
+++ b/docs/INTERACTIONS.md
@@ -19,11 +19,12 @@
 
 | Action | Effect |
 |--------|--------|
-| Drag | Pan the view |
+| Left-drag | Box select multiple nodes |
+| Shift + left-drag | Add boxed nodes to the current selection |
+| Right-drag | Pan the view |
 | Scroll | Zoom in/out |
 | Hover cursor | Default cursor |
 | Right-click | Open background context menu |
-| `Shift+Drag` | Box select multiple nodes |
 
 ## Context menu
 

--- a/packages/extension/src/webview/components/graph/interactionRuntime/handlers.ts
+++ b/packages/extension/src/webview/components/graph/interactionRuntime/handlers.ts
@@ -32,6 +32,7 @@ export interface GraphInteractionHandlersDependencies {
   graphMode: '2d' | '3d';
   highlightedNeighborsRef: MutableRefObject<Set<string>>;
   highlightedNodeRef: MutableRefObject<string | null>;
+  isContextMenuSuppressed?(): boolean;
   isMacPlatform: boolean;
   lastClickRef: MutableRefObject<GraphLastClickState | null>;
   lastGraphContextEventRef: MutableRefObject<number>;

--- a/packages/extension/src/webview/components/graph/interactionRuntime/handlers/click.ts
+++ b/packages/extension/src/webview/components/graph/interactionRuntime/handlers/click.ts
@@ -24,11 +24,30 @@ export interface ClickHandlerCallbacks {
   setGraphCursor(this: void, cursor: GraphCursorStyle): void;
 }
 
+function isSuppressedMacControlContextAction(
+  event: MouseEvent,
+  dependencies: GraphInteractionHandlersDependencies,
+): boolean {
+  return dependencies.isMacPlatform
+    && event.ctrlKey
+    && dependencies.isContextMenuSuppressed?.() === true;
+}
+
+function stopSuppressedContextClick(event: MouseEvent): void {
+  event.preventDefault();
+  event.stopPropagation();
+}
+
 export function createClickHandlers(
   dependencies: GraphInteractionHandlersDependencies,
   callbacks: ClickHandlerCallbacks,
 ): ClickHandlers {
   const handleNodeClick = (node: FGNode, event: MouseEvent): void => {
+    if (isSuppressedMacControlContextAction(event, dependencies)) {
+      stopSuppressedContextClick(event);
+      return;
+    }
+
     const command = getNodeClickCommand({
       nodeId: node.id,
       label: node.label,
@@ -61,6 +80,11 @@ export function createClickHandlers(
       return;
     }
 
+    if (isSuppressedMacControlContextAction(event, dependencies)) {
+      stopSuppressedContextClick(event);
+      return;
+    }
+
     callbacks.applyGraphInteractionEffects(
       getBackgroundClickCommand({
         ctrlKey: event.ctrlKey,
@@ -71,6 +95,11 @@ export function createClickHandlers(
   };
 
   const handleLinkClick = (link: FGLink, event: MouseEvent): void => {
+    if (isSuppressedMacControlContextAction(event, dependencies)) {
+      stopSuppressedContextClick(event);
+      return;
+    }
+
     callbacks.applyGraphInteractionEffects(
       getLinkClickCommand({
         ctrlKey: event.ctrlKey,

--- a/packages/extension/src/webview/components/graph/marqueeSelection/model.ts
+++ b/packages/extension/src/webview/components/graph/marqueeSelection/model.ts
@@ -1,0 +1,74 @@
+import type { FGNode } from '../model/build';
+
+export interface MarqueePoint {
+  x: number;
+  y: number;
+}
+
+export interface MarqueeBounds {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface GetMarqueeSelectedNodeIdsOptions {
+  bounds: MarqueeBounds;
+  graphToScreen(this: void, x: number, y: number): MarqueePoint;
+  nodes: readonly FGNode[];
+}
+
+export interface GraphMarqueeSelectionState {
+  bounds: MarqueeBounds;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function getMarqueeBounds(start: MarqueePoint, current: MarqueePoint): MarqueeBounds {
+  const left = Math.min(start.x, current.x);
+  const top = Math.min(start.y, current.y);
+
+  return {
+    left,
+    top,
+    width: Math.abs(current.x - start.x),
+    height: Math.abs(current.y - start.y),
+  };
+}
+
+export function isMarqueePastThreshold(
+  start: MarqueePoint,
+  current: MarqueePoint,
+  thresholdPx: number,
+): boolean {
+  return Math.hypot(current.x - start.x, current.y - start.y) > thresholdPx;
+}
+
+function containsPoint(bounds: MarqueeBounds, point: MarqueePoint): boolean {
+  return point.x >= bounds.left
+    && point.x <= bounds.left + bounds.width
+    && point.y >= bounds.top
+    && point.y <= bounds.top + bounds.height;
+}
+
+export function getMarqueeSelectedNodeIds({
+  bounds,
+  graphToScreen,
+  nodes,
+}: GetMarqueeSelectedNodeIdsOptions): string[] {
+  const selectedNodeIds: string[] = [];
+
+  for (const node of nodes) {
+    if (!isFiniteNumber(node.x) || !isFiniteNumber(node.y)) {
+      continue;
+    }
+
+    if (containsPoint(bounds, graphToScreen(node.x, node.y))) {
+      selectedNodeIds.push(node.id);
+    }
+  }
+
+  return selectedNodeIds;
+}

--- a/packages/extension/src/webview/components/graph/model/build.ts
+++ b/packages/extension/src/webview/components/graph/model/build.ts
@@ -20,6 +20,7 @@ export type FGNode = NodeObject & {
   borderWidth: number;
   baseOpacity: number;
   isFavorite: boolean;
+  isDragging?: boolean;
   nodeType?: NodeType;
   shape2D?: NodeShape2D;
   shape3D?: NodeShape3D;

--- a/packages/extension/src/webview/components/graph/rendering/surface/sharedProps.ts
+++ b/packages/extension/src/webview/components/graph/rendering/surface/sharedProps.ts
@@ -22,6 +22,8 @@ export interface GraphSurfaceSharedProps {
   onLinkClick(this: void, link: LinkObject, event: MouseEvent): void;
   onLinkRightClick(this: void, link: LinkObject, event: MouseEvent): void;
   onNodeClick(this: void, node: NodeObject, event: MouseEvent): void;
+  onNodeDrag?(this: void, node: NodeObject, translate: { x: number; y: number }): void;
+  onNodeDragEnd?(this: void, node: NodeObject): void;
   onNodeHover(this: void, node: NodeObject | null): void;
   onNodeRightClick(this: void, node: NodeObject, event: MouseEvent): void;
   warmupTicks: number;
@@ -38,6 +40,8 @@ export interface BuildSharedGraphPropsOptions {
   onLinkClick(this: void, link: FGLink, event: MouseEvent): void;
   onLinkRightClick(this: void, link: FGLink, event: MouseEvent): void;
   onNodeClick(this: void, node: FGNode, event: MouseEvent): void;
+  onNodeDrag?(this: void, node: FGNode, translate: { x: number; y: number }): void;
+  onNodeDragEnd?(this: void, node: FGNode): void;
   onNodeHover(this: void, node: FGNode | null): void;
   onNodeRightClick(this: void, node: FGNode, event: MouseEvent): void;
   damping: number;
@@ -56,6 +60,17 @@ export function buildSharedGraphProps(
     width: normalizeGraphDimension(options.containerSize.width),
     height: normalizeGraphDimension(options.containerSize.height),
     onNodeClick: (node, event) => options.onNodeClick(node as FGNode, event),
+    ...(options.onNodeDrag
+      ? {
+          onNodeDrag: (node: NodeObject, translate: { x: number; y: number }) =>
+            options.onNodeDrag?.(node as FGNode, translate),
+        }
+      : {}),
+    ...(options.onNodeDragEnd
+      ? {
+          onNodeDragEnd: (node: NodeObject) => options.onNodeDragEnd?.(node as FGNode),
+        }
+      : {}),
     onNodeRightClick: (node, event) => options.onNodeRightClick(node as FGNode, event),
     onLinkClick: (link, event) => options.onLinkClick(link as FGLink, event),
     onLinkRightClick: (link, event) => options.onLinkRightClick(link as FGLink, event),

--- a/packages/extension/src/webview/components/graph/rendering/surface/view/twoDimensional.tsx
+++ b/packages/extension/src/webview/components/graph/rendering/surface/view/twoDimensional.tsx
@@ -81,6 +81,7 @@ export function Surface2d({
       }
       onRenderFramePost={onRenderFramePost}
       autoPauseRedraw={false}
+      enablePanInteraction={false}
     />
   );
 }

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction.ts
@@ -1,7 +1,10 @@
 import {
   useEffect,
   useMemo,
+  useRef,
+  useState,
   type Dispatch,
+  type MouseEvent as ReactMouseEvent,
   type MutableRefObject,
   type SetStateAction,
 } from 'react';
@@ -22,6 +25,13 @@ import {
   type GraphTooltipInteractionDependencies,
 } from './tooltip/hook';
 import type { FGNode } from '../../model/build';
+import {
+  getMarqueeBounds,
+  getMarqueeSelectedNodeIds,
+  isMarqueePastThreshold,
+  type GraphMarqueeSelectionState,
+  type MarqueePoint,
+} from '../../marqueeSelection/model';
 import type { UseGraphStateResult } from './state';
 import type { WebviewPluginHost } from '../../../../pluginHost/manager';
 import { postMessage } from '../../../../vscodeApi';
@@ -72,6 +82,7 @@ export interface UseGraphInteractionRuntimeResult {
   handleNodeRightClick: GraphContextMenuOpeningRuntime['handleNodeRightClick'];
   hoveredNodeRef: MutableRefObject<FGNode | null>;
   interactionHandlers: ReturnType<typeof createGraphInteractionHandlers>;
+  marqueeSelection: GraphMarqueeSelectionState | null;
   setTooltipData: ReturnType<typeof useGraphTooltip>['setTooltipData'];
   stopTooltipTracking: ReturnType<typeof useGraphTooltip>['stopTooltipTracking'];
   tooltipData: ReturnType<typeof useGraphTooltip>['tooltipData'];
@@ -79,6 +90,14 @@ export interface UseGraphInteractionRuntimeResult {
 }
 
 type GraphInteractionHandlersRuntime = ReturnType<typeof createGraphInteractionHandlers>;
+
+const MARQUEE_DRAG_THRESHOLD_PX = 6;
+
+interface MarqueeDragState {
+  current: MarqueePoint;
+  selecting: boolean;
+  start: MarqueePoint;
+}
 
 function buildTooltipInteractionHandlers(
   interactionHandlers: GraphInteractionHandlersRuntime,
@@ -91,6 +110,18 @@ function buildTooltipInteractionHandlers(
 
 function handleGraphEngineStop(): void {
   postMessage({ type: 'PHYSICS_STABILIZED' });
+}
+
+function getLocalMarqueePoint(
+  event: ReactMouseEvent<HTMLDivElement>,
+  container: HTMLDivElement | null,
+): MarqueePoint {
+  const rect = container?.getBoundingClientRect();
+
+  return {
+    x: event.clientX - (rect?.left ?? 0),
+    y: event.clientY - (rect?.top ?? 0),
+  };
 }
 
 export function useGraphInteractionRuntime({
@@ -175,11 +206,83 @@ export function useGraphInteractionRuntime({
     pluginHost,
     postMessage,
   });
+  const marqueeDragRef = useRef<MarqueeDragState | null>(null);
+  const [marqueeSelection, setMarqueeSelection] = useState<GraphMarqueeSelectionState | null>(null);
 
   const actionContext = useMemo(
     () => resolveGraphContextActionContext(graphContextSelection),
     [graphContextSelection],
   );
+
+  function clearMarqueeSelection(): void {
+    marqueeDragRef.current = null;
+    setMarqueeSelection(null);
+  }
+
+  function handleMarqueeMouseDownCapture(event: ReactMouseEvent<HTMLDivElement>): void {
+    if (
+      event.button !== 0
+      || event.shiftKey
+      || graphMode !== '2d'
+      || hoveredNodeRef.current
+    ) {
+      clearMarqueeSelection();
+      return;
+    }
+
+    const point = getLocalMarqueePoint(event, refs.containerRef.current);
+    marqueeDragRef.current = {
+      current: point,
+      selecting: false,
+      start: point,
+    };
+  }
+
+  function handleMarqueeMouseMoveCapture(event: ReactMouseEvent<HTMLDivElement>): void {
+    const drag = marqueeDragRef.current;
+    if (!drag) {
+      return;
+    }
+
+    const current = getLocalMarqueePoint(event, refs.containerRef.current);
+    drag.current = current;
+
+    if (!drag.selecting) {
+      drag.selecting = isMarqueePastThreshold(
+        drag.start,
+        current,
+        MARQUEE_DRAG_THRESHOLD_PX,
+      );
+    }
+
+    if (drag.selecting) {
+      event.preventDefault();
+      setMarqueeSelection({ bounds: getMarqueeBounds(drag.start, current) });
+    }
+  }
+
+  function handleMarqueeMouseUpCapture(event: ReactMouseEvent<HTMLDivElement>): void {
+    if (event.button !== 0) {
+      return;
+    }
+
+    const drag = marqueeDragRef.current;
+    clearMarqueeSelection();
+
+    if (!drag?.selecting) {
+      return;
+    }
+
+    event.preventDefault();
+    const graph = refs.fg2dRef.current;
+    const selectedNodeIds = getMarqueeSelectedNodeIds({
+      bounds: getMarqueeBounds(drag.start, drag.current),
+      graphToScreen: (x, y) => graph?.graph2ScreenCoords?.(x, y) ?? { x, y },
+      nodes: graphDataRef.current.nodes,
+    });
+    interactionHandlers.setHighlight(null);
+    interactionHandlers.setSelection(selectedNodeIds);
+  }
 
   const contextMenuOpeningRuntime = useMemo(
     () => createGraphContextMenuOpeningRuntime({
@@ -230,13 +333,37 @@ export function useGraphInteractionRuntime({
     [contextMenuOpeningRuntime.contextMenuRuntime],
   );
 
+  function handleMouseDownCapture(event: ReactMouseEvent<HTMLDivElement>): void {
+    handleMarqueeMouseDownCapture(event);
+    contextMenuOpeningRuntime.handleMouseDownCapture(event);
+  }
+
+  function handleMouseMoveCapture(event: ReactMouseEvent<HTMLDivElement>): void {
+    handleMarqueeMouseMoveCapture(event);
+    contextMenuOpeningRuntime.handleMouseMoveCapture(event);
+  }
+
+  function handleMouseUpCapture(event: ReactMouseEvent<HTMLDivElement>): void {
+    handleMarqueeMouseUpCapture(event);
+    contextMenuOpeningRuntime.handleMouseUpCapture(event);
+  }
+
+  function handleGraphMouseLeave(): void {
+    clearMarqueeSelection();
+    handleMouseLeave();
+  }
+
   return {
     ...contextMenuOpeningRuntime,
     handleEngineStop: handleGraphEngineStop,
-    handleMouseLeave,
+    handleMouseLeave: handleGraphMouseLeave,
     handleNodeHover,
+    handleMouseDownCapture,
+    handleMouseMoveCapture,
+    handleMouseUpCapture,
     hoveredNodeRef,
     interactionHandlers,
+    marqueeSelection,
     setTooltipData,
     stopTooltipTracking,
     tooltipData,

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction.ts
@@ -26,6 +26,17 @@ import {
 } from './tooltip/hook';
 import type { FGNode } from '../../model/build';
 import {
+  createSuppressedContextMenuHandlers,
+  useContextMenuSuppression,
+} from './interaction/contextSuppression';
+import {
+  applyNodeDrag,
+  releaseDraggedNodes,
+  type NodeDragGroupSession,
+  type NodeDragTranslate,
+} from './interaction/nodeDrag';
+import { useGraphViewportPanRuntime } from './interaction/viewportPan/hook';
+import {
   getMarqueeBounds,
   getMarqueeSelectedNodeIds,
   isMarqueePastThreshold,
@@ -78,6 +89,8 @@ export interface UseGraphInteractionRuntimeResult {
   handleMouseLeave(this: void): void;
   handleMouseMoveCapture: GraphContextMenuOpeningRuntime['handleMouseMoveCapture'];
   handleMouseUpCapture: GraphContextMenuOpeningRuntime['handleMouseUpCapture'];
+  handleNodeDrag(this: void, node: FGNode, translate: NodeDragTranslate): void;
+  handleNodeDragEnd(this: void, node: FGNode): void;
   handleNodeHover(this: void, node: FGNode | null): void;
   handleNodeRightClick: GraphContextMenuOpeningRuntime['handleNodeRightClick'];
   hoveredNodeRef: MutableRefObject<FGNode | null>;
@@ -94,6 +107,7 @@ type GraphInteractionHandlersRuntime = ReturnType<typeof createGraphInteractionH
 const MARQUEE_DRAG_THRESHOLD_PX = 6;
 
 interface MarqueeDragState {
+  additive: boolean;
   current: MarqueePoint;
   selecting: boolean;
   start: MarqueePoint;
@@ -146,6 +160,7 @@ export function useGraphInteractionRuntime({
   setHighlightVersion,
   setSelectedNodes,
 }: UseGraphInteractionRuntimeOptions): UseGraphInteractionRuntimeResult {
+  const nodeDragGroupRef = useRef<NodeDragGroupSession | null>(null);
   const interactionHandlers = useMemo(
     () => createGraphInteractionHandlers({
       containerRef: refs.containerRef,
@@ -206,6 +221,14 @@ export function useGraphInteractionRuntime({
     pluginHost,
     postMessage,
   });
+  const contextMenuSuppression = useContextMenuSuppression();
+  const viewportPanRuntime = useGraphViewportPanRuntime({
+    containerRef: refs.containerRef,
+    fg2dRef: refs.fg2dRef,
+    graphMode,
+    rightMouseDownRef: refs.rightMouseDownRef,
+    suppressContextMenu: contextMenuSuppression.suppressContextMenu,
+  });
   const marqueeDragRef = useRef<MarqueeDragState | null>(null);
   const [marqueeSelection, setMarqueeSelection] = useState<GraphMarqueeSelectionState | null>(null);
 
@@ -222,7 +245,7 @@ export function useGraphInteractionRuntime({
   function handleMarqueeMouseDownCapture(event: ReactMouseEvent<HTMLDivElement>): void {
     if (
       event.button !== 0
-      || event.shiftKey
+      || event.ctrlKey
       || graphMode !== '2d'
       || hoveredNodeRef.current
     ) {
@@ -232,6 +255,7 @@ export function useGraphInteractionRuntime({
 
     const point = getLocalMarqueePoint(event, refs.containerRef.current);
     marqueeDragRef.current = {
+      additive: event.shiftKey,
       current: point,
       selecting: false,
       start: point,
@@ -280,8 +304,28 @@ export function useGraphInteractionRuntime({
       graphToScreen: (x, y) => graph?.graph2ScreenCoords?.(x, y) ?? { x, y },
       nodes: graphDataRef.current.nodes,
     });
+    const nextSelectedNodeIds = drag.additive
+      ? [...new Set([...refs.selectedNodesSetRef.current, ...selectedNodeIds])]
+      : selectedNodeIds;
     interactionHandlers.setHighlight(null);
-    interactionHandlers.setSelection(selectedNodeIds);
+    interactionHandlers.setSelection(nextSelectedNodeIds);
+  }
+
+  function handleNodeDrag(node: FGNode, translate: NodeDragTranslate): void {
+    nodeDragGroupRef.current = applyNodeDrag(node, translate, {
+      graphData: graphDataRef.current,
+      graphMode,
+      selectedNodeIds: refs.selectedNodesSetRef.current,
+    }, nodeDragGroupRef.current);
+    clearMarqueeSelection();
+  }
+
+  function handleNodeDragEnd(node: FGNode): void {
+    releaseDraggedNodes(node, nodeDragGroupRef.current, {
+      graphData: graphDataRef.current,
+      graphMode,
+    });
+    nodeDragGroupRef.current = null;
   }
 
   const contextMenuOpeningRuntime = useMemo(
@@ -316,6 +360,13 @@ export function useGraphInteractionRuntime({
       tooltipTimeoutRef,
     ],
   );
+  const suppressedContextMenuHandlers = useMemo(
+    () => createSuppressedContextMenuHandlers(
+      contextMenuOpeningRuntime,
+      contextMenuSuppression,
+    ),
+    [contextMenuOpeningRuntime, contextMenuSuppression],
+  );
 
   useEffect(() => {
     const frame = requestAnimationFrame(() => {
@@ -334,16 +385,19 @@ export function useGraphInteractionRuntime({
   );
 
   function handleMouseDownCapture(event: ReactMouseEvent<HTMLDivElement>): void {
+    viewportPanRuntime.handleMouseDownCapture(event);
     handleMarqueeMouseDownCapture(event);
     contextMenuOpeningRuntime.handleMouseDownCapture(event);
   }
 
   function handleMouseMoveCapture(event: ReactMouseEvent<HTMLDivElement>): void {
+    viewportPanRuntime.handleMouseMoveCapture(event);
     handleMarqueeMouseMoveCapture(event);
     contextMenuOpeningRuntime.handleMouseMoveCapture(event);
   }
 
   function handleMouseUpCapture(event: ReactMouseEvent<HTMLDivElement>): void {
+    viewportPanRuntime.handleMouseUpCapture(event);
     handleMarqueeMouseUpCapture(event);
     contextMenuOpeningRuntime.handleMouseUpCapture(event);
   }
@@ -355,9 +409,15 @@ export function useGraphInteractionRuntime({
 
   return {
     ...contextMenuOpeningRuntime,
+    handleBackgroundRightClick: suppressedContextMenuHandlers.handleBackgroundRightClick,
+    handleContextMenu: suppressedContextMenuHandlers.handleContextMenu,
     handleEngineStop: handleGraphEngineStop,
+    handleLinkRightClick: suppressedContextMenuHandlers.handleLinkRightClick,
     handleMouseLeave: handleGraphMouseLeave,
+    handleNodeDrag,
+    handleNodeDragEnd,
     handleNodeHover,
+    handleNodeRightClick: suppressedContextMenuHandlers.handleNodeRightClick,
     handleMouseDownCapture,
     handleMouseMoveCapture,
     handleMouseUpCapture,

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction.ts
@@ -161,6 +161,7 @@ export function useGraphInteractionRuntime({
   setSelectedNodes,
 }: UseGraphInteractionRuntimeOptions): UseGraphInteractionRuntimeResult {
   const nodeDragGroupRef = useRef<NodeDragGroupSession | null>(null);
+  const contextMenuSuppression = useContextMenuSuppression();
   const interactionHandlers = useMemo(
     () => createGraphInteractionHandlers({
       containerRef: refs.containerRef,
@@ -174,6 +175,7 @@ export function useGraphInteractionRuntime({
       graphMode,
       highlightedNeighborsRef,
       highlightedNodeRef,
+      isContextMenuSuppressed: contextMenuSuppression.isContextMenuSuppressed,
       isMacPlatform,
       lastClickRef,
       lastGraphContextEventRef,
@@ -191,6 +193,7 @@ export function useGraphInteractionRuntime({
       graphMode,
       highlightedNeighborsRef,
       highlightedNodeRef,
+      contextMenuSuppression.isContextMenuSuppressed,
       isMacPlatform,
       lastClickRef,
       lastGraphContextEventRef,
@@ -221,7 +224,6 @@ export function useGraphInteractionRuntime({
     pluginHost,
     postMessage,
   });
-  const contextMenuSuppression = useContextMenuSuppression();
   const viewportPanRuntime = useGraphViewportPanRuntime({
     containerRef: refs.containerRef,
     fg2dRef: refs.fg2dRef,

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/contextSuppression.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/contextSuppression.ts
@@ -1,0 +1,110 @@
+import {
+  useMemo,
+  useRef,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
+import type { GraphContextMenuOpeningRuntime } from '../../../contextMenuOpening/runtime';
+import type { FGLink, FGNode } from '../../../model/build';
+
+const CONTEXT_MENU_SUPPRESSION_MS = 250;
+
+interface ContextMenuSuppressionRuntime {
+  isContextMenuSuppressed(this: void): boolean;
+  suppressContextMenu(this: void): void;
+}
+
+export interface SuppressedContextMenuHandlers {
+  handleBackgroundRightClick: GraphContextMenuOpeningRuntime['handleBackgroundRightClick'];
+  handleContextMenu(this: void, event?: ReactMouseEvent<HTMLDivElement>): void;
+  handleLinkRightClick: GraphContextMenuOpeningRuntime['handleLinkRightClick'];
+  handleNodeRightClick: GraphContextMenuOpeningRuntime['handleNodeRightClick'];
+}
+
+export function useContextMenuSuppression(): ContextMenuSuppressionRuntime {
+  const contextMenuSuppressedUntilRef = useRef(0);
+
+  return useMemo(() => ({
+    isContextMenuSuppressed: () => Date.now() < contextMenuSuppressedUntilRef.current,
+    suppressContextMenu: () => {
+      contextMenuSuppressedUntilRef.current = Date.now() + CONTEXT_MENU_SUPPRESSION_MS;
+    },
+  }), []);
+}
+
+function callContextMenuUnlessSuppressed(
+  contextMenuOpeningRuntime: GraphContextMenuOpeningRuntime,
+  isContextMenuSuppressed: () => boolean,
+  event?: ReactMouseEvent<HTMLDivElement>,
+): void {
+  if (isContextMenuSuppressed()) {
+    event?.preventDefault();
+    event?.stopPropagation();
+    return;
+  }
+
+  contextMenuOpeningRuntime.handleContextMenu();
+}
+
+function callBackgroundRightClickUnlessSuppressed(
+  contextMenuOpeningRuntime: GraphContextMenuOpeningRuntime,
+  isContextMenuSuppressed: () => boolean,
+  event: MouseEvent,
+): void {
+  if (!isContextMenuSuppressed()) {
+    contextMenuOpeningRuntime.handleBackgroundRightClick(event);
+  }
+}
+
+function callLinkRightClickUnlessSuppressed(
+  contextMenuOpeningRuntime: GraphContextMenuOpeningRuntime,
+  isContextMenuSuppressed: () => boolean,
+  link: FGLink,
+  event: MouseEvent,
+): void {
+  if (!isContextMenuSuppressed()) {
+    contextMenuOpeningRuntime.handleLinkRightClick(link, event);
+  }
+}
+
+function callNodeRightClickUnlessSuppressed(
+  contextMenuOpeningRuntime: GraphContextMenuOpeningRuntime,
+  isContextMenuSuppressed: () => boolean,
+  node: FGNode,
+  event: MouseEvent,
+): void {
+  if (!isContextMenuSuppressed()) {
+    contextMenuOpeningRuntime.handleNodeRightClick(node, event);
+  }
+}
+
+export function createSuppressedContextMenuHandlers(
+  contextMenuOpeningRuntime: GraphContextMenuOpeningRuntime,
+  contextMenuSuppression: Pick<ContextMenuSuppressionRuntime, 'isContextMenuSuppressed'>,
+): SuppressedContextMenuHandlers {
+  const { isContextMenuSuppressed } = contextMenuSuppression;
+
+  return {
+    handleBackgroundRightClick: (event) => callBackgroundRightClickUnlessSuppressed(
+      contextMenuOpeningRuntime,
+      isContextMenuSuppressed,
+      event,
+    ),
+    handleContextMenu: (event) => callContextMenuUnlessSuppressed(
+      contextMenuOpeningRuntime,
+      isContextMenuSuppressed,
+      event,
+    ),
+    handleLinkRightClick: (link, event) => callLinkRightClickUnlessSuppressed(
+      contextMenuOpeningRuntime,
+      isContextMenuSuppressed,
+      link,
+      event,
+    ),
+    handleNodeRightClick: (node, event) => callNodeRightClickUnlessSuppressed(
+      contextMenuOpeningRuntime,
+      isContextMenuSuppressed,
+      node,
+      event,
+    ),
+  };
+}

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/nodeDrag.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/nodeDrag.ts
@@ -1,0 +1,154 @@
+import type { FGNode } from '../../../model/build';
+
+export interface NodeDragTranslate {
+  x: number;
+  y: number;
+}
+
+export interface NodeDragGroupSession {
+  draggedNodeIds: Set<string>;
+  primaryNodeId: string;
+}
+
+type GraphMode = '2d' | '3d';
+
+interface NodeDragGraphData {
+  nodes: readonly FGNode[];
+}
+
+interface ApplyNodeDragOptions {
+  graphData: NodeDragGraphData;
+  graphMode: GraphMode;
+  selectedNodeIds: ReadonlySet<string>;
+}
+
+interface NodeDragReleaseOptions {
+  graphData: NodeDragGraphData;
+  graphMode: GraphMode;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isFiniteTranslate(translate: NodeDragTranslate): boolean {
+  return isFiniteNumber(translate.x) && isFiniteNumber(translate.y);
+}
+
+function createNodeMap(nodes: readonly FGNode[]): Map<string, FGNode> {
+  return new Map(nodes.map(node => [node.id, node]));
+}
+
+export function markNodeDragging(node: FGNode): void {
+  node.isDragging = true;
+}
+
+function releaseNodeDrag(node: FGNode, graphMode: GraphMode): void {
+  node.isDragging = false;
+
+  node.fx = undefined;
+  node.fy = undefined;
+  if (graphMode === '3d') {
+    node.fz = undefined;
+  }
+}
+
+function moveNodeByTranslate(node: FGNode, translate: NodeDragTranslate): void {
+  if (!isFiniteTranslate(translate)) {
+    return;
+  }
+
+  const x = (isFiniteNumber(node.x) ? node.x : 0) + translate.x;
+  const y = (isFiniteNumber(node.y) ? node.y : 0) + translate.y;
+  node.x = x;
+  node.y = y;
+  node.fx = x;
+  node.fy = y;
+  node.vx = 0;
+  node.vy = 0;
+}
+
+function createDragGroupSession(
+  primaryNode: FGNode,
+  options: ApplyNodeDragOptions,
+): NodeDragGroupSession | null {
+  if (
+    options.graphMode !== '2d'
+    || !options.selectedNodeIds.has(primaryNode.id)
+    || options.selectedNodeIds.size < 2
+  ) {
+    return null;
+  }
+
+  const nodesById = createNodeMap(options.graphData.nodes);
+  const draggedNodeIds = new Set<string>();
+  for (const nodeId of options.selectedNodeIds) {
+    if (nodesById.has(nodeId)) {
+      draggedNodeIds.add(nodeId);
+    }
+  }
+
+  return draggedNodeIds.size > 1
+    ? { draggedNodeIds, primaryNodeId: primaryNode.id }
+    : null;
+}
+
+export function applyNodeDrag(
+  primaryNode: FGNode,
+  translate: NodeDragTranslate,
+  options: ApplyNodeDragOptions,
+  session: NodeDragGroupSession | null = null,
+): NodeDragGroupSession | null {
+  markNodeDragging(primaryNode);
+
+  const nextSession = session ?? createDragGroupSession(primaryNode, options);
+  if (!nextSession || !isFiniteTranslate(translate)) {
+    return nextSession;
+  }
+
+  const nodesById = createNodeMap(options.graphData.nodes);
+  for (const nodeId of nextSession.draggedNodeIds) {
+    const node = nodesById.get(nodeId);
+    if (!node) {
+      continue;
+    }
+
+    markNodeDragging(node);
+    if (node.id !== primaryNode.id) {
+      moveNodeByTranslate(node, translate);
+    }
+  }
+
+  return nextSession;
+}
+
+function getDragEndNodes(
+  primaryNode: FGNode,
+  session: NodeDragGroupSession | null,
+  graphData: NodeDragGraphData,
+): FGNode[] {
+  if (!session) {
+    return [primaryNode];
+  }
+
+  const nodesById = createNodeMap(graphData.nodes);
+  const nodes: FGNode[] = [];
+  for (const nodeId of session.draggedNodeIds) {
+    const node = nodeId === primaryNode.id ? primaryNode : nodesById.get(nodeId);
+    if (node) {
+      nodes.push(node);
+    }
+  }
+
+  return nodes;
+}
+
+export function releaseDraggedNodes(
+  primaryNode: FGNode,
+  session: NodeDragGroupSession | null,
+  options: NodeDragReleaseOptions,
+): void {
+  for (const node of getDragEndNodes(primaryNode, session, options.graphData)) {
+    releaseNodeDrag(node, options.graphMode);
+  }
+}

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/positions.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/positions.ts
@@ -1,0 +1,3 @@
+export function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/coordinates.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/coordinates.ts
@@ -1,0 +1,36 @@
+import type { MarqueePoint } from '../../../../marqueeSelection/model';
+import type { UseGraphStateResult } from '../../state';
+import { isFiniteNumber } from '../positions';
+import type { ViewportPanDragState } from './state';
+
+export function readViewportPanCenter(
+  graph: UseGraphStateResult['fg2dRef']['current'],
+  container: HTMLDivElement | null,
+): { x: number; y: number } {
+  const rect = container?.getBoundingClientRect();
+  const center = rect
+    ? graph?.screen2GraphCoords?.(rect.width / 2, rect.height / 2)
+    : undefined;
+  return isFiniteNumber(center?.x) && isFiniteNumber(center?.y)
+    ? center
+    : { x: 0, y: 0 };
+}
+
+export function readViewportPanZoom(
+  graph: UseGraphStateResult['fg2dRef']['current'],
+): number {
+  const zoom = graph?.zoom?.();
+  return isFiniteNumber(zoom) && zoom !== 0 ? zoom : 1;
+}
+
+export function applyViewportPanDrag(
+  drag: ViewportPanDragState,
+  current: MarqueePoint,
+  graph: UseGraphStateResult['fg2dRef']['current'],
+): void {
+  graph?.centerAt?.(
+    drag.center.x - ((current.x - drag.start.x) / drag.zoom),
+    drag.center.y - ((current.y - drag.start.y) / drag.zoom),
+    0,
+  );
+}

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/hook.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/hook.ts
@@ -1,0 +1,100 @@
+import {
+  useRef,
+  type MouseEvent as ReactMouseEvent,
+  type MutableRefObject,
+} from 'react';
+import type { MarqueePoint } from '../../../../marqueeSelection/model';
+import { applyViewportPanDrag } from './coordinates';
+import {
+  canStartViewportPanDrag,
+  clearViewportPanDrag,
+  createViewportPanDragState,
+  type GraphViewportPanRuntime,
+  type GraphViewportPanRuntimeOptions,
+  updateViewportPanDragState,
+  type ViewportPanDragState,
+} from './state';
+
+function startViewportPanDrag(
+  event: ReactMouseEvent<HTMLDivElement>,
+  options: GraphViewportPanRuntimeOptions,
+  panDragRef: MutableRefObject<ViewportPanDragState | null>,
+): void {
+  if (!canStartViewportPanDrag(event, options)) {
+    clearViewportPanDrag(panDragRef);
+    return;
+  }
+
+  event.preventDefault();
+  panDragRef.current = createViewportPanDragState(
+    event,
+    options.fg2dRef.current,
+    options.containerRef.current,
+  );
+}
+
+function markRightClickPanMoved(options: GraphViewportPanRuntimeOptions): void {
+  if (options.rightMouseDownRef.current) {
+    options.rightMouseDownRef.current.moved = true;
+  }
+}
+
+function applyViewportPanAfterThreshold(
+  drag: ViewportPanDragState,
+  current: MarqueePoint,
+  event: ReactMouseEvent<HTMLDivElement>,
+  options: GraphViewportPanRuntimeOptions,
+): void {
+  event.preventDefault();
+  if (drag.suppressContextMenu) {
+    options.suppressContextMenu();
+  }
+  if (drag.button === 2) {
+    markRightClickPanMoved(options);
+  }
+  applyViewportPanDrag(drag, current, options.fg2dRef.current);
+}
+
+function moveViewportPanDrag(
+  event: ReactMouseEvent<HTMLDivElement>,
+  options: GraphViewportPanRuntimeOptions,
+  panDragRef: MutableRefObject<ViewportPanDragState | null>,
+): void {
+  const drag = panDragRef.current;
+  if (!drag) {
+    return;
+  }
+
+  const current = { x: event.clientX, y: event.clientY };
+  updateViewportPanDragState(drag, current);
+  if (drag.moved) {
+    applyViewportPanAfterThreshold(drag, current, event, options);
+  }
+}
+
+function stopViewportPanDrag(
+  event: ReactMouseEvent<HTMLDivElement>,
+  panDragRef: MutableRefObject<ViewportPanDragState | null>,
+): void {
+  const drag = panDragRef.current;
+  if (!drag || event.button !== drag.button) {
+    return;
+  }
+
+  if (drag.moved) {
+    event.preventDefault();
+  }
+  clearViewportPanDrag(panDragRef);
+}
+
+export function useGraphViewportPanRuntime(
+  options: GraphViewportPanRuntimeOptions,
+): GraphViewportPanRuntime {
+  const panDragRef = useRef<ViewportPanDragState | null>(null);
+
+  return {
+    handleMouseDownCapture: (event) => startViewportPanDrag(event, options, panDragRef),
+    handleMouseMoveCapture: (event) => moveViewportPanDrag(event, options, panDragRef),
+    handleMouseUpCapture: (event) => stopViewportPanDrag(event, panDragRef),
+  };
+}

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/state.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/state.ts
@@ -1,0 +1,87 @@
+import type {
+  MouseEvent as ReactMouseEvent,
+  MutableRefObject,
+} from 'react';
+import {
+  isMarqueePastThreshold,
+  type MarqueePoint,
+} from '../../../../marqueeSelection/model';
+import type { UseGraphStateResult } from '../../state';
+import {
+  readViewportPanCenter,
+  readViewportPanZoom,
+} from './coordinates';
+
+type GraphMode = '2d' | '3d';
+
+export const VIEWPORT_PAN_DRAG_THRESHOLD_PX = 2;
+
+export interface ViewportPanDragState {
+  button: number;
+  center: { x: number; y: number };
+  moved: boolean;
+  start: MarqueePoint;
+  suppressContextMenu: boolean;
+  zoom: number;
+}
+
+export interface GraphViewportPanRuntimeOptions {
+  containerRef: UseGraphStateResult['containerRef'];
+  fg2dRef: UseGraphStateResult['fg2dRef'];
+  graphMode: GraphMode;
+  rightMouseDownRef: UseGraphStateResult['rightMouseDownRef'];
+  suppressContextMenu(this: void): void;
+}
+
+export interface GraphViewportPanRuntime {
+  handleMouseDownCapture(this: void, event: ReactMouseEvent<HTMLDivElement>): void;
+  handleMouseMoveCapture(this: void, event: ReactMouseEvent<HTMLDivElement>): void;
+  handleMouseUpCapture(this: void, event: ReactMouseEvent<HTMLDivElement>): void;
+}
+
+function isViewportPanButton(event: ReactMouseEvent<HTMLDivElement>): boolean {
+  return event.button === 1
+    || event.button === 2
+    || (event.button === 0 && event.ctrlKey);
+}
+
+export function createViewportPanDragState(
+  event: ReactMouseEvent<HTMLDivElement>,
+  graph: UseGraphStateResult['fg2dRef']['current'],
+  container: HTMLDivElement | null,
+): ViewportPanDragState {
+  return {
+    button: event.button,
+    center: readViewportPanCenter(graph, container),
+    moved: false,
+    start: { x: event.clientX, y: event.clientY },
+    suppressContextMenu: event.button === 2 || (event.button === 0 && event.ctrlKey),
+    zoom: readViewportPanZoom(graph),
+  };
+}
+
+export function updateViewportPanDragState(
+  drag: ViewportPanDragState,
+  current: MarqueePoint,
+): void {
+  if (!drag.moved) {
+    drag.moved = isMarqueePastThreshold(
+      drag.start,
+      current,
+      VIEWPORT_PAN_DRAG_THRESHOLD_PX,
+    );
+  }
+}
+
+export function clearViewportPanDrag(
+  panDragRef: MutableRefObject<ViewportPanDragState | null>,
+): void {
+  panDragRef.current = null;
+}
+
+export function canStartViewportPanDrag(
+  event: ReactMouseEvent<HTMLDivElement>,
+  options: GraphViewportPanRuntimeOptions,
+): boolean {
+  return options.graphMode === '2d' && isViewportPanButton(event);
+}

--- a/packages/extension/src/webview/components/graph/view/sharedPropsOptions.ts
+++ b/packages/extension/src/webview/components/graph/view/sharedPropsOptions.ts
@@ -31,6 +31,8 @@ export function buildGraphSharedPropsOptions({
     onLinkClick: interactions.interactionHandlers.handleLinkClick,
     onLinkRightClick: interactions.handleLinkRightClick,
     onNodeClick: interactions.interactionHandlers.handleNodeClick,
+    onNodeDrag: interactions.handleNodeDrag,
+    onNodeDragEnd: interactions.handleNodeDragEnd,
     onNodeHover: interactions.handleNodeHover,
     onNodeRightClick: interactions.handleNodeRightClick,
     timelineActive,

--- a/packages/extension/src/webview/components/graph/viewport/shell.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/shell.tsx
@@ -154,6 +154,7 @@ export function GraphViewportShell({
       handleMouseMoveCapture={interactions.handleMouseMoveCapture}
       handleMouseUpCapture={interactions.handleMouseUpCapture}
       menuEntries={viewportModel.menuEntries}
+      marqueeSelection={interactions.marqueeSelection}
       surface2dProps={{
         fg2dRef: graphState.fg2dRef,
         getArrowColor: callbacks.getArrowColor,

--- a/packages/extension/src/webview/components/graph/viewport/view.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/view.tsx
@@ -127,7 +127,7 @@ export function Viewport({
           {marqueeSelection ? (
             <div
               data-testid="graph-marquee-selection"
-              className="pointer-events-none absolute z-20 rounded-sm border border-dashed border-[var(--vscode-focusBorder)] bg-[rgba(59,130,246,0.14)]"
+              className="pointer-events-none absolute z-20 rounded-sm border border-dashed border-[var(--cg-focus-border)] bg-[var(--cg-graph-marquee-background)]"
               style={{
                 left: marqueeSelection.bounds.left,
                 top: marqueeSelection.bounds.top,

--- a/packages/extension/src/webview/components/graph/viewport/view.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/view.tsx
@@ -1,5 +1,6 @@
 import type { MouseEvent as ReactMouseEvent, ReactElement, Ref } from 'react';
 import type { DirectionMode } from '../../../../shared/settings/modes';
+import type { GraphMarqueeSelectionState } from '../marqueeSelection/model';
 import type { GraphTooltipState } from '../tooltip/model';
 import {
   ContextMenu,
@@ -39,6 +40,7 @@ export interface ViewportProps {
   handleMouseLeave: (this: void) => void;
   handleMouseMoveCapture: (this: void, event: ReactMouseEvent<HTMLDivElement>) => void;
   handleMouseUpCapture: (this: void, event: ReactMouseEvent<HTMLDivElement>) => void;
+  marqueeSelection?: GraphMarqueeSelectionState | null;
   menuEntries: GraphContextMenuEntry[];
   surface2dProps: Omit<Surface2dProps, 'backgroundColor' | 'directionMode'>;
   surface3dProps: Omit<Surface3dProps, 'backgroundColor' | 'directionMode'>;
@@ -60,6 +62,7 @@ export function Viewport({
   handleMouseLeave,
   handleMouseMoveCapture,
   handleMouseUpCapture,
+  marqueeSelection,
   menuEntries,
   surface2dProps,
   surface3dProps,
@@ -119,6 +122,18 @@ export function Viewport({
               slot="graph-overlay"
               data-testid="graph-overlay-slot"
               className="absolute inset-0 z-10 pointer-events-none"
+            />
+          ) : null}
+          {marqueeSelection ? (
+            <div
+              data-testid="graph-marquee-selection"
+              className="pointer-events-none absolute z-20 rounded-sm border border-dashed border-[var(--vscode-focusBorder)] bg-[rgba(59,130,246,0.14)]"
+              style={{
+                left: marqueeSelection.bounds.left,
+                top: marqueeSelection.bounds.top,
+                width: marqueeSelection.bounds.width,
+                height: marqueeSelection.bounds.height,
+              }}
             />
           ) : null}
         </div>

--- a/packages/extension/src/webview/index.css
+++ b/packages/extension/src/webview/index.css
@@ -78,6 +78,7 @@
     --cg-graph-link-highlight: var(--cg-primary);
     --cg-graph-link-muted: var(--vscode-disabledForeground, GrayText);
     --cg-graph-node-selection-border: var(--vscode-contrastActiveBorder, var(--cg-focus-border));
+    --cg-graph-marquee-background: color-mix(in srgb, var(--cg-primary) 14%, transparent);
     --cg-graph-mesh-dimmed: var(--vscode-disabledForeground, GrayText);
     --cg-graph-mesh-selected: var(--vscode-foreground, CanvasText);
     --cg-menu-background: var(--vscode-menu-background, var(--cg-popover));

--- a/packages/extension/tests/webview/graph/interactionRuntime/handlers/click.test.ts
+++ b/packages/extension/tests/webview/graph/interactionRuntime/handlers/click.test.ts
@@ -114,6 +114,32 @@ describe('graph/interactionRuntime/click', () => {
     expect(applyGraphInteractionEffects).toHaveBeenCalledWith(effects, { event });
   });
 
+  it('ignores mac ctrl-background-click while context menus are suppressed after a pan drag', () => {
+    const dependencies = createInteractionDependencies({
+      isContextMenuSuppressed: () => true,
+      isMacPlatform: true,
+    });
+    const applyGraphInteractionEffects = vi.fn();
+    const setGraphCursor = vi.fn();
+    const event = {
+      ctrlKey: true,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as MouseEvent;
+    const handlers = createClickHandlers(dependencies, {
+      applyGraphInteractionEffects,
+      setGraphCursor,
+    });
+
+    handlers.handleBackgroundClick(event);
+
+    expect(setGraphCursor).toHaveBeenCalledWith('default');
+    expect(interactionHarness.getBackgroundClickCommand).not.toHaveBeenCalled();
+    expect(applyGraphInteractionEffects).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
   it('handles link clicks through the interaction model with the clicked link and event', () => {
     const dependencies = createInteractionDependencies({ isMacPlatform: true });
     const applyGraphInteractionEffects = vi.fn();
@@ -137,5 +163,62 @@ describe('graph/interactionRuntime/click', () => {
       isMacPlatform: true,
     });
     expect(applyGraphInteractionEffects).toHaveBeenCalledWith(effects, { event, link });
+  });
+
+  it('ignores mac ctrl-node-click while context menus are suppressed after a pan drag', () => {
+    const dependencies = createInteractionDependencies({
+      isContextMenuSuppressed: () => true,
+      isMacPlatform: true,
+    });
+    const applyGraphInteractionEffects = vi.fn();
+    const event = {
+      clientX: 100,
+      clientY: 200,
+      ctrlKey: true,
+      metaKey: false,
+      preventDefault: vi.fn(),
+      shiftKey: false,
+      stopPropagation: vi.fn(),
+    } as unknown as MouseEvent;
+    const handlers = createClickHandlers(dependencies, {
+      applyGraphInteractionEffects,
+      setGraphCursor: vi.fn(),
+    });
+
+    handlers.handleNodeClick({ id: 'src/app.ts', label: 'app.ts' } as FGNode, event);
+
+    expect(interactionHarness.getNodeClickCommand).not.toHaveBeenCalled();
+    expect(applyGraphInteractionEffects).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores mac ctrl-link-click while context menus are suppressed after a pan drag', () => {
+    const dependencies = createInteractionDependencies({
+      isContextMenuSuppressed: () => true,
+      isMacPlatform: true,
+    });
+    const applyGraphInteractionEffects = vi.fn();
+    const link = {
+      id: 'src/app.ts->src/utils.ts',
+      from: 'src/app.ts',
+      to: 'src/utils.ts',
+    } as FGLink;
+    const event = {
+      ctrlKey: true,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as MouseEvent;
+    const handlers = createClickHandlers(dependencies, {
+      applyGraphInteractionEffects,
+      setGraphCursor: vi.fn(),
+    });
+
+    handlers.handleLinkClick(link, event);
+
+    expect(interactionHarness.getLinkClickCommand).not.toHaveBeenCalled();
+    expect(applyGraphInteractionEffects).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/extension/tests/webview/graph/marqueeSelection/model.test.ts
+++ b/packages/extension/tests/webview/graph/marqueeSelection/model.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getMarqueeBounds,
+  getMarqueeSelectedNodeIds,
+  isMarqueePastThreshold,
+} from '../../../../src/webview/components/graph/marqueeSelection/model';
+import type { FGNode } from '../../../../src/webview/components/graph/model/build';
+
+function node(id: string, x: number | undefined, y: number | undefined): FGNode {
+  return {
+    id,
+    label: id,
+    size: 16,
+    color: '#93c5fd',
+    borderColor: '#1d4ed8',
+    borderWidth: 2,
+    baseOpacity: 1,
+    isFavorite: false,
+    isPinned: false,
+    x,
+    y,
+  } as FGNode;
+}
+
+describe('graph/marqueeSelection/model', () => {
+  it('normalizes marquee bounds for any drag direction', () => {
+    expect(getMarqueeBounds({ x: 140, y: 120 }, { x: 80, y: 40 })).toEqual({
+      left: 80,
+      top: 40,
+      width: 60,
+      height: 80,
+    });
+  });
+
+  it('waits until the drag passes the movement threshold', () => {
+    expect(isMarqueePastThreshold({ x: 10, y: 10 }, { x: 14, y: 14 }, 6)).toBe(false);
+    expect(isMarqueePastThreshold({ x: 10, y: 10 }, { x: 17, y: 10 }, 6)).toBe(true);
+  });
+
+  it('selects visible graph nodes whose projected screen points are inside the marquee', () => {
+    const graphToScreen = vi.fn((x: number, y: number) => ({ x: x + 10, y: y + 20 }));
+
+    expect(getMarqueeSelectedNodeIds({
+      bounds: { left: 90, top: 80, width: 80, height: 80 },
+      graphToScreen,
+      nodes: [
+        node('inside-a.ts', 90, 70),
+        node('inside-b.ts', 120, 100),
+        node('outside.ts', 250, 250),
+        node('missing-position.ts', undefined, 100),
+      ],
+    })).toEqual(['inside-a.ts', 'inside-b.ts']);
+    expect(graphToScreen).toHaveBeenCalledWith(90, 70);
+    expect(graphToScreen).toHaveBeenCalledWith(120, 100);
+  });
+});

--- a/packages/extension/tests/webview/graph/marqueeSelection/view.test.tsx
+++ b/packages/extension/tests/webview/graph/marqueeSelection/view.test.tsx
@@ -1,0 +1,103 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ForceGraph2D from 'react-force-graph-2d';
+import Graph from '../../../../src/webview/components/graph/view/component';
+import { DEFAULT_DIRECTION_COLOR } from '../../../../src/shared/fileColors';
+import type { IGraphData } from '../../../../src/shared/graph/contracts';
+import { graphStore } from '../../../../src/webview/store/state';
+
+const graphData: IGraphData = {
+  nodes: [
+    { id: 'src/app.ts', label: 'app.ts', color: '#93c5fd', x: 100, y: 100 },
+    { id: 'src/utils.ts', label: 'utils.ts', color: '#67e8f9', x: 140, y: 120 },
+    { id: 'README.md', label: 'README.md', color: '#facc15', x: 300, y: 300 },
+  ],
+  edges: [],
+};
+
+function setStore(overrides: Record<string, unknown> = {}): void {
+  graphStore.setState({
+    favorites: new Set<string>(),
+    bidirectionalMode: 'separate',
+    physicsSettings: {
+      repelForce: 10,
+      linkDistance: 80,
+      linkForce: 0.15,
+      damping: 0.7,
+      centerForce: 0.1,
+    },
+    nodeSizeMode: 'connections',
+    directionMode: 'arrows',
+    directionColor: DEFAULT_DIRECTION_COLOR,
+    particleSpeed: 0.005,
+    particleSize: 4,
+    showLabels: true,
+    graphMode: '2d',
+    ...overrides,
+  });
+}
+
+describe('graph/marqueeSelection view', () => {
+  beforeEach(() => {
+    ForceGraph2D.clearAllHandlers();
+    vi.clearAllMocks();
+    setStore();
+  });
+
+  it('shows the marquee rectangle while dragging and selects nodes inside it', async () => {
+    render(<Graph data={graphData} />);
+    const container = document.querySelector('.graph-container') as HTMLElement;
+
+    act(() => {
+      fireEvent.mouseDown(container, { button: 0, clientX: 90, clientY: 90 });
+      fireEvent.mouseMove(container, { button: 0, clientX: 170, clientY: 150 });
+    });
+
+    expect(screen.getByTestId('graph-marquee-selection')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.mouseUp(container, { button: 0, clientX: 170, clientY: 150 });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('graph-marquee-selection')).not.toBeInTheDocument();
+    });
+
+    act(() => {
+      ForceGraph2D.simulateNodeRightClick({ id: 'src/app.ts' });
+    });
+
+    expect(await screen.findByText('Open 2 Files')).toBeInTheDocument();
+  });
+
+  it('leaves Shift-left-drag available for panning instead of marquee selection', () => {
+    render(<Graph data={graphData} />);
+    const container = document.querySelector('.graph-container') as HTMLElement;
+
+    act(() => {
+      fireEvent.mouseDown(container, { button: 0, shiftKey: true, clientX: 90, clientY: 90 });
+      fireEvent.mouseMove(container, { button: 0, shiftKey: true, clientX: 170, clientY: 150 });
+      fireEvent.mouseUp(container, { button: 0, shiftKey: true, clientX: 170, clientY: 150 });
+    });
+
+    expect(screen.queryByTestId('graph-marquee-selection')).not.toBeInTheDocument();
+  });
+
+  it('clears an active marquee when the pointer leaves the graph', () => {
+    render(<Graph data={graphData} />);
+    const container = document.querySelector('.graph-container') as HTMLElement;
+
+    act(() => {
+      fireEvent.mouseDown(container, { button: 0, clientX: 90, clientY: 90 });
+      fireEvent.mouseMove(container, { button: 0, clientX: 170, clientY: 150 });
+    });
+
+    expect(screen.getByTestId('graph-marquee-selection')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.mouseLeave(container);
+    });
+
+    expect(screen.queryByTestId('graph-marquee-selection')).not.toBeInTheDocument();
+  });
+});

--- a/packages/extension/tests/webview/graph/marqueeSelection/view.test.tsx
+++ b/packages/extension/tests/webview/graph/marqueeSelection/view.test.tsx
@@ -70,17 +70,16 @@ describe('graph/marqueeSelection view', () => {
     expect(await screen.findByText('Open 2 Files')).toBeInTheDocument();
   });
 
-  it('leaves Shift-left-drag available for panning instead of marquee selection', () => {
+  it('shows the marquee rectangle while Shift-left-dragging to extend selection', () => {
     render(<Graph data={graphData} />);
     const container = document.querySelector('.graph-container') as HTMLElement;
 
     act(() => {
       fireEvent.mouseDown(container, { button: 0, shiftKey: true, clientX: 90, clientY: 90 });
       fireEvent.mouseMove(container, { button: 0, shiftKey: true, clientX: 170, clientY: 150 });
-      fireEvent.mouseUp(container, { button: 0, shiftKey: true, clientX: 170, clientY: 150 });
     });
 
-    expect(screen.queryByTestId('graph-marquee-selection')).not.toBeInTheDocument();
+    expect(screen.getByTestId('graph-marquee-selection')).toBeInTheDocument();
   });
 
   it('clears an active marquee when the pointer leaves the graph', () => {

--- a/packages/extension/tests/webview/graph/runtime/use/interaction.test.tsx
+++ b/packages/extension/tests/webview/graph/runtime/use/interaction.test.tsx
@@ -215,16 +215,18 @@ describe('graph/runtime/useGraphInteractionRuntime', () => {
     );
 
     result.current.handleMouseDownCapture({
-      button: 2,
+      button: 1,
       clientX: 10,
       clientY: 20,
       ctrlKey: true,
+      preventDefault: vi.fn(),
     } as never);
     result.current.handleMouseMoveCapture({
       clientX: 30,
       clientY: 40,
+      preventDefault: vi.fn(),
     } as never);
-    result.current.handleMouseUpCapture({ button: 2 } as never);
+    result.current.handleMouseUpCapture({ button: 1, preventDefault: vi.fn() } as never);
     result.current.handleNodeRightClick(createNode('src/node.ts'), { type: 'contextmenu' } as never);
     result.current.handleBackgroundRightClick({ type: 'contextmenu' } as never);
     result.current.handleLinkRightClick(createLink('edge-a'), { type: 'contextmenu' } as never);
@@ -247,17 +249,19 @@ describe('graph/runtime/useGraphInteractionRuntime', () => {
     result.current.handleMenuAction(secondAction);
     result.current.handleEngineStop();
 
-    expect(contextMenuRuntime.handleMouseDownCapture).toHaveBeenCalledWith({
-      button: 2,
+    expect(contextMenuRuntime.handleMouseDownCapture).toHaveBeenCalledWith(expect.objectContaining({
+      button: 1,
       clientX: 10,
       clientY: 20,
       ctrlKey: true,
-    });
-    expect(contextMenuRuntime.handleMouseMoveCapture).toHaveBeenCalledWith({
+    }));
+    expect(contextMenuRuntime.handleMouseMoveCapture).toHaveBeenCalledWith(expect.objectContaining({
       clientX: 30,
       clientY: 40,
-    });
-    expect(contextMenuRuntime.handleMouseUpCapture).toHaveBeenCalledWith({ button: 2 });
+    }));
+    expect(contextMenuRuntime.handleMouseUpCapture).toHaveBeenCalledWith(expect.objectContaining({
+      button: 1,
+    }));
     expect(interactionHandlers.openNodeContextMenu).toHaveBeenCalledWith('src/node.ts', { type: 'contextmenu' });
     expect(interactionHandlers.openBackgroundContextMenu).toHaveBeenCalledWith({ type: 'contextmenu' });
     expect(interactionHandlers.openEdgeContextMenu).toHaveBeenCalledWith(createLink('edge-a'), { type: 'contextmenu' });

--- a/packages/extension/tests/webview/graph/runtime/use/interaction/contextSuppression.test.tsx
+++ b/packages/extension/tests/webview/graph/runtime/use/interaction/contextSuppression.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FGLink, FGNode } from '../../../../../../src/webview/components/graph/model/build';
+import {
+  createSuppressedContextMenuHandlers,
+  useContextMenuSuppression,
+} from '../../../../../../src/webview/components/graph/runtime/use/interaction/contextSuppression';
+
+function createOpeningRuntime() {
+  return {
+    handleBackgroundRightClick: vi.fn(),
+    handleContextMenu: vi.fn(),
+    handleLinkRightClick: vi.fn(),
+    handleNodeRightClick: vi.fn(),
+  };
+}
+
+describe('graph/runtime/use/interaction context suppression', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('forwards context-menu calls while no drag suppression is active', () => {
+    const openingRuntime = createOpeningRuntime();
+    const { result } = renderHook(() => useContextMenuSuppression());
+    const handlers = createSuppressedContextMenuHandlers(openingRuntime as never, result.current);
+    const event = { preventDefault: vi.fn(), stopPropagation: vi.fn() };
+
+    handlers.handleContextMenu(event as never);
+    handlers.handleBackgroundRightClick({ type: 'background' } as never);
+    handlers.handleLinkRightClick({ id: 'edge' } as FGLink, { type: 'link' } as never);
+    handlers.handleNodeRightClick({ id: 'node' } as FGNode, { type: 'node' } as never);
+
+    expect(openingRuntime.handleContextMenu).toHaveBeenCalledTimes(1);
+    expect(openingRuntime.handleBackgroundRightClick).toHaveBeenCalledTimes(1);
+    expect(openingRuntime.handleLinkRightClick).toHaveBeenCalledWith({ id: 'edge' }, { type: 'link' });
+    expect(openingRuntime.handleNodeRightClick).toHaveBeenCalledWith({ id: 'node' }, { type: 'node' });
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it('blocks context-menu calls during the drag suppression window', () => {
+    const openingRuntime = createOpeningRuntime();
+    const { result } = renderHook(() => useContextMenuSuppression());
+    const handlers = createSuppressedContextMenuHandlers(openingRuntime as never, result.current);
+    const event = { preventDefault: vi.fn(), stopPropagation: vi.fn() };
+
+    result.current.suppressContextMenu();
+    handlers.handleContextMenu(event as never);
+    handlers.handleBackgroundRightClick({ type: 'background' } as never);
+    handlers.handleLinkRightClick({ id: 'edge' } as FGLink, { type: 'link' } as never);
+    handlers.handleNodeRightClick({ id: 'node' } as FGNode, { type: 'node' } as never);
+
+    expect(openingRuntime.handleContextMenu).not.toHaveBeenCalled();
+    expect(openingRuntime.handleBackgroundRightClick).not.toHaveBeenCalled();
+    expect(openingRuntime.handleLinkRightClick).not.toHaveBeenCalled();
+    expect(openingRuntime.handleNodeRightClick).not.toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/extension/tests/webview/graph/runtime/use/interaction/nodeDrag.test.ts
+++ b/packages/extension/tests/webview/graph/runtime/use/interaction/nodeDrag.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { FGNode } from '../../../../../../src/webview/components/graph/model/build';
+import {
+  applyNodeDrag,
+  releaseDraggedNodes,
+} from '../../../../../../src/webview/components/graph/runtime/use/interaction/nodeDrag';
+
+describe('graph/runtime/use/interaction node drag', () => {
+  it('moves the selected node group by the live drag delta', () => {
+    const primary = { id: 'primary', x: 15, y: 12 } as FGNode;
+    const sibling = { id: 'sibling', vx: 1, vy: 2, x: 30, y: 40 } as FGNode;
+    const outside = { id: 'outside', x: 90, y: 90 } as FGNode;
+
+    const session = applyNodeDrag(primary, { x: 5, y: -3 }, {
+      graphData: { nodes: [primary, sibling, outside] },
+      graphMode: '2d',
+      selectedNodeIds: new Set(['primary', 'sibling']),
+    });
+
+    expect(session?.draggedNodeIds).toEqual(new Set(['primary', 'sibling']));
+    expect(primary.isDragging).toBe(true);
+    expect(sibling).toMatchObject({
+      fx: 35,
+      fy: 37,
+      isDragging: true,
+      vx: 0,
+      vy: 0,
+      x: 35,
+      y: 37,
+    });
+    expect(outside).toMatchObject({ x: 90, y: 90 });
+  });
+
+  it('keeps the same selected drag group for later drag events', () => {
+    const primary = { id: 'primary', x: 15, y: 12 } as FGNode;
+    const sibling = { id: 'sibling', x: 30, y: 40 } as FGNode;
+    const session = applyNodeDrag(primary, { x: 5, y: 5 }, {
+      graphData: { nodes: [primary, sibling] },
+      graphMode: '2d',
+      selectedNodeIds: new Set(['primary', 'sibling']),
+    });
+
+    const nextSession = applyNodeDrag(primary, { x: 2, y: 3 }, {
+      graphData: { nodes: [primary, sibling] },
+      graphMode: '2d',
+      selectedNodeIds: new Set(['primary']),
+    }, session);
+
+    expect(nextSession).toBe(session);
+    expect(sibling).toMatchObject({
+      fx: 37,
+      fy: 48,
+      x: 37,
+      y: 48,
+    });
+  });
+
+  it('does not create a group drag outside 2d multi-selection', () => {
+    const primary = { id: 'primary', x: 15, y: 12 } as FGNode;
+    const sibling = { id: 'sibling', x: 30, y: 40 } as FGNode;
+
+    const in3d = applyNodeDrag(primary, { x: 5, y: 5 }, {
+      graphData: { nodes: [primary, sibling] },
+      graphMode: '3d',
+      selectedNodeIds: new Set(['primary', 'sibling']),
+    });
+    const single = applyNodeDrag(primary, { x: 5, y: 5 }, {
+      graphData: { nodes: [primary, sibling] },
+      graphMode: '2d',
+      selectedNodeIds: new Set(['primary']),
+    });
+
+    expect(in3d).toBeNull();
+    expect(single).toBeNull();
+    expect(sibling).toMatchObject({ x: 30, y: 40 });
+  });
+
+  it('releases every dragged node from fixed drag coordinates', () => {
+    const primary = { id: 'primary', fx: 15, fy: 12, isDragging: true } as FGNode;
+    const sibling = { id: 'sibling', fx: 30, fy: 40, isDragging: true } as FGNode;
+
+    releaseDraggedNodes(primary, {
+      draggedNodeIds: new Set(['primary', 'sibling']),
+      primaryNodeId: 'primary',
+    }, {
+      graphData: { nodes: [primary, sibling] },
+      graphMode: '2d',
+    });
+
+    expect(primary).toMatchObject({ isDragging: false });
+    expect(sibling).toMatchObject({ isDragging: false });
+    expect(primary.fx).toBeUndefined();
+    expect(primary.fy).toBeUndefined();
+    expect(sibling.fx).toBeUndefined();
+    expect(sibling.fy).toBeUndefined();
+  });
+});

--- a/packages/extension/tests/webview/graph/runtime/use/interaction/viewportPan.test.tsx
+++ b/packages/extension/tests/webview/graph/runtime/use/interaction/viewportPan.test.tsx
@@ -1,0 +1,160 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useGraphViewportPanRuntime } from '../../../../../../src/webview/components/graph/runtime/use/interaction/viewportPan/hook';
+
+function createEvent(button: number, x: number, y: number, ctrlKey = false) {
+  return {
+    button,
+    clientX: x,
+    clientY: y,
+    ctrlKey,
+    preventDefault: vi.fn(),
+  };
+}
+
+type PanGraph = {
+  centerAt?: ReturnType<typeof vi.fn>;
+  screen2GraphCoords?: ReturnType<typeof vi.fn>;
+  zoom?: ReturnType<typeof vi.fn>;
+};
+
+function createPanRuntime(options: {
+  container?: HTMLDivElement | null;
+  graph?: PanGraph | null;
+  graphMode?: '2d' | '3d';
+  rightMouseDown?: {
+    ctrlKey: boolean;
+    moved: boolean;
+    x: number;
+    y: number;
+  } | null;
+} = {}) {
+  const container = options.container === undefined
+    ? document.createElement('div')
+    : options.container;
+  if (container) {
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
+      bottom: 300,
+      height: 300,
+      left: 0,
+      right: 400,
+      top: 0,
+      width: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+  }
+  const graph = options.graph === undefined
+    ? {
+        centerAt: vi.fn(),
+        screen2GraphCoords: vi.fn(() => ({ x: 100, y: 200 })),
+        zoom: vi.fn(() => 2),
+      }
+    : options.graph;
+  const rightMouseDownRef = {
+    current: options.rightMouseDown === undefined ? {
+      ctrlKey: false,
+      moved: false,
+      x: 10,
+      y: 20,
+    } : options.rightMouseDown,
+  };
+  const suppressContextMenu = vi.fn();
+  const { result } = renderHook(() => useGraphViewportPanRuntime({
+    containerRef: { current: container } as never,
+    fg2dRef: { current: graph } as never,
+    graphMode: options.graphMode ?? '2d',
+    rightMouseDownRef: rightMouseDownRef as never,
+    suppressContextMenu,
+  }));
+
+  return {
+    graph,
+    result,
+    rightMouseDownRef,
+    suppressContextMenu,
+  };
+}
+
+describe('graph/runtime/use/interaction viewport pan', () => {
+  it('pans the 2d viewport with right-button drag and suppresses the context menu', () => {
+    const runtime = createPanRuntime();
+    const down = createEvent(2, 10, 20);
+    const move = createEvent(2, 16, 24);
+    const up = createEvent(2, 16, 24);
+
+    runtime.result.current.handleMouseDownCapture(down as never);
+    runtime.result.current.handleMouseMoveCapture(move as never);
+    runtime.result.current.handleMouseUpCapture(up as never);
+
+    expect(down.preventDefault).toHaveBeenCalledTimes(1);
+    expect(move.preventDefault).toHaveBeenCalledTimes(1);
+    expect(up.preventDefault).toHaveBeenCalledTimes(1);
+    expect(runtime.graph?.screen2GraphCoords).toHaveBeenCalledWith(200, 150);
+    expect(runtime.graph?.centerAt).toHaveBeenCalledWith(97, 198, 0);
+    expect(runtime.suppressContextMenu).toHaveBeenCalledTimes(1);
+    expect(runtime.rightMouseDownRef.current?.moved).toBe(true);
+  });
+
+  it('pans with middle-button drag without suppressing right-click context menus', () => {
+    const runtime = createPanRuntime();
+
+    runtime.result.current.handleMouseDownCapture(createEvent(1, 10, 20) as never);
+    runtime.result.current.handleMouseMoveCapture(createEvent(1, 14, 20) as never);
+
+    expect(runtime.graph?.centerAt).toHaveBeenCalledWith(98, 200, 0);
+    expect(runtime.suppressContextMenu).not.toHaveBeenCalled();
+    expect(runtime.rightMouseDownRef.current?.moved).toBe(false);
+  });
+
+  it('pans with ctrl-left drag and suppresses native context menu fallback', () => {
+    const runtime = createPanRuntime();
+    const down = createEvent(0, 10, 20, true);
+    const move = createEvent(0, 16, 24, true);
+    const up = createEvent(0, 16, 24, true);
+
+    runtime.result.current.handleMouseDownCapture(down as never);
+    runtime.result.current.handleMouseMoveCapture(move as never);
+    runtime.result.current.handleMouseUpCapture(up as never);
+
+    expect(down.preventDefault).toHaveBeenCalledTimes(1);
+    expect(move.preventDefault).toHaveBeenCalledTimes(1);
+    expect(up.preventDefault).toHaveBeenCalledTimes(1);
+    expect(runtime.graph?.centerAt).toHaveBeenCalledWith(97, 198, 0);
+    expect(runtime.suppressContextMenu).toHaveBeenCalledTimes(1);
+    expect(runtime.rightMouseDownRef.current?.moved).toBe(false);
+  });
+
+  it('ignores non-pan buttons and 3d graph mode', () => {
+    const in2d = createPanRuntime({ graphMode: '2d' });
+    const in3d = createPanRuntime({ graphMode: '3d' });
+    const leftDown = createEvent(0, 10, 20);
+    const rightDown3d = createEvent(2, 10, 20);
+
+    in2d.result.current.handleMouseDownCapture(leftDown as never);
+    in2d.result.current.handleMouseMoveCapture(createEvent(0, 30, 40) as never);
+    in3d.result.current.handleMouseDownCapture(rightDown3d as never);
+    in3d.result.current.handleMouseMoveCapture(createEvent(2, 30, 40) as never);
+
+    expect(leftDown.preventDefault).not.toHaveBeenCalled();
+    expect(rightDown3d.preventDefault).not.toHaveBeenCalled();
+    expect(in2d.graph?.centerAt).not.toHaveBeenCalled();
+    expect(in3d.graph?.centerAt).not.toHaveBeenCalled();
+  });
+
+  it('does not pan or suppress context menus before the drag threshold', () => {
+    const runtime = createPanRuntime();
+    const move = createEvent(2, 11, 21);
+    const up = createEvent(2, 11, 21);
+
+    runtime.result.current.handleMouseDownCapture(createEvent(2, 10, 20) as never);
+    runtime.result.current.handleMouseMoveCapture(move as never);
+    runtime.result.current.handleMouseUpCapture(up as never);
+
+    expect(move.preventDefault).not.toHaveBeenCalled();
+    expect(up.preventDefault).not.toHaveBeenCalled();
+    expect(runtime.graph?.centerAt).not.toHaveBeenCalled();
+    expect(runtime.suppressContextMenu).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds desktop-style marquee selection for graph nodes.
- Supports Shift selection extension, selected group dragging, and right/middle/Ctrl-left viewport panning.
- Keeps this branch independent from graph sections: no section creation, ownership, or pin behavior is introduced here.

## Verification
- pnpm --filter @codegraphy/extension exec vitest run --config vitest.config.ts tests/webview/graph/runtime/use/interaction/nodeDrag.test.ts tests/webview/graph/runtime/use/interaction/viewportPan.test.tsx tests/webview/graph/runtime/use/interaction/contextSuppression.test.tsx tests/webview/graph/marqueeSelection/model.test.ts tests/webview/graph/marqueeSelection/view.test.tsx
- pnpm run typecheck
- pnpm run lint

No mutation tests run per request.