### PR TITLE
Fix mutation seed runner loading

### DIFF
--- a/packages/extension/tests/extension/mutation/seedJobs.test.ts
+++ b/packages/extension/tests/extension/mutation/seedJobs.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 import {
   discoverMutationSeedJobMatrix,
@@ -69,6 +70,19 @@ describe('mutation seed jobs', () => {
       package: 'extension',
       shard: 'webview',
     });
+  });
+});
+
+describe('runSeedJob script', () => {
+  it('loads through tsx before validating required flags', () => {
+    const result = spawnSync('pnpm', ['exec', 'tsx', 'scripts/mutation/runSeedJob.ts'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Missing required --package value.');
+    expect(result.stderr).not.toContain('Transform failed');
   });
 });
 

--- a/scripts/mutation/runSeedJob.ts
+++ b/scripts/mutation/runSeedJob.ts
@@ -38,7 +38,7 @@ function runQualityToolsMutation(args: string[], env: NodeJS.ProcessEnv): Promis
   });
 }
 
-try {
+async function main(): Promise<void> {
   const args = process.argv.slice(2).filter((arg) => arg !== '--');
   const packageName = requiredFlag(args, '--package');
   const shard = requiredFlag(args, '--shard');
@@ -58,7 +58,9 @@ try {
       : process.env.CODEGRAPHY_VITEST_SCOPE ?? 'workspace',
     CODEGRAPHY_VITEST_INCLUDE_JSON: JSON.stringify(job.testIncludes),
   });
-} catch (error) {
+}
+
+void main().catch((error: unknown) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
-}
+});


### PR DESCRIPTION
## Summary
- wrap the mutation seed runner in an async main function so tsx does not need top-level await support
- add a regression test that proves the script loads through tsx before validating required flags

## Root cause
The merged mutation seed workflow calls `pnpm exec tsx scripts/mutation/runSeedJob.ts`. That script used top-level await, and tsx/esbuild transformed it as CommonJS in CI, failing before quality-tools or Stryker started. This is a CodeGraphy CI wrapper issue, not a quality-tools package integration issue.

## Validation
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/mutation/seedJobs.test.ts
- pnpm exec tsx scripts/mutation/runSeedJob.ts
- pnpm exec tsx scripts/mutation/runSeedJob.ts --package plugin-python --shard missing-shard
- pnpm run typecheck
- pnpm run lint

I did not run a real mutation shard locally because the failure happened before Stryker starts and full mutation is intentionally expensive.
