### PR TITLE
Fix root indexing graph cache refresh

### DIFF
--- a/.changeset/steady-graphs-reindex.md
+++ b/.changeset/steady-graphs-reindex.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy-dev/core": patch
+"@codegraphy-dev/extension": patch
+---
+
+Keep workspace indexing responsive while rebuilding the Graph Cache from a missing or stale cache.

--- a/packages/core/src/analysis/workspaceAnalyze.ts
+++ b/packages/core/src/analysis/workspaceAnalyze.ts
@@ -57,7 +57,9 @@ export interface WorkspacePipelineAnalysisDependencies
   };
   getWorkspaceRoot(): string | undefined;
   logInfo(message: string): void;
-  saveCache(): void;
+  saveCache(
+    onProgress?: (progress: { current: number; total: number }) => void,
+  ): void | Promise<void>;
   showWarningMessage(message: string): void;
   sendProgress?(progress: { phase: string; current: number; total: number }): void;
 }
@@ -80,6 +82,11 @@ export async function analyzeWorkspaceWithAnalyzer(
   const config = dependencies.getConfig();
   const disabledCustomPatterns = new Set(config.disabledCustomFilterPatterns ?? []);
   const disabledPluginPatterns = new Set(config.disabledPluginFilterPatterns ?? []);
+  dependencies.sendProgress?.({
+    phase: 'Discovering Files',
+    current: 0,
+    total: 1,
+  });
   const discoveryResult = await discoverWorkspacePipelineFiles(
     dependencies,
     workspaceRoot,
@@ -89,6 +96,11 @@ export async function analyzeWorkspaceWithAnalyzer(
       .filter(pattern => !disabledPluginPatterns.has(pattern)),
     signal,
   );
+  dependencies.sendProgress?.({
+    phase: 'Discovering Files',
+    current: 1,
+    total: 1,
+  });
 
   throwIfWorkspaceAnalysisAborted(signal);
 
@@ -135,14 +147,40 @@ export async function analyzeWorkspaceWithAnalyzer(
   source._lastDiscoveredFiles = discoveryResult.files;
   source._lastWorkspaceRoot = workspaceRoot;
 
+  dependencies.sendProgress?.({
+    phase: 'Building Graph',
+    current: 0,
+    total: 1,
+  });
   const graphData = source._buildGraphDataFromAnalysis(
     analysisResult.fileAnalysis,
     workspaceRoot,
     config.showOrphans,
     disabledPlugins,
   );
+  dependencies.sendProgress?.({
+    phase: 'Building Graph',
+    current: 1,
+    total: 1,
+  });
 
-  dependencies.saveCache();
+  dependencies.sendProgress?.({
+    phase: 'Saving Graph Cache',
+    current: 0,
+    total: 1,
+  });
+  await dependencies.saveCache(progress => {
+    dependencies.sendProgress?.({
+      phase: 'Saving Graph Cache',
+      current: progress.current,
+      total: progress.total,
+    });
+  });
+  dependencies.sendProgress?.({
+    phase: 'Saving Graph Cache',
+    current: 1,
+    total: 1,
+  });
   dependencies.logInfo(
     `[CodeGraphy] Graph built: ${graphData.nodes.length} nodes, ${graphData.edges.length} edges`,
   );

--- a/packages/core/src/graphCache/database/io/connection.ts
+++ b/packages/core/src/graphCache/database/io/connection.ts
@@ -66,3 +66,20 @@ export function withConnection<T>(
     database.closeSync();
   }
 }
+
+export async function withConnectionAsync<T>(
+  databasePath: string,
+  callback: (connection: lb.Connection) => Promise<T>,
+): Promise<T> {
+  const database = new Database(databasePath);
+  const connection = new Connection(database);
+
+  try {
+    connection.initSync();
+    ensureSchema(connection);
+    return await callback(connection);
+  } finally {
+    connection.closeSync();
+    database.closeSync();
+  }
+}

--- a/packages/core/src/graphCache/database/io/save.ts
+++ b/packages/core/src/graphCache/database/io/save.ts
@@ -1,9 +1,38 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { setImmediate as waitForImmediate } from 'node:timers/promises';
 import type { IWorkspaceAnalysisCache } from '../../../analysis/cache';
-import { runStatementSync, withConnection } from './connection';
+import { runStatementSync, withConnection, withConnectionAsync } from './connection';
 import { ensureDatabaseDirectory, getWorkspaceAnalysisDatabasePath } from './paths';
-import { persistAnalysisEntry, sortedCacheEntries } from '../query/write';
+import {
+  persistAnalysisEntry,
+  persistAnalysisEntryAsync,
+  sortedCacheEntries,
+} from '../query/write';
+
+export interface WorkspaceAnalysisDatabaseSaveProgress {
+  current: number;
+  total: number;
+}
+
+export interface WorkspaceAnalysisDatabaseSaveOptions {
+  onProgress?: (progress: WorkspaceAnalysisDatabaseSaveProgress) => void;
+  yieldEvery?: number;
+}
+
+function createTemporaryDatabasePath(databasePath: string): string {
+  return `${databasePath}.${process.pid}.${Date.now()}.tmp`;
+}
+
+function replaceDatabaseCache(tempDatabasePath: string, databasePath: string): void {
+  fs.renameSync(tempDatabasePath, databasePath);
+}
+
+function cleanupTemporaryDatabase(tempDatabasePath: string): void {
+  if (fs.existsSync(tempDatabasePath)) {
+    fs.rmSync(tempDatabasePath, { force: true });
+  }
+}
 
 export function saveWorkspaceAnalysisDatabaseCache(
   workspaceRoot: string,
@@ -14,16 +43,69 @@ export function saveWorkspaceAnalysisDatabaseCache(
   if (!fs.existsSync(path.dirname(databasePath))) {
     return;
   }
+  const tempDatabasePath = createTemporaryDatabasePath(databasePath);
 
-  withConnection(databasePath, (connection) => {
-    runStatementSync(connection, 'MATCH (entry:FileAnalysis) DELETE entry');
-    runStatementSync(connection, 'MATCH (entry:Symbol) DELETE entry');
-    runStatementSync(connection, 'MATCH (entry:Relation) DELETE entry');
+  try {
+    withConnection(tempDatabasePath, (connection) => {
+      runStatementSync(connection, 'MATCH (entry:FileAnalysis) DELETE entry');
+      runStatementSync(connection, 'MATCH (entry:Symbol) DELETE entry');
+      runStatementSync(connection, 'MATCH (entry:Relation) DELETE entry');
 
-    for (const [filePath, entry] of sortedCacheEntries(cache)) {
-      persistAnalysisEntry(connection, filePath, entry);
-    }
-  });
+      for (const [filePath, entry] of sortedCacheEntries(cache)) {
+        persistAnalysisEntry(connection, filePath, entry);
+      }
+    });
+    replaceDatabaseCache(tempDatabasePath, databasePath);
+  } catch (error) {
+    cleanupTemporaryDatabase(tempDatabasePath);
+    throw error;
+  }
+}
+
+export async function saveWorkspaceAnalysisDatabaseCacheAsync(
+  workspaceRoot: string,
+  cache: IWorkspaceAnalysisCache,
+  options: WorkspaceAnalysisDatabaseSaveOptions = {},
+): Promise<void> {
+  ensureDatabaseDirectory(workspaceRoot);
+  const databasePath = getWorkspaceAnalysisDatabasePath(workspaceRoot);
+  if (!fs.existsSync(path.dirname(databasePath))) {
+    return;
+  }
+
+  const entries = sortedCacheEntries(cache);
+  const total = entries.length;
+  const yieldEvery = options.yieldEvery ?? 100;
+  const tempDatabasePath = createTemporaryDatabasePath(databasePath);
+  options.onProgress?.({ current: 0, total });
+
+  try {
+    await withConnectionAsync(tempDatabasePath, async (connection) => {
+      runStatementSync(connection, 'MATCH (entry:FileAnalysis) DELETE entry');
+      runStatementSync(connection, 'MATCH (entry:Symbol) DELETE entry');
+      runStatementSync(connection, 'MATCH (entry:Relation) DELETE entry');
+
+      let current = 0;
+      let statementsSinceYield = 0;
+      const yieldAfterStatement = async (): Promise<void> => {
+        statementsSinceYield += 1;
+        if (yieldEvery > 0 && statementsSinceYield >= yieldEvery) {
+          statementsSinceYield = 0;
+          await waitForImmediate();
+        }
+      };
+
+      for (const [filePath, entry] of entries) {
+        await persistAnalysisEntryAsync(connection, filePath, entry, yieldAfterStatement);
+        current += 1;
+        options.onProgress?.({ current, total });
+      }
+    });
+    replaceDatabaseCache(tempDatabasePath, databasePath);
+  } catch (error) {
+    cleanupTemporaryDatabase(tempDatabasePath);
+    throw error;
+  }
 }
 
 export function clearWorkspaceAnalysisDatabaseCache(workspaceRoot: string): void {

--- a/packages/core/src/graphCache/database/query/write.ts
+++ b/packages/core/src/graphCache/database/query/write.ts
@@ -44,3 +44,23 @@ export function persistAnalysisEntry(
     runStatementSync(connection, createRelationStatement(filePath, relation, relationIndex));
   }
 }
+
+export async function persistAnalysisEntryAsync(
+  connection: lb.Connection,
+  filePath: string,
+  entry: IWorkspaceAnalysisCache['files'][string],
+  afterStatement: () => Promise<void>,
+): Promise<void> {
+  runStatementSync(connection, createFileAnalysisStatement(filePath, entry));
+  await afterStatement();
+
+  for (const symbol of entry.analysis.symbols ?? []) {
+    runStatementSync(connection, createSymbolStatement(symbol));
+    await afterStatement();
+  }
+
+  for (const [relationIndex, relation] of (entry.analysis.relations ?? []).entries()) {
+    runStatementSync(connection, createRelationStatement(filePath, relation, relationIndex));
+    await afterStatement();
+  }
+}

--- a/packages/core/src/graphCache/database/storage.ts
+++ b/packages/core/src/graphCache/database/storage.ts
@@ -7,6 +7,8 @@ import {
 import {
   clearWorkspaceAnalysisDatabaseCache as clearWorkspaceAnalysisDatabaseCacheImpl,
   saveWorkspaceAnalysisDatabaseCache as saveWorkspaceAnalysisDatabaseCacheImpl,
+  saveWorkspaceAnalysisDatabaseCacheAsync as saveWorkspaceAnalysisDatabaseCacheAsyncImpl,
+  type WorkspaceAnalysisDatabaseSaveOptions,
 } from './io/save';
 
 export type WorkspaceAnalysisDatabaseSnapshot = WorkspaceAnalysisDatabaseSnapshotImpl;
@@ -40,4 +42,12 @@ export function saveWorkspaceAnalysisDatabaseCache(
   cache: Parameters<typeof saveWorkspaceAnalysisDatabaseCacheImpl>[1],
 ): void {
   saveWorkspaceAnalysisDatabaseCacheImpl(workspaceRoot, cache);
+}
+
+export function saveWorkspaceAnalysisDatabaseCacheAsync(
+  workspaceRoot: string,
+  cache: Parameters<typeof saveWorkspaceAnalysisDatabaseCacheImpl>[1],
+  options?: WorkspaceAnalysisDatabaseSaveOptions,
+): Promise<void> {
+  return saveWorkspaceAnalysisDatabaseCacheAsyncImpl(workspaceRoot, cache, options);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,6 +100,7 @@ export {
   loadWorkspaceAnalysisDatabaseCache,
   readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCache,
+  saveWorkspaceAnalysisDatabaseCacheAsync,
 } from './graphCache/database/storage';
 export type {
   CoreEdgeKind,

--- a/packages/core/tests/analysis/workspaceAnalyze.test.ts
+++ b/packages/core/tests/analysis/workspaceAnalyze.test.ts
@@ -166,16 +166,46 @@ describe('pipeline/analysis/analyze', () => {
     expect(source._lastFileAnalysis).toBe(fileAnalysis);
     expect(source._lastFileConnections).toBe(fileConnections);
     expect(source._lastWorkspaceRoot).toBe('/workspace');
-    expect(dependencies.saveCache).toHaveBeenCalledOnce();
+    expect(dependencies.saveCache).toHaveBeenCalledWith(expect.any(Function));
     expect(dependencies.logInfo).toHaveBeenCalledWith('[CodeGraphy] Discovered 1 files in 4ms');
     expect(dependencies.logInfo).toHaveBeenCalledWith('[CodeGraphy] Graph built: 1 nodes, 1 edges');
     expect(dependencies.sendProgress).toHaveBeenNthCalledWith(1, {
-      phase: 'Analyzing Files',
+      phase: 'Discovering Files',
       current: 0,
       total: 1,
     });
     expect(dependencies.sendProgress).toHaveBeenNthCalledWith(2, {
+      phase: 'Discovering Files',
+      current: 1,
+      total: 1,
+    });
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(3, {
       phase: 'Analyzing Files',
+      current: 0,
+      total: 1,
+    });
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(4, {
+      phase: 'Analyzing Files',
+      current: 1,
+      total: 1,
+    });
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(5, {
+      phase: 'Building Graph',
+      current: 0,
+      total: 1,
+    });
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(6, {
+      phase: 'Building Graph',
+      current: 1,
+      total: 1,
+    });
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(7, {
+      phase: 'Saving Graph Cache',
+      current: 0,
+      total: 1,
+    });
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(8, {
+      phase: 'Saving Graph Cache',
       current: 1,
       total: 1,
     });

--- a/packages/core/tests/graphCache/database/storage.test.ts
+++ b/packages/core/tests/graphCache/database/storage.test.ts
@@ -13,6 +13,7 @@ import {
   loadWorkspaceAnalysisDatabaseCache,
   readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCache,
+  saveWorkspaceAnalysisDatabaseCacheAsync,
 } from '../../../src/graphCache/database/storage';
 
 const tempRoots = new Set<string>();
@@ -116,6 +117,44 @@ describe('workspace analysis database cache', { timeout: 30000 }, () => {
         },
       ],
     });
+  });
+
+  it('persists asynchronously and reports cache write progress', async () => {
+    const workspaceRoot = createWorkspaceRoot();
+    const cache: IWorkspaceAnalysisCache = {
+      version: WORKSPACE_ANALYSIS_CACHE_VERSION,
+      files: {
+        'src/first.ts': {
+          mtime: 1,
+          size: 10,
+          analysis: {
+            filePath: '/workspace/src/first.ts',
+            relations: [],
+          },
+        },
+        'src/second.ts': {
+          mtime: 2,
+          size: 20,
+          analysis: {
+            filePath: '/workspace/src/second.ts',
+            relations: [],
+          },
+        },
+      },
+    };
+    const progressUpdates: Array<{ current: number; total: number }> = [];
+
+    await saveWorkspaceAnalysisDatabaseCacheAsync(workspaceRoot, cache, {
+      onProgress: progress => progressUpdates.push(progress),
+      yieldEvery: 1,
+    });
+
+    expect(loadWorkspaceAnalysisDatabaseCache(workspaceRoot)).toEqual(cache);
+    expect(progressUpdates).toEqual([
+      { current: 0, total: 2 },
+      { current: 1, total: 2 },
+      { current: 2, total: 2 },
+    ]);
   });
 
   it('skips persistence when the workspace root no longer exists', () => {

--- a/packages/extension/src/e2e/suite/graph.test.ts
+++ b/packages/extension/src/e2e/suite/graph.test.ts
@@ -6,6 +6,7 @@
  * simulating what a user sees in the panel.
  */
 import * as assert from 'assert';
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { getCurrentE2EScenario } from '../scenarios';
@@ -37,6 +38,7 @@ let discoveredGraphPromise: Promise<void> | undefined;
 const CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD = 20_000;
 const CODEGRAPHY_ROOT_RENDERED_EDGE_THRESHOLD = 10_000;
 const CODEGRAPHY_ROOT_RENDERED_NODE_THRESHOLD = 5_000;
+const CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS = 600_000;
 
 function sortedStrings(values: readonly string[]): string[] {
   return [...values].sort();
@@ -99,6 +101,22 @@ function getScenarioPackagePlugin(): { pluginId: string; packageName: string } {
   }
 }
 
+function getWorkspaceRoot(): string {
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  assert.ok(workspaceRoot, 'Expected an open workspace folder');
+  return workspaceRoot;
+}
+
+function getGraphCachePath(): string {
+  return path.join(getWorkspaceRoot(), '.codegraphy', 'graph.lbug');
+}
+
+function getIndexTimeoutMs(): number {
+  return scenario.name === 'codegraphy-root'
+    ? CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS
+    : 30_000;
+}
+
 suite('Graph: Workspace Analysis', function () {
   this.timeout(60_000);
 
@@ -132,10 +150,20 @@ suite('Graph: Workspace Analysis', function () {
   });
 
   test('manual graph indexing creates scenario edges', async function() {
+    this.timeout(getIndexTimeoutMs());
+
     const api = await getAPI();
     await ensureIndexedGraph(api);
 
     const graphData = api.getGraphData();
+    if (scenario.name === 'codegraphy-root') {
+      assert.ok(
+        graphData.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        `Expected the CodeGraphy monorepo index to rebuild plugin edges, got ${graphData.edges.length}`,
+      );
+      return;
+    }
+
     const edgeIds = graphData.edges.map((edge) => String(edge.id));
     assertIncludesAllEdges(
       edgeIds,
@@ -325,6 +353,95 @@ suite('Graph: Workspace Analysis', function () {
       subscription.dispose();
     }
   });
+
+  test('CodeGraphy monorepo recreates the Graph Cache from a missing cache without dropping rebuilt edges', async function() {
+    if (scenario.name !== 'codegraphy-root') {
+      this.skip();
+      return;
+    }
+
+    this.timeout(CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS);
+
+    const api = await getAPI();
+    await ensureIndexedGraph(api);
+
+    const graphCachePath = getGraphCachePath();
+    assert.ok(fs.existsSync(graphCachePath), `Expected an existing Graph Cache at ${graphCachePath}`);
+    fs.unlinkSync(graphCachePath);
+    assert.ok(!fs.existsSync(graphCachePath), 'Expected the Graph Cache to be removed before reindexing');
+
+    indexedGraphPromise = undefined;
+    const progressPhases: string[] = [];
+    const graphUpdates: Array<{ nodes: number; edges: number }> = [];
+    const subscription = api.onExtensionMessage(message => {
+      const type = (message as { type?: string }).type;
+      if (type === 'GRAPH_INDEX_PROGRESS') {
+        progressPhases.push((message as { payload: { phase: string } }).payload.phase);
+        return;
+      }
+
+      if (type === 'GRAPH_DATA_UPDATED') {
+        const graphData = (message as { payload: import('../../shared/graph/contracts').IGraphData }).payload;
+        graphUpdates.push({
+          nodes: graphData.nodes.length,
+          edges: graphData.edges.length,
+        });
+      }
+    });
+
+    try {
+      const rebuiltGraph = waitForExtensionMessageWhere<{
+        type: 'GRAPH_DATA_UPDATED';
+        payload: import('../../shared/graph/contracts').IGraphData;
+      }>(
+        api,
+        'GRAPH_DATA_UPDATED',
+        message => message.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS,
+      );
+      const indexReady = waitForGraphIndexStatus(api, true, CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS);
+
+      await api.dispatchWebviewMessage({ type: 'INDEX_GRAPH' });
+      const rebuiltGraphMessage = await rebuiltGraph;
+      await indexReady;
+      await sleep(5_000);
+
+      assert.ok(
+        fs.existsSync(graphCachePath),
+        `Expected manual indexing to recreate the Graph Cache at ${graphCachePath}`,
+      );
+      assert.ok(
+        fs.statSync(graphCachePath).size > 0,
+        `Expected the recreated Graph Cache to contain data at ${graphCachePath}`,
+      );
+      assert.ok(
+        rebuiltGraphMessage.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        `Expected rebuilt graph edges, got ${rebuiltGraphMessage.payload.edges.length}. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+      assert.ok(
+        progressPhases.includes('Discovering Files'),
+        `Expected discovery progress before the cache file exists. Phases: ${progressPhases.join(', ')}`,
+      );
+      assert.ok(
+        progressPhases.includes('Saving Graph Cache'),
+        `Expected cache persistence progress while writing graph.lbug. Phases: ${progressPhases.join(', ')}`,
+      );
+
+      const firstRebuiltIndex = graphUpdates.findIndex(
+        update => update.edges > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+      );
+      const droppedAfterRebuild = graphUpdates.slice(firstRebuiltIndex + 1).find(
+        update => update.nodes > 0 && update.edges === 0,
+      );
+      assert.strictEqual(
+        droppedAfterRebuild,
+        undefined,
+        `Expected rebuilt plugin edges to stay present after indexing. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+    } finally {
+      subscription.dispose();
+    }
+  });
 });
 
 function waitForExtensionMessage(
@@ -388,8 +505,19 @@ async function ensureIndexedGraph(api: CodeGraphyAPI): Promise<void> {
   await vscode.commands.executeCommand('codegraphy.open');
 
   indexedGraphPromise ??= (async () => {
-    const graphUpdated = waitForExtensionMessage(api, 'GRAPH_DATA_UPDATED', 30_000);
-    const indexUpdated = waitForGraphIndexStatus(api, true, 30_000);
+    const timeoutMs = getIndexTimeoutMs();
+    const graphUpdated = scenario.name === 'codegraphy-root'
+      ? waitForExtensionMessageWhere<{
+        type: 'GRAPH_DATA_UPDATED';
+        payload: import('../../shared/graph/contracts').IGraphData;
+      }>(
+        api,
+        'GRAPH_DATA_UPDATED',
+        message => message.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        timeoutMs,
+      )
+      : waitForExtensionMessage(api, 'GRAPH_DATA_UPDATED', timeoutMs);
+    const indexUpdated = waitForGraphIndexStatus(api, true, timeoutMs);
     await api.dispatchWebviewMessage({ type: 'INDEX_GRAPH' });
     await Promise.all([graphUpdated, indexUpdated]);
     await sleep(500);

--- a/packages/extension/src/extension/graphView/analysis/execution/progress.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/progress.ts
@@ -25,7 +25,7 @@ export function createGraphViewAnalysisProgressForwarder(
   return (progress) => {
     handlers.sendIndexProgress?.({
       ...progress,
-      phase,
+      phase: progress.phase || phase,
     });
   };
 }

--- a/packages/extension/src/extension/graphView/groups/defaults/materialTheme/fileName.ts
+++ b/packages/extension/src/extension/graphView/groups/defaults/materialTheme/fileName.ts
@@ -1,9 +1,14 @@
 import type { MaterialMatch } from './model';
-import { findLongestPathMatch } from './pathMatch';
+import {
+  createMaterialPathRuleMatcher,
+  findLongestPathMatchWithMatcher,
+  type MaterialPathRuleMatcher,
+} from './pathMatch';
 
 export function matchMaterialFileName(
   nodeId: string,
   fileNames: Record<string, string>,
+  matcher: MaterialPathRuleMatcher = createMaterialPathRuleMatcher(fileNames),
 ): MaterialMatch | undefined {
-  return findLongestPathMatch(nodeId, fileNames, 'fileName');
+  return findLongestPathMatchWithMatcher(nodeId, matcher, 'fileName');
 }

--- a/packages/extension/src/extension/graphView/groups/defaults/materialTheme/files.ts
+++ b/packages/extension/src/extension/graphView/groups/defaults/materialTheme/files.ts
@@ -17,7 +17,9 @@ export function collectMaterialFileGroups(
       continue;
     }
 
-    const match = findMaterialMatch(node.id, theme.manifest);
+    const match = findMaterialMatch(node.id, theme.manifest, {
+      pathMatchers: theme.pathMatchers,
+    });
     if (!match) {
       continue;
     }

--- a/packages/extension/src/extension/graphView/groups/defaults/materialTheme/folderName.ts
+++ b/packages/extension/src/extension/graphView/groups/defaults/materialTheme/folderName.ts
@@ -1,11 +1,27 @@
 import type { MaterialMatch } from './model';
-import { findLongestPathMatch } from './pathMatch';
+import {
+  createMaterialPathRuleMatcher,
+  findLongestPathMatchWithMatcher,
+  type MaterialPathRuleMatcher,
+} from './pathMatch';
 
 export function matchMaterialFolderName(
   folderPath: string,
   folderNames: Record<string, string>,
   folderNamesExpanded: Record<string, string> = {},
+  matchers: {
+    folderNames?: MaterialPathRuleMatcher;
+    folderNamesExpanded?: MaterialPathRuleMatcher;
+  } = {},
 ): MaterialMatch | undefined {
-  return findLongestPathMatch(folderPath, folderNames, 'folderName')
-    ?? findLongestPathMatch(folderPath, folderNamesExpanded, 'folderName');
+  return findLongestPathMatchWithMatcher(
+    folderPath,
+    matchers.folderNames ?? createMaterialPathRuleMatcher(folderNames),
+    'folderName',
+  )
+    ?? findLongestPathMatchWithMatcher(
+      folderPath,
+      matchers.folderNamesExpanded ?? createMaterialPathRuleMatcher(folderNamesExpanded),
+      'folderName',
+    );
 }

--- a/packages/extension/src/extension/graphView/groups/defaults/materialTheme/folders.ts
+++ b/packages/extension/src/extension/graphView/groups/defaults/materialTheme/folders.ts
@@ -23,7 +23,10 @@ function getFolderMatch(
   folderPath: string,
   theme: MaterialThemeCacheEntry,
 ): MaterialMatch | undefined {
-  const matched = findMaterialMatch(folderPath, theme.manifest, { nodeType: 'folder' });
+  const matched = findMaterialMatch(folderPath, theme.manifest, {
+    nodeType: 'folder',
+    pathMatchers: theme.pathMatchers,
+  });
   if (matched) {
     return matched;
   }

--- a/packages/extension/src/extension/graphView/groups/defaults/materialTheme/manifest.ts
+++ b/packages/extension/src/extension/graphView/groups/defaults/materialTheme/manifest.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { MaterialThemeCacheEntry, MaterialIconManifest } from './model';
+import { createMaterialPathRuleMatcher } from './pathMatch';
 
 const materialThemeCache = new Map<string, MaterialThemeCacheEntry | null>();
 const materialIconThemePackageName = 'material-icon-theme';
@@ -43,6 +44,17 @@ export function loadMaterialTheme(extensionUri: vscode.Uri): MaterialThemeCacheE
     iconDataByName: new Map(),
     manifest,
     manifestPath,
+    pathMatchers: {
+      fileNames: manifest.fileNames
+        ? createMaterialPathRuleMatcher(manifest.fileNames)
+        : undefined,
+      folderNames: manifest.folderNames
+        ? createMaterialPathRuleMatcher(manifest.folderNames)
+        : undefined,
+      folderNamesExpanded: manifest.folderNamesExpanded
+        ? createMaterialPathRuleMatcher(manifest.folderNamesExpanded)
+        : undefined,
+    },
   } satisfies MaterialThemeCacheEntry;
 
   materialThemeCache.set(cacheKey, theme);

--- a/packages/extension/src/extension/graphView/groups/defaults/materialTheme/match.ts
+++ b/packages/extension/src/extension/graphView/groups/defaults/materialTheme/match.ts
@@ -1,4 +1,4 @@
-import type { MaterialIconManifest, MaterialMatch } from './model';
+import type { MaterialIconManifest, MaterialMatch, MaterialThemePathMatchers } from './model';
 import { matchMaterialFileExtension } from './fileExtension';
 import { matchMaterialFileName } from './fileName';
 import { matchMaterialFolderName } from './folderName';
@@ -8,32 +8,39 @@ import { getMaterialBaseName } from './paths';
 export function findMaterialMatch(
   nodeId: string,
   manifest: MaterialIconManifest,
-  options?: { nodeType?: 'file' | 'folder' },
+  options?: { nodeType?: 'file' | 'folder'; pathMatchers?: MaterialThemePathMatchers },
 ): MaterialMatch | undefined {
   return options?.nodeType === 'folder'
-    ? findFolderMaterialMatch(nodeId, manifest)
-    : findFileMaterialMatch(nodeId, manifest);
+    ? findFolderMaterialMatch(nodeId, manifest, options.pathMatchers)
+    : findFileMaterialMatch(nodeId, manifest, options?.pathMatchers);
 }
 
 function findFolderMaterialMatch(
   nodeId: string,
   manifest: MaterialIconManifest,
+  pathMatchers: MaterialThemePathMatchers | undefined,
 ): MaterialMatch | undefined {
   return manifest.folderNames
-    ? matchMaterialFolderName(nodeId, manifest.folderNames, manifest.folderNamesExpanded)
+    ? matchMaterialFolderName(
+      nodeId,
+      manifest.folderNames,
+      manifest.folderNamesExpanded,
+      pathMatchers,
+    )
     : undefined;
 }
 
 function findFileMaterialMatch(
   nodeId: string,
   manifest: MaterialIconManifest,
+  pathMatchers: MaterialThemePathMatchers | undefined,
 ): MaterialMatch | undefined {
   const baseName = getMaterialBaseName(nodeId);
   if (!baseName) {
     return undefined;
   }
 
-  return findFileNameMaterialMatch(nodeId, manifest)
+  return findFileNameMaterialMatch(nodeId, manifest, pathMatchers)
     ?? findFileExtensionMaterialMatch(baseName, manifest)
     ?? findLanguageMaterialMatch(baseName, manifest);
 }
@@ -41,9 +48,10 @@ function findFileMaterialMatch(
 function findFileNameMaterialMatch(
   nodeId: string,
   manifest: MaterialIconManifest,
+  pathMatchers: MaterialThemePathMatchers | undefined,
 ): MaterialMatch | undefined {
   return manifest.fileNames
-    ? matchMaterialFileName(nodeId, manifest.fileNames)
+    ? matchMaterialFileName(nodeId, manifest.fileNames, pathMatchers?.fileNames)
     : undefined;
 }
 

--- a/packages/extension/src/extension/graphView/groups/defaults/materialTheme/model.ts
+++ b/packages/extension/src/extension/graphView/groups/defaults/materialTheme/model.ts
@@ -18,6 +18,13 @@ export interface MaterialThemeCacheEntry {
   iconDataByName: Map<string, MaterialIconData>;
   manifest: MaterialIconManifest;
   manifestPath: string;
+  pathMatchers: MaterialThemePathMatchers;
+}
+
+export interface MaterialThemePathMatchers {
+  fileNames?: MaterialPathRuleMatcher;
+  folderNames?: MaterialPathRuleMatcher;
+  folderNamesExpanded?: MaterialPathRuleMatcher;
 }
 
 export interface MaterialMatch {
@@ -27,3 +34,4 @@ export interface MaterialMatch {
 }
 
 export const DEFAULT_MATERIAL_COLOR = '#90A4AE';
+import type { MaterialPathRuleMatcher } from './pathMatch';

--- a/packages/extension/src/extension/graphView/groups/defaults/materialTheme/pathMatch.ts
+++ b/packages/extension/src/extension/graphView/groups/defaults/materialTheme/pathMatch.ts
@@ -10,24 +10,71 @@ interface PathMatchContext {
   subjectPath: string;
 }
 
+interface MaterialPathRuleEntry {
+  iconName: string;
+  lowerRule: string;
+  normalizedRule: string;
+}
+
+export interface MaterialPathRuleMatcher {
+  baseNameRules: Map<string, MaterialPathRuleEntry>;
+  pathRules: MaterialPathRuleEntry[];
+}
+
+export function createMaterialPathRuleMatcher(
+  rules: Record<string, string>,
+): MaterialPathRuleMatcher {
+  const baseNameRules = new Map<string, MaterialPathRuleEntry>();
+  const pathRules: MaterialPathRuleEntry[] = [];
+
+  for (const [ruleKey, iconName] of Object.entries(rules)) {
+    const normalizedRule = normalizePathSeparators(ruleKey);
+    const lowerRule = normalizedRule.toLowerCase();
+    const entry = { iconName, lowerRule, normalizedRule };
+
+    if (normalizedRule.includes('/')) {
+      pathRules.push(entry);
+      continue;
+    }
+
+    baseNameRules.set(lowerRule, entry);
+  }
+
+  pathRules.sort((left, right) => right.normalizedRule.length - left.normalizedRule.length);
+
+  return { baseNameRules, pathRules };
+}
+
 export function findLongestPathMatch(
   subjectPath: string,
   rules: Record<string, string>,
   kind: PathMatchKind,
 ): MaterialMatch | undefined {
-  const context = getPathMatchContext(subjectPath);
-  let bestMatch: MaterialMatch | undefined;
+  return findLongestPathMatchWithMatcher(
+    subjectPath,
+    createMaterialPathRuleMatcher(rules),
+    kind,
+  );
+}
 
-  for (const [ruleKey, iconName] of Object.entries(rules)) {
-    const match = createPathMatch(context, ruleKey, iconName, kind);
-    if (!match || (bestMatch && bestMatch.key.length >= match.key.length)) {
+export function findLongestPathMatchWithMatcher(
+  subjectPath: string,
+  matcher: MaterialPathRuleMatcher,
+  kind: PathMatchKind,
+): MaterialMatch | undefined {
+  const context = getPathMatchContext(subjectPath);
+  for (const rule of matcher.pathRules) {
+    if (!matchesPathRule(context, rule.normalizedRule, rule.lowerRule)) {
       continue;
     }
 
-    bestMatch = match;
+    return createMaterialMatch(context, rule, kind);
   }
 
-  return bestMatch;
+  const baseNameRule = matcher.baseNameRules.get(context.lowerBaseName);
+  return baseNameRule
+    ? createMaterialMatch(context, baseNameRule, kind)
+    : undefined;
 }
 
 function getPathMatchContext(subjectPath: string): PathMatchContext {
@@ -40,21 +87,14 @@ function getPathMatchContext(subjectPath: string): PathMatchContext {
   };
 }
 
-function createPathMatch(
+function createMaterialMatch(
   context: PathMatchContext,
-  ruleKey: string,
-  iconName: string,
+  rule: MaterialPathRuleEntry,
   kind: PathMatchKind,
 ): MaterialMatch | undefined {
-  const normalizedRule = normalizePathSeparators(ruleKey);
-  const lowerRule = normalizedRule.toLowerCase();
-  if (!matchesPathRule(context, normalizedRule, lowerRule)) {
-    return undefined;
-  }
-
   return {
-    iconName,
-    key: resolveMatchedPathKey(context, normalizedRule, lowerRule),
+    iconName: rule.iconName,
+    key: resolveMatchedPathKey(context, rule.normalizedRule, rule.lowerRule),
     kind,
   };
 }

--- a/packages/extension/src/extension/pipeline/analysis/run.ts
+++ b/packages/extension/src/extension/pipeline/analysis/run.ts
@@ -3,7 +3,7 @@ import type { FileDiscovery } from '@codegraphy-dev/core';
 import type { IGraphData } from '../../../shared/graph/contracts';
 import type { Configuration } from '../../config/reader';
 import type { IWorkspaceAnalysisCache } from '../cache';
-import { saveWorkspaceAnalysisDatabaseCache } from '../database/cache/storage';
+import { saveWorkspaceAnalysisDatabaseCacheAsync } from '../database/cache/storage';
 import {
   analyzeWorkspaceWithAnalyzer,
   type WorkspacePipelineAnalysisSource,
@@ -38,11 +38,13 @@ export function runWorkspacePipelineAnalysis(
       logInfo: message => {
         console.log(message);
       },
-      saveCache: () => {
+      saveCache: async onProgress => {
         const workspaceRoot = getWorkspaceRoot();
         if (workspaceRoot) {
           try {
-            saveWorkspaceAnalysisDatabaseCache(workspaceRoot, cache);
+            await saveWorkspaceAnalysisDatabaseCacheAsync(workspaceRoot, cache, {
+              onProgress,
+            });
           } catch (error) {
             console.warn('[CodeGraphy] Failed to persist repo-local analysis cache.', error);
           }

--- a/packages/extension/src/extension/pipeline/database/cache/storage.ts
+++ b/packages/extension/src/extension/pipeline/database/cache/storage.ts
@@ -5,4 +5,5 @@ export {
   loadWorkspaceAnalysisDatabaseCache,
   readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCache,
+  saveWorkspaceAnalysisDatabaseCacheAsync,
 } from '@codegraphy-dev/core';

--- a/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
@@ -179,7 +179,7 @@ export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipeline
     return this.analyze(filterPatterns, disabledPlugins, signal, progress => {
       onProgress?.({
         ...progress,
-        phase: 'Refreshing Index',
+        phase: progress.phase || 'Refreshing Index',
       });
     });
   }

--- a/packages/extension/src/extension/pipeline/service/runtime/refresh.ts
+++ b/packages/extension/src/extension/pipeline/service/runtime/refresh.ts
@@ -83,7 +83,7 @@ export async function refreshWorkspacePipelineChangedFiles(
       progress => {
         dependencies.onProgress?.({
           ...progress,
-          phase: 'Applying Changes',
+          phase: progress.phase || 'Applying Changes',
         });
       },
     );
@@ -103,7 +103,7 @@ export async function refreshWorkspacePipelineChangedFiles(
       progress => {
         dependencies.onProgress?.({
           ...progress,
-          phase: 'Applying Changes',
+          phase: progress.phase || 'Applying Changes',
         });
       },
     );

--- a/packages/extension/tests/extension/graphView/analysis/execution/progress.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/progress.test.ts
@@ -6,11 +6,27 @@ import {
 import { createExecutionHandlers } from './fixtures';
 
 describe('graph view analysis execution progress', () => {
-  it('forwards progress updates with the phase label for the current mode', () => {
+  it('preserves analyzer progress phase labels', () => {
     const { handlers } = createExecutionHandlers();
 
     createGraphViewAnalysisProgressForwarder('refresh', handlers)({
-      phase: 'ignored',
+      phase: 'Saving Graph Cache',
+      current: 2,
+      total: 5,
+    });
+
+    expect(handlers.sendIndexProgress).toHaveBeenCalledWith({
+      phase: 'Saving Graph Cache',
+      current: 2,
+      total: 5,
+    });
+  });
+
+  it('falls back to the mode label when a progress update does not name its phase', () => {
+    const { handlers } = createExecutionHandlers();
+
+    createGraphViewAnalysisProgressForwarder('refresh', handlers)({
+      phase: '',
       current: 2,
       total: 5,
     });

--- a/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/files.test.ts
+++ b/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/files.test.ts
@@ -22,6 +22,7 @@ function createTheme(): MaterialThemeCacheEntry {
   return {
     iconDataByName: new Map(),
     manifestPath,
+    pathMatchers: {},
     manifest: {
       fileExtensions: { ts: 'typescript' },
       fileNames: { 'readme.md': 'readme' },

--- a/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/folders.test.ts
+++ b/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/folders.test.ts
@@ -28,6 +28,7 @@ function createTheme(): MaterialThemeCacheEntry {
   return {
     iconDataByName: new Map(),
     manifestPath,
+    pathMatchers: {},
     manifest: {
       folder: 'folder',
       rootFolder: 'folder-root',

--- a/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/icons.test.ts
+++ b/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/icons.test.ts
@@ -23,6 +23,7 @@ function createTheme(): MaterialThemeCacheEntry {
     iconDataByName: new Map(),
     manifest: {},
     manifestPath,
+    pathMatchers: {},
   };
 }
 

--- a/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/pathMatch.test.ts
+++ b/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/pathMatch.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { findLongestPathMatch } from '../../../../../../src/extension/graphView/groups/defaults/materialTheme/pathMatch';
+import {
+  createMaterialPathRuleMatcher,
+  findLongestPathMatch,
+  findLongestPathMatchWithMatcher,
+} from '../../../../../../src/extension/graphView/groups/defaults/materialTheme/pathMatch';
 
 describe('graphView/materialTheme/pathMatch', () => {
   it('matches basename rules case-insensitively', () => {
@@ -16,6 +20,19 @@ describe('graphView/materialTheme/pathMatch', () => {
     }, 'fileName')).toEqual({
       iconName: 'vite',
       key: 'web/vite.config.ts',
+      kind: 'fileName',
+    });
+  });
+
+  it('prefers scoped path rules over basename rules when using a precompiled matcher', () => {
+    const matcher = createMaterialPathRuleMatcher({
+      'vite.config.ts': 'generic-vite',
+      'apps/web/vite.config.ts': 'web-vite',
+    });
+
+    expect(findLongestPathMatchWithMatcher('apps/web/vite.config.ts', matcher, 'fileName')).toEqual({
+      iconName: 'web-vite',
+      key: 'apps/web/vite.config.ts',
       kind: 'fileName',
     });
   });

--- a/packages/extension/tests/extension/pipeline/analysis/run.test.ts
+++ b/packages/extension/tests/extension/pipeline/analysis/run.test.ts
@@ -17,8 +17,8 @@ describe('pipeline/analysis/run', () => {
       .mockResolvedValue({ nodes: [], edges: [] });
     const showWarningMessageSpy = vi.fn();
     const saveWorkspaceAnalysisDatabaseCacheSpy = vi
-      .spyOn(databaseCacheModule, 'saveWorkspaceAnalysisDatabaseCache')
-      .mockImplementation(() => undefined);
+      .spyOn(databaseCacheModule, 'saveWorkspaceAnalysisDatabaseCacheAsync')
+      .mockResolvedValue(undefined);
     (vscode.window as Record<string, unknown>).showWarningMessage = showWarningMessageSpy;
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const source = {
@@ -86,8 +86,10 @@ describe('pipeline/analysis/run', () => {
     expect(logSpy).toHaveBeenCalledWith('hello');
     dependencies.showWarningMessage('warning');
     expect(showWarningMessageSpy).toHaveBeenCalledWith('warning');
-    dependencies.saveCache();
-    expect(saveWorkspaceAnalysisDatabaseCacheSpy).toHaveBeenCalledWith('/workspace', cache);
+    await dependencies.saveCache();
+    expect(saveWorkspaceAnalysisDatabaseCacheSpy).toHaveBeenCalledWith('/workspace', cache, {
+      onProgress: undefined,
+    });
   });
 
   it('passes empty user filters and disabled sets when they are omitted', async () => {
@@ -134,8 +136,8 @@ describe('pipeline/analysis/run', () => {
       .spyOn(analyzeModule, 'analyzeWorkspaceWithAnalyzer')
       .mockResolvedValue({ nodes: [], edges: [] });
     const saveWorkspaceAnalysisDatabaseCacheSpy = vi
-      .spyOn(databaseCacheModule, 'saveWorkspaceAnalysisDatabaseCache')
-      .mockImplementation(() => undefined);
+      .spyOn(databaseCacheModule, 'saveWorkspaceAnalysisDatabaseCacheAsync')
+      .mockResolvedValue(undefined);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await runWorkspacePipelineAnalysis(
@@ -168,7 +170,7 @@ describe('pipeline/analysis/run', () => {
       () => undefined,
     );
 
-    analyzeWorkspaceWithAnalyzerSpy.mock.calls[0][1].saveCache();
+    await analyzeWorkspaceWithAnalyzerSpy.mock.calls[0][1].saveCache();
     expect(saveWorkspaceAnalysisDatabaseCacheSpy).not.toHaveBeenCalled();
     expect(warnSpy).not.toHaveBeenCalled();
   });
@@ -178,7 +180,7 @@ describe('pipeline/analysis/run', () => {
       .spyOn(analyzeModule, 'analyzeWorkspaceWithAnalyzer')
       .mockResolvedValue({ nodes: [], edges: [] });
     const failure = new Error('db unavailable');
-    vi.spyOn(databaseCacheModule, 'saveWorkspaceAnalysisDatabaseCache').mockImplementation(() => {
+    vi.spyOn(databaseCacheModule, 'saveWorkspaceAnalysisDatabaseCacheAsync').mockImplementation(async () => {
       throw failure;
     });
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -213,7 +215,7 @@ describe('pipeline/analysis/run', () => {
       () => '/workspace',
     );
 
-    analyzeWorkspaceWithAnalyzerSpy.mock.calls[0][1].saveCache();
+    await analyzeWorkspaceWithAnalyzerSpy.mock.calls[0][1].saveCache();
     expect(warnSpy).toHaveBeenCalledWith(
       '[CodeGraphy] Failed to persist repo-local analysis cache.',
       failure,

--- a/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
@@ -324,8 +324,15 @@ describe('pipeline/service/discoveryFacade', () => {
     }) => void;
     forwardedProgress({ phase: 'Analyzing', current: 2, total: 5 });
     expect(onProgress).toHaveBeenCalledWith({
-      phase: 'Refreshing Index',
+      phase: 'Analyzing',
       current: 2,
+      total: 5,
+    });
+
+    forwardedProgress({ phase: '', current: 3, total: 5 });
+    expect(onProgress).toHaveBeenCalledWith({
+      phase: 'Refreshing Index',
+      current: 3,
       total: 5,
     });
   });

--- a/packages/extension/tests/extension/pipeline/service/runtime/refresh.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/runtime/refresh.test.ts
@@ -63,7 +63,7 @@ describe('pipeline/service/refresh', () => {
     const graph = await refreshWorkspacePipelineChangedFiles(source as never, dependencies as never);
     const forwardedProgress = source.analyze.mock.calls[0][3];
 
-    forwardedProgress({ phase: 'Ignored', current: 2, total: 5 });
+    forwardedProgress({ phase: 'Analyzing Files', current: 2, total: 5 });
 
     expect(dependencies.toWorkspaceRelativePath).toHaveBeenCalledWith('/workspace', '/workspace/src/a.ts');
     expect(source.analyze).toHaveBeenCalledWith(
@@ -73,7 +73,7 @@ describe('pipeline/service/refresh', () => {
       expect.any(Function),
     );
     expect(dependencies.onProgress).toHaveBeenCalledWith({
-      phase: 'Applying Changes',
+      phase: 'Analyzing Files',
       current: 2,
       total: 5,
     });

--- a/packages/extension/tests/extension/pluginIntegration/installed/activation.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/installed/activation.test.ts
@@ -16,7 +16,7 @@ const mockState = vi.hoisted(() => ({
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
-    saveWorkspaceAnalysisDatabaseCache: vi.fn(),
+    saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
   },
 }));
 
@@ -44,7 +44,7 @@ vi.mock('../../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
-  saveWorkspaceAnalysisDatabaseCache: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache,
+  saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
 }));
 
 function createContext() {
@@ -155,6 +155,6 @@ describe('extension/pluginIntegration/installedPluginActivation', () => {
     expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
       workspaceFixture!.workspacePath,
     );
-    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache).toHaveBeenCalled();
+    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 });

--- a/packages/extension/tests/extension/pluginIntegration/installed/statuses.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/installed/statuses.test.ts
@@ -16,7 +16,7 @@ const mockState = vi.hoisted(() => ({
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
-    saveWorkspaceAnalysisDatabaseCache: vi.fn(),
+    saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
   },
 }));
 
@@ -44,7 +44,7 @@ vi.mock('../../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
-  saveWorkspaceAnalysisDatabaseCache: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache,
+  saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
 }));
 
 function createContext() {
@@ -264,7 +264,7 @@ describe('extension/pluginIntegration/installedPluginStatuses', () => {
     expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
       workspaceFixture!.workspacePath,
     );
-    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache).toHaveBeenCalled();
+    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 
   it('sends package-enabled graph view contributions to the webview after startup', async () => {

--- a/packages/extension/tests/extension/pluginIntegration/typescript.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/typescript.test.ts
@@ -17,7 +17,7 @@ const mockState = vi.hoisted(() => ({
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
-    saveWorkspaceAnalysisDatabaseCache: vi.fn(),
+    saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
   },
 }));
 
@@ -41,7 +41,7 @@ vi.mock('../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
-  saveWorkspaceAnalysisDatabaseCache: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache,
+  saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
 }));
 
 function createContext() {
@@ -154,6 +154,6 @@ describe('extension/pluginIntegration/typescript', () => {
     expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
       workspaceFixture!.workspacePath,
     );
-    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache).toHaveBeenCalled();
+    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 });


### PR DESCRIPTION
## Summary
- make Graph Cache persistence cooperative and atomic so root indexing can keep the extension host responsive and never replaces a good cache with a partial write
- preserve detailed analysis progress phases, including discovery/build/save, during manual indexing and refresh flows
- precompile Material Icon Theme path matchers to avoid the large post-index grouping stall that made the graph view look like it refreshed and dropped edges
- add a CodeGraphy-root E2E regression that deletes `.codegraphy/graph.lbug`, manually indexes, verifies the Graph Cache is recreated, and asserts rebuilt edges do not drop to a zero-edge graph after the rebuild

## Validation
- `pnpm run test`
- `pnpm run lint`
- `pnpm run typecheck`
- `CODEGRAPHY_E2E_ONLY_SCENARIO=codegraphy-root CODEGRAPHY_E2E_GREP="recreates the Graph Cache" pnpm --filter @codegraphy-dev/extension run test:vscode`
