### PR TITLE
Fix mutation seed test discovery

### DIFF
--- a/packages/extension/tests/extension/mutation/seedJobs.test.ts
+++ b/packages/extension/tests/extension/mutation/seedJobs.test.ts
@@ -1,8 +1,10 @@
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
+import { buildQualityToolsMutationArgs } from '../../../../../scripts/mutation/runSeedJob';
 import {
   discoverMutationSeedJobMatrix,
   discoverMutationSeedJobs,
@@ -13,6 +15,8 @@ import {
   writeMutationSeedReports,
 } from '../../../../../scripts/mutation/seedMerge';
 import { REPO_ROOT } from '../../../../../scripts/mutation/paths';
+
+const require = createRequire(import.meta.url);
 
 function createReport(options: {
   fileName: string;
@@ -74,6 +78,21 @@ describe('mutation seed jobs', () => {
 });
 
 describe('runSeedJob script', () => {
+  it('forwards seed job mutate and test include scopes to quality-tools', () => {
+    expect(buildQualityToolsMutationArgs({
+      mutate: ['packages/plugin-typescript/src/**/*.ts'],
+      package: 'plugin-typescript',
+      shard: 'plugin-typescript',
+      testIncludes: ['packages/plugin-typescript/tests/**/*.test.ts'],
+    })).toEqual([
+      'plugin-typescript/',
+      '--mutate-globs-json',
+      JSON.stringify(['packages/plugin-typescript/src/**/*.ts']),
+      '--test-includes-json',
+      JSON.stringify(['packages/plugin-typescript/tests/**/*.test.ts']),
+    ]);
+  });
+
   it('loads through tsx before validating required flags', () => {
     const result = spawnSync('pnpm', ['exec', 'tsx', 'scripts/mutation/runSeedJob.ts'], {
       cwd: REPO_ROOT,
@@ -83,6 +102,26 @@ describe('runSeedJob script', () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('Missing required --package value.');
     expect(result.stderr).not.toContain('Transform failed');
+  });
+});
+
+describe('stryker seed configs', () => {
+  it('keeps the workspace seed config open to non-extension package tests', () => {
+    const config = require('../../../../../stryker.config.cjs') as {
+      vitest?: { configFile?: string; dir?: string };
+    };
+
+    expect(config.vitest?.configFile).toBe('packages/extension/vitest.config.ts');
+    expect(config.vitest?.dir).toBeUndefined();
+  });
+
+  it('keeps the extension package config open to repo-relative test includes', () => {
+    const config = require('../../../../../stryker.extension.config.cjs') as {
+      vitest?: { configFile?: string; dir?: string };
+    };
+
+    expect(config.vitest?.configFile).toBe('packages/extension/vitest.config.ts');
+    expect(config.vitest?.dir).toBeUndefined();
   });
 });
 

--- a/packages/extension/tests/vitest.includes.test.ts
+++ b/packages/extension/tests/vitest.includes.test.ts
@@ -16,6 +16,7 @@ describe('vitest includes', () => {
     delete process.env.CODEGRAPHY_VITEST_SCOPE;
     delete process.env.CODEGRAPHY_VITEST_INCLUDE_JSON;
     delete process.env.CODEGRAPHY_VITEST_WEBVIEW_GROUP;
+    delete process.env.QUALITY_TOOLS_VITEST_INCLUDE_JSON;
   });
 
   it('defaults mutation scope to extension tests', () => {
@@ -74,5 +75,11 @@ describe('vitest includes', () => {
     process.env.CODEGRAPHY_VITEST_INCLUDE_JSON = JSON.stringify(['packages/plugin-godot/tests/**/*.test.ts']);
 
     expect(resolveMutationVitestIncludes()).toEqual(['packages/plugin-godot/tests/**/*.test.ts']);
+  });
+
+  it('accepts explicit mutation include overrides from quality-tools', () => {
+    expect(resolveMutationVitestIncludes({
+      QUALITY_TOOLS_VITEST_INCLUDE_JSON: JSON.stringify(['packages/plugin-typescript/tests/**/*.test.ts']),
+    })).toEqual(['packages/plugin-typescript/tests/**/*.test.ts']);
   });
 });

--- a/packages/extension/vitest.config.ts
+++ b/packages/extension/vitest.config.ts
@@ -11,7 +11,9 @@ const workspaceRoot = resolve(__dirname, '../..');
 const extensionNodeModules = resolve(__dirname, 'node_modules');
 const vitestScope = process.env.CODEGRAPHY_VITEST_SCOPE ?? 'extension';
 const useMutationCompatibleConfig =
-  Boolean(process.env.CODEGRAPHY_VITEST_INCLUDE_JSON) || vitestScope === 'workspace';
+  Boolean(process.env.CODEGRAPHY_VITEST_INCLUDE_JSON)
+    || Boolean(process.env.QUALITY_TOOLS_VITEST_INCLUDE_JSON)
+    || vitestScope === 'workspace';
 const coverageReportKey = vitestScope === 'workspace' ? 'workspace' : 'extension';
 const coverageInclude = vitestScope === 'workspace'
   ? ['packages/*/src/**/*.{ts,tsx}']

--- a/packages/extension/vitest.includes.ts
+++ b/packages/extension/vitest.includes.ts
@@ -74,7 +74,10 @@ export const workspaceMutationIncludes = [
 
 type ScopeEnv = Partial<Pick<
   NodeJS.ProcessEnv,
-  'CODEGRAPHY_VITEST_INCLUDE_JSON' | 'CODEGRAPHY_VITEST_SCOPE' | 'CODEGRAPHY_VITEST_WEBVIEW_GROUP'
+  | 'CODEGRAPHY_VITEST_INCLUDE_JSON'
+  | 'CODEGRAPHY_VITEST_SCOPE'
+  | 'CODEGRAPHY_VITEST_WEBVIEW_GROUP'
+  | 'QUALITY_TOOLS_VITEST_INCLUDE_JSON'
 >>;
 
 function isExtensionWebviewTestGroup(value: string): value is ExtensionWebviewTestGroup {
@@ -95,8 +98,11 @@ export function resolveExtensionWebviewTestIncludes(environment: ScopeEnv = proc
 }
 
 export function resolveMutationVitestIncludes(environment: ScopeEnv = process.env): string[] {
-  if (environment.CODEGRAPHY_VITEST_INCLUDE_JSON) {
-    return JSON.parse(environment.CODEGRAPHY_VITEST_INCLUDE_JSON) as string[];
+  const explicitIncludes = environment.QUALITY_TOOLS_VITEST_INCLUDE_JSON
+    ?? environment.CODEGRAPHY_VITEST_INCLUDE_JSON;
+
+  if (explicitIncludes) {
+    return JSON.parse(explicitIncludes) as string[];
   }
 
   return environment.CODEGRAPHY_VITEST_SCOPE === 'workspace'

--- a/scripts/mutation/runSeedJob.ts
+++ b/scripts/mutation/runSeedJob.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env tsx
 
 import { spawn } from 'node:child_process';
-import { findMutationSeedJob } from './seedJobs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findMutationSeedJob, type MutationSeedJob } from './seedJobs';
 import { REPO_ROOT } from './paths';
 
 function flagValue(args: readonly string[], flag: string): string | undefined {
@@ -38,6 +40,20 @@ function runQualityToolsMutation(args: string[], env: NodeJS.ProcessEnv): Promis
   });
 }
 
+export function buildQualityToolsMutationArgs(
+  job: MutationSeedJob,
+  options: { force?: boolean } = {},
+): string[] {
+  return [
+    `${job.package}/`,
+    '--mutate-globs-json',
+    JSON.stringify(job.mutate),
+    '--test-includes-json',
+    JSON.stringify(job.testIncludes),
+    ...(options.force ? ['--force'] : []),
+  ];
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2).filter((arg) => arg !== '--');
   const packageName = requiredFlag(args, '--package');
@@ -45,12 +61,9 @@ async function main(): Promise<void> {
   const job = findMutationSeedJob(REPO_ROOT, packageName, shard);
 
   console.error(`[mutation] Running seed job ${job.package}/${job.shard}.`);
-  await runQualityToolsMutation([
-    `${job.package}/`,
-    '--mutate-globs-json',
-    JSON.stringify(job.mutate),
-    ...(args.includes('--force') ? ['--force'] : []),
-  ], {
+  await runQualityToolsMutation(buildQualityToolsMutationArgs(job, {
+    force: args.includes('--force'),
+  }), {
     ...process.env,
     CODEGRAPHY_MUTATION_RUN: '1',
     CODEGRAPHY_VITEST_SCOPE: job.package === 'extension'
@@ -60,7 +73,13 @@ async function main(): Promise<void> {
   });
 }
 
-void main().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+function isEntrypoint(): boolean {
+  return Boolean(process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]));
+}
+
+if (isEntrypoint()) {
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/stryker.config.cjs
+++ b/stryker.config.cjs
@@ -1,4 +1,3 @@
-const path = require('node:path');
 const base = require('@poleski/quality-tools/stryker.config.cjs');
 
 process.env.CODEGRAPHY_VITEST_SCOPE = process.env.CODEGRAPHY_VITEST_SCOPE ?? 'workspace';
@@ -20,8 +19,7 @@ module.exports = {
   packageManager: 'pnpm',
   vitest: {
     ...base.vitest,
-    configFile: path.join(__dirname, 'packages/extension/vitest.config.ts'),
-    dir: path.join(__dirname, 'packages/extension'),
+    configFile: 'packages/extension/vitest.config.ts',
     related: false,
   },
   reporters: [

--- a/stryker.extension.config.cjs
+++ b/stryker.extension.config.cjs
@@ -1,11 +1,9 @@
-const path = require('node:path');
 const base = require('@poleski/quality-tools/stryker.config.cjs');
 
 module.exports = {
   ...base,
   vitest: {
     ...base.vitest,
-    configFile: path.join(__dirname, 'packages/extension/vitest.config.ts'),
-    dir: path.join(__dirname, 'packages/extension'),
+    configFile: 'packages/extension/vitest.config.ts',
   },
 };


### PR DESCRIPTION
## Summary
- pass seed job test include globs through to the external quality-tools mutation command
- let CodeGraphy's Vitest config consume quality-tools include env overrides
- make Stryker Vitest config paths sandbox-relative and stop constraining repo-relative test globs with a package dir

## Validation
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/mutation/seedJobs.test.ts tests/vitest.includes.test.ts
- pnpm exec tsx scripts/mutation/runSeedJob.ts --package plugin-typescript --shard plugin-typescript
- CODEGRAPHY_MUTATION_RUN=1 CODEGRAPHY_VITEST_SCOPE=extension QUALITY_TOOLS_VITEST_INCLUDE_JSON='["packages/extension/tests/shared/globMatch.test.ts"]' QUALITY_TOOLS_REPORTS_DIR=reports/quality-tools node node_modules/.pnpm/@stryker-mutator+core@9.6.1_@types+node@20.19.37/node_modules/@stryker-mutator/core/bin/stryker.js run stryker.extension.config.cjs --dryRunOnly --incrementalFile reports/quality-tools/mutation/extension/debug-incremental.json -m 'packages/extension/src/shared/globMatch.ts'
- pnpm run typecheck
- pnpm run lint
- git diff --check