### PR TITLE
Fix aborted graph refresh dropping edges

### DIFF
--- a/.changeset/clean-lamps-relate.md
+++ b/.changeset/clean-lamps-relate.md
@@ -2,4 +2,4 @@
 "@codegraphy-dev/extension": patch
 ---
 
-Preserve the last good Graph Cache when a full index refresh is aborted so graph edges do not disappear after interrupted refreshes.
+Preserve the last good Graph Cache when a full index refresh is aborted and report the actual Graph Cache status after indexing so graph edges do not disappear after interrupted refreshes.

--- a/.changeset/clean-lamps-relate.md
+++ b/.changeset/clean-lamps-relate.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Preserve the last good Graph Cache when a full index refresh is aborted so graph edges do not disappear after interrupted refreshes.

--- a/packages/extension/src/extension/graphView/analysis/execution/publish.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/publish.ts
@@ -43,9 +43,10 @@ export function publishAnalyzedGraph(
   rawGraphData: IGraphData,
   hasIndex: boolean,
 ): void {
-  const status = resolveGraphIndexStatus(state, hasIndex);
+  const actualHasIndex = state.analyzer?.hasIndex() ?? hasIndex;
+  const status = resolveGraphIndexStatus(state, actualHasIndex);
   handlers.setRawGraphData(rawGraphData);
-  handlers.sendGraphIndexStatusUpdated(hasIndex, status.freshness, status.detail);
+  handlers.sendGraphIndexStatusUpdated(actualHasIndex, status.freshness, status.detail);
   handlers.updateViewContext();
   handlers.applyViewTransform();
   handlers.computeMergedGroups();

--- a/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
@@ -19,6 +19,7 @@ import {
   analyzeWorkspacePipeline,
   rebuildWorkspacePipelineGraph,
 } from './runtime/run';
+import { createEmptyWorkspaceAnalysisCache } from '../cache';
 
 export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipelineInternalBase {
   private _workspacePluginReloadQueue: Promise<void> = Promise.resolve();
@@ -163,13 +164,18 @@ export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipeline
     );
   }
 
+  protected resetCacheForIndexRefresh(): void {
+    this._cache = createEmptyWorkspaceAnalysisCache();
+    console.log('[CodeGraphy] Cache cleared');
+  }
+
   async refreshIndex(
     filterPatterns: string[] = [],
     disabledPlugins: Set<string> = new Set(),
     signal?: AbortSignal,
     onProgress?: (progress: { phase: string; current: number; total: number }) => void,
   ): Promise<IGraphData> {
-    this.clearCache();
+    this.resetCacheForIndexRefresh();
     return this.analyze(filterPatterns, disabledPlugins, signal, progress => {
       onProgress?.({
         ...progress,

--- a/packages/extension/tests/extension/graphView/analysis/execution/publish.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/publish.test.ts
@@ -77,6 +77,31 @@ describe('graph view analysis execution publish', () => {
     expect(handlers.markWorkspaceReady).toHaveBeenCalledWith(getGraphData());
   });
 
+  it('publishes the actual missing index state when indexing does not create a Graph Cache', () => {
+    const rawGraphData: IGraphData = {
+      nodes: [{ id: 'src/index.ts', label: 'src/index.ts', color: '#ffffff' }],
+      edges: [],
+    };
+    const state = createExecutionState({
+      analyzer: createExecutionAnalyzer({
+        hasIndex: vi.fn(() => false),
+        getIndexStatus: vi.fn(() => ({
+          freshness: 'missing' as const,
+          detail: 'CodeGraphy index is missing. Index the workspace to build the graph.',
+        })),
+      }),
+    });
+    const { handlers } = createExecutionHandlers();
+
+    publishAnalyzedGraph(state, handlers, rawGraphData, true);
+
+    expect(handlers.sendGraphIndexStatusUpdated).toHaveBeenCalledWith(
+      false,
+      'missing',
+      'CodeGraphy index is missing. Index the workspace to build the graph.',
+    );
+  });
+
   it('recomputes and publishes legends after the transformed graph is available', () => {
     const rawGraphData: IGraphData = {
       nodes: [{ id: 'package.json', label: 'package.json', color: '#ffffff' }],

--- a/packages/extension/tests/extension/graphView/provider/analysis/methods.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/analysis/methods.test.ts
@@ -287,6 +287,41 @@ describe('graphView/provider/analysis/methods', () => {
     expect(runAnalysisRequest).toHaveBeenCalledOnce();
   });
 
+  it('keeps webview-ready loading from interrupting an active first index', async () => {
+    const source = createSource();
+    let finishIndex: (() => void) | undefined;
+    const runAnalysisRequest = vi.fn(async state => {
+      if (state.mode !== 'index') {
+        return;
+      }
+
+      await new Promise<void>(resolve => {
+        finishIndex = resolve;
+      });
+    });
+    const methods = createGraphViewProviderAnalysisMethods(source as never, {
+      runAnalysisRequest,
+      executeAnalysis: vi.fn(async () => undefined),
+      markWorkspaceReady: vi.fn(),
+      isAnalysisStale: vi.fn(() => false),
+      isAbortError: vi.fn(() => false),
+      hasWorkspace: vi.fn(() => true),
+      logError: vi.fn(),
+    });
+
+    const index = methods._indexAndSendData();
+    await Promise.resolve();
+    const load = methods._loadAndSendData();
+
+    expect(runAnalysisRequest).toHaveBeenCalledOnce();
+
+    finishIndex?.();
+    await index;
+    await load;
+
+    expect(runAnalysisRequest).toHaveBeenCalledOnce();
+  });
+
   it('falls back to the delegate wrappers when source-owned analysis methods are unavailable', async () => {
     const source = createSource({
       _analyzer: undefined,

--- a/packages/extension/tests/extension/graphViewProvider.lifecycle.test.ts
+++ b/packages/extension/tests/extension/graphViewProvider.lifecycle.test.ts
@@ -1,12 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { IGraphData } from '../../src/shared/graph/contracts';
 import { GraphViewProvider } from '../../src/extension/graphViewProvider';
 import { getGraphViewProviderInternals } from './graphViewProvider/internals';
+import {
+  getWorkspaceAnalysisDatabasePath,
+  readWorkspaceAnalysisDatabaseSnapshot,
+} from '../../src/extension/pipeline/database/cache/storage';
 
 let workspaceFoldersValue:
   | Array<{ uri: { fsPath: string; path: string }; name: string; index: number }>
   | undefined;
+const tempWorkspaceRoots: string[] = [];
 
 Object.defineProperty(vscode.workspace, 'workspaceFolders', {
   get: () => workspaceFoldersValue,
@@ -24,12 +32,42 @@ function createContext() {
   };
 }
 
+async function createWorkspace(files: Record<string, string>): Promise<string> {
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-provider-'));
+  tempWorkspaceRoots.push(workspaceRoot);
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(workspaceRoot, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, content, 'utf8');
+  }
+
+  return workspaceRoot;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe('GraphViewProvider lifecycle', () => {
   beforeEach(() => {
     workspaceFoldersValue = [
       { uri: vscode.Uri.file('/test/workspace'), name: 'workspace', index: 0 },
     ];
     vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempWorkspaceRoots.splice(0).map((workspaceRoot) =>
+        fs.rm(workspaceRoot, { recursive: true, force: true }),
+      ),
+    );
   });
 
   it('forwards decoration manager change notifications to _sendDecorations', () => {
@@ -108,6 +146,36 @@ describe('GraphViewProvider lifecycle', () => {
 
     expect(clearCache).toHaveBeenCalledTimes(1);
     expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('recreates the Graph Cache and Tree-sitter edges after a deleted cache is refreshed then indexed', async () => {
+    const workspaceRoot = await createWorkspace({
+      'src/utils.ts': 'export const value = 1;\n',
+      'src/index.ts': "import { value } from './utils';\nconsole.log(value);\n",
+    });
+    workspaceFoldersValue = [
+      { uri: vscode.Uri.file(workspaceRoot), name: 'workspace', index: 0 },
+    ];
+    const provider = new GraphViewProvider(
+      vscode.Uri.file('/test/extension'),
+      createContext() as unknown as vscode.ExtensionContext
+    );
+    const databasePath = getWorkspaceAnalysisDatabasePath(workspaceRoot);
+
+    await provider.dispatchWebviewMessage({ type: 'INDEX_GRAPH' });
+    expect(provider.getGraphData().edges.map(edge => edge.id)).toContain('src/index.ts->src/utils.ts#import');
+    expect(await pathExists(databasePath)).toBe(true);
+
+    await fs.unlink(databasePath);
+    await provider.dispatchWebviewMessage({ type: 'WEBVIEW_READY', payload: null });
+    expect(provider.getGraphData().edges).toEqual([]);
+    expect(await pathExists(databasePath)).toBe(false);
+
+    await provider.dispatchWebviewMessage({ type: 'INDEX_GRAPH' });
+
+    expect(provider.getGraphData().edges.map(edge => edge.id)).toContain('src/index.ts->src/utils.ts#import');
+    expect(await pathExists(databasePath)).toBe(true);
+    expect(readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot).relations.length).toBeGreaterThan(0);
   });
 
   it('sends empty graph data when _doAnalyzeAndSendData runs without an analyzer', async () => {

--- a/packages/extension/tests/extension/pipeline/analysis.test.ts
+++ b/packages/extension/tests/extension/pipeline/analysis.test.ts
@@ -5,7 +5,10 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { IFileAnalysisResult } from '../../../src/core/plugins/types/contracts';
 import { DEFAULT_EXCLUDE_PATTERNS } from '../../../src/extension/config/defaults';
-import { readWorkspaceAnalysisDatabaseSnapshot } from '../../../src/extension/pipeline/database/cache/storage';
+import {
+  getWorkspaceAnalysisDatabasePath,
+  readWorkspaceAnalysisDatabaseSnapshot,
+} from '../../../src/extension/pipeline/database/cache/storage';
 import { formatWorkspacePipelineLimitReachedMessage } from '../../../src/extension/pipeline/discovery';
 import { WorkspacePipeline } from '../../../src/extension/pipeline/service/lifecycleFacade';
 
@@ -45,6 +48,15 @@ async function createWorkspace(files: Record<string, string>): Promise<string> {
   }
 
   return workspaceRoot;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 afterAll(async () => {
@@ -215,6 +227,35 @@ describe('WorkspacePipeline analysis', () => {
     expect(readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot).relations.length).toBe(
       snapshotBefore.relations.length,
     );
+  });
+
+  it('recreates a deleted Graph Cache when indexing the workspace', async () => {
+    const workspaceRoot = await createWorkspace({
+      'src/utils.ts': 'export const value = 1;\n',
+      'src/index.ts': "import { value } from './utils';\nconsole.log(value);\n",
+    });
+    workspaceFoldersValue = [
+      { uri: vscode.Uri.file(workspaceRoot), name: 'workspace', index: 0 },
+    ];
+    const analyzer = new WorkspacePipeline(
+      createContext() as unknown as vscode.ExtensionContext
+    );
+
+    await analyzer.initialize();
+
+    const initialGraph = await analyzer.analyze();
+    expect(initialGraph.edges.map(edge => edge.id)).toContain('src/index.ts->src/utils.ts#import');
+    const databasePath = getWorkspaceAnalysisDatabasePath(workspaceRoot);
+    expect(await pathExists(databasePath)).toBe(true);
+
+    await fs.unlink(databasePath);
+    expect(analyzer.hasIndex()).toBe(false);
+
+    const indexedGraph = await analyzer.refreshIndex();
+
+    expect(indexedGraph.edges.map(edge => edge.id)).toContain('src/index.ts->src/utils.ts#import');
+    expect(await pathExists(databasePath)).toBe(true);
+    expect(readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot).relations.length).toBeGreaterThan(0);
   });
 
   it('returns an empty graph when no workspace folder is open', async () => {

--- a/packages/extension/tests/extension/pipeline/analysis.test.ts
+++ b/packages/extension/tests/extension/pipeline/analysis.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { IFileAnalysisResult } from '../../../src/core/plugins/types/contracts';
 import { DEFAULT_EXCLUDE_PATTERNS } from '../../../src/extension/config/defaults';
+import { readWorkspaceAnalysisDatabaseSnapshot } from '../../../src/extension/pipeline/database/cache/storage';
 import { formatWorkspacePipelineLimitReachedMessage } from '../../../src/extension/pipeline/discovery';
 import { WorkspacePipeline } from '../../../src/extension/pipeline/service/lifecycleFacade';
 
@@ -155,6 +156,64 @@ describe('WorkspacePipeline analysis', () => {
           toFilePath: path.join(workspaceRoot, 'pkg/thing.py'),
         }),
       ]),
+    );
+  });
+
+  it('keeps Tree-sitter relations after workspace plugin reload and index refresh', async () => {
+    workspaceFoldersValue = [
+      { uri: vscode.Uri.file(fixtureWorkspacePath), name: 'workspace', index: 0 },
+    ];
+    const analyzer = new WorkspacePipeline(
+      createContext() as unknown as vscode.ExtensionContext
+    );
+
+    await analyzer.initialize();
+
+    const initialGraph = await analyzer.analyze();
+    expect(initialGraph.edges.map(edge => edge.id)).toEqual(
+      expect.arrayContaining([
+        'src/index.ts->src/utils.ts#import',
+      ]),
+    );
+
+    await analyzer.reloadWorkspacePlugins();
+    const refreshedGraph = await analyzer.refreshIndex();
+
+    expect(analyzer.registry.get('codegraphy.treesitter')).toBeDefined();
+    expect(refreshedGraph.edges.map(edge => edge.id)).toEqual(
+      expect.arrayContaining([
+        'src/index.ts->src/utils.ts#import',
+      ]),
+    );
+  });
+
+  it('preserves the previous Tree-sitter index when a full refresh is aborted', async () => {
+    const workspaceRoot = await createWorkspace({
+      'src/utils.ts': 'export const value = 1;\n',
+      'src/index.ts': "import { value } from './utils';\nconsole.log(value);\n",
+    });
+    workspaceFoldersValue = [
+      { uri: vscode.Uri.file(workspaceRoot), name: 'workspace', index: 0 },
+    ];
+    const analyzer = new WorkspacePipeline(
+      createContext() as unknown as vscode.ExtensionContext
+    );
+
+    await analyzer.initialize();
+
+    const graph = await analyzer.analyze();
+    expect(graph.edges.map(edge => edge.id)).toContain('src/index.ts->src/utils.ts#import');
+    const snapshotBefore = readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot);
+    expect(snapshotBefore.relations.length).toBeGreaterThan(0);
+
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      analyzer.refreshIndex([], new Set<string>(), controller.signal),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot).relations.length).toBe(
+      snapshotBefore.relations.length,
     );
   });
 

--- a/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
@@ -290,6 +290,7 @@ describe('pipeline/service/discoveryFacade', () => {
       nodes: [{ id: 'refresh', label: 'Refresh', color: '#444444' }],
       edges: [],
     });
+    const cacheBeforeRefresh = facade._cache;
     await expect(
       facade.refreshIndex(undefined, disabledPlugins, signal),
     ).resolves.toEqual({
@@ -297,7 +298,9 @@ describe('pipeline/service/discoveryFacade', () => {
       edges: [],
     });
 
-    expect(facade.clearCache).toHaveBeenCalledOnce();
+    expect(facade.clearCache).not.toHaveBeenCalled();
+    expect(facade._cache).not.toBe(cacheBeforeRefresh);
+    expect(facade._cache.files).toEqual({});
     expect(analyzeSpy).toHaveBeenCalledWith([], disabledPlugins, signal, expect.any(Function));
 
     const refreshWithoutProgress = analyzeSpy.mock.calls[1][3] as (progress: {


### PR DESCRIPTION
## Summary
- keep full index refreshes from deleting the persisted Graph Cache before the new analysis completes
- preserve Tree-sitter edge data when refresh/index work is aborted or interrupted
- add regression coverage for workspace plugin reload + Tree-sitter edges and aborted refresh cache preservation

## Tests
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/analysis.test.ts
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/service/discoveryFacade.test.ts
- pnpm --filter @codegraphy-dev/extension test
- pnpm --filter @codegraphy-dev/extension lint
- pnpm --filter @codegraphy-dev/extension typecheck
- pre-commit hook: pnpm run typecheck + lint-staged eslint --fix