### PR TITLE
Smooth Graph Cache startup and plugin lifecycle

### DIFF
--- a/.changeset/smooth-cache-startup.md
+++ b/.changeset/smooth-cache-startup.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Keep the cached graph visible during startup and plugin changes while Graph Cache sync runs in the background.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -203,8 +203,12 @@ The workspace-local LadybugDB graph data at `<workspace-root>/.codegraphy/graph.
 _Avoid_: Saved index, saved DB, CodeGraphy database when speaking in domain terms
 
 **Live Update**:
-An incremental graph update from repo changes after indexing has already produced a cache.
+An incremental graph update from CodeGraphy Workspace changes after indexing has already produced a cache.
 _Avoid_: Re-index, refresh
+
+**Graph Cache Sync**:
+A background catch-up pass that runs after cached graph data has already been rendered. Graph Cache Sync compares the workspace-local Graph Cache with current runtime inputs such as enabled plugins, plugin signatures, settings signatures, schema metadata, and pending changed files, then updates graph data without replacing the whole Graph View with a loading state.
+_Avoid_: Re-index when a readable cache is already being shown, reconciliation
 
 **Refresh**:
 A user-triggered graph rerender that re-runs the force graph simulation without reprocessing graph data.
@@ -459,9 +463,11 @@ _Avoid_: Graph export
 - Structured data and styling formats such as JSON and CSS are outside **Core Tree-sitter Language Coverage** unless a separate relationship model is defined for them.
 - C and C++ **Core Tree-sitter Language Coverage** should include local include relationships, useful code symbols, examples, and docs; full compiler include-path semantics, macros, templates, and conditional compilation are deeper project-aware work.
 - **Graph Projection** produces the **Relationship Graph** data that later flows through **Graph Scope**, **Filter**, **Search**, and view settings.
-- **Graph Cache** stores indexed graph data so reopening the repo does not require full **Indexing**.
+- **Graph Cache** stores indexed graph data so reopening the CodeGraphy Workspace does not require full **Indexing**.
 - **Live Updates** keep the **Graph Cache** and graph data current as files change.
+- **Graph Cache Sync** keeps a readable but out-of-date **Graph Cache** useful by rendering cached graph data first, then updating it in the background.
 - Any graph-changing update from added files, renamed files, changed code, or settings that affect graph data should be saved to **Graph Cache**.
+- A stale status is a reporting signal that **Graph Cache Sync** is needed; it does not mean the **Graph Cache** should be cleared or hidden.
 - **CodeGraphy MCP** is a lightweight command and query adapter; the **Core Package** owns **Graph Cache** access, **Indexing**, plugin wiring, and Graph Query execution.
 - **CodeGraphy MCP** runs against the current or explicit **CodeGraphy Workspace** path and should not require a prior repo selection or VS Code focus for normal Indexing and Graph Query.
 - **CodeGraphy MCP** should not be limited to the **Visible Graph**; it should ask the **Core Package** for **Relationship Graph** data and allow agent queries to apply **Graph Scope**, **Filter**, and **Search** to reduce noise.
@@ -470,6 +476,7 @@ _Avoid_: Graph export
 - **Refresh Graph** and **Re-index Workspace** should be distinct UI actions.
 - **Refresh** only reruns the force graph simulation and does not process source data.
 - **Re-index** reruns **Indexing**, updates graph data, persists it to **Graph Cache**, and then **Refreshes** the graph.
+- The Graph View can show `Loading graph...` before the first graph render for a webview page. After the first render, later **Graph Cache Sync**, **Live Update**, or **Re-index** work should keep the current **Visible Graph** rendered and use graph-local progress.
 - CodeGraphy has two **Views**: the **Graph View** and the **Timeline View**.
 - The **Graph View** contains the **Visible Graph**, search, filters, popups, settings UI, and overlay controls.
 - The **Visible Graph** is graph data shown inside the **Graph View**, not the whole view.

--- a/packages/extension/docs/README.md
+++ b/packages/extension/docs/README.md
@@ -3,6 +3,7 @@
 This folder documents the current `@codegraphy-dev/extension` package.
 
 - `boundaries.md` - package boundaries and ownership
+- `graph-cache-lifecycle.md` - Graph Cache startup, sync, plugin changes, and loading-state rules
 - `messages.md` - extension/webview message flow
 - `plugin-lifecycle.md` - plugin readiness and lifecycle
 - `testing.md` - package testing strategy and commands

--- a/packages/extension/docs/graph-cache-lifecycle.md
+++ b/packages/extension/docs/graph-cache-lifecycle.md
@@ -1,0 +1,52 @@
+# Graph Cache Lifecycle
+
+The Graph View should prefer a readable **Graph Cache** over a blank loading screen. A stale cache is still useful: it means the cached graph needs **Graph Cache Sync**, not that the graph should be hidden.
+
+## Startup
+
+`Loading graph...` is a webview-page startup state only. It is allowed while the extension has not yet delivered the first graph payload for that page.
+
+```mermaid
+flowchart TD
+  A["Webview page opens"] --> B["Startup shell shows Loading graph..."]
+  B --> C{"Readable Graph Cache exists?"}
+  C -->|"yes"| D["Render cached Relationship Graph"]
+  C -->|"no"| E["Run initial Indexing"]
+  E --> D
+  D --> F["Initial loading is finished"]
+```
+
+Once `Initial loading is finished`, the shell should not return to `Loading graph...` for that page. Later graph work belongs in graph-local progress UI while the current graph remains rendered.
+
+## Graph Cache Sync
+
+**Graph Cache Sync** is the background catch-up pass after a readable cached graph has already been shown. It checks the current runtime inputs against the saved Graph Cache, then updates the cache and the **Visible Graph** when new data is ready.
+
+Inputs that can require sync include:
+
+- enabled plugin packages changing
+- plugin signatures or available plugin ids changing
+- settings signatures changing
+- Graph Cache schema metadata changing
+- pending changed files from workspace file events
+
+Sync should be incremental whenever the changed scope is known. Plugin enablement should reprocess plugin-owned files. File saves, creates, renames, and deletes should update the affected file paths. Full Indexing is the fallback for no cache, unreadable cache, incompatible cache, or explicit user re-index.
+
+## Plugin Changes
+
+Package plugin enablement updates workspace settings, reloads workspace plugins, sends the refreshed plugin/control state, then reprocesses files owned by the enabled plugin. This lets the plugin add its nodes, relationships, edge types, decorations, filters, or webview contributions without blocking the whole **Graph View**.
+
+Package plugin disablement updates workspace settings and reloads workspace plugins, but it does not delete plugin-owned data from the Graph Cache. The **Visible Graph** filters disabled or unregistered plugin contributions out at projection time. Keeping the data lets re-enabling the plugin reuse cached work.
+
+Late external plugin registration follows the same rule: initialize the plugin, replay readiness when needed, then reprocess plugin-owned files. It must not clear the Graph Cache.
+
+## Progress UI
+
+The whole-view loading state is only for the first render. After that:
+
+- **Graph Cache Sync** may show graph-local progress.
+- **Live Updates** may show graph-local progress.
+- **Re-index Workspace** may show graph-local progress.
+- The current **Visible Graph**, tool rail, search, panels, and plugin list should remain usable unless a specific command is disabled while work is active.
+
+This keeps a refresh-window or plugin-toggle flow smooth: users see the cached graph immediately, CodeGraphy catches it up in the background, and the graph payload is replaced when the new data is ready.

--- a/packages/extension/docs/messages.md
+++ b/packages/extension/docs/messages.md
@@ -18,6 +18,8 @@ Typical path:
 
 The graph-view provider now composes its host bridge through explicit typed method-source adapters instead of mutating the class surface with `Object.assign`.
 
+Startup loading is a special case. The webview may show `Loading graph...` only before the first graph payload and bootstrap completion for that page. After the first graph render, later Indexing, Graph Cache Sync, plugin changes, and file updates should keep the current graph rendered and use graph-local progress messages such as `GRAPH_INDEX_PROGRESS`.
+
 ## Webview to extension
 
 The webview sends user interaction and UI state messages back to the host.
@@ -40,12 +42,13 @@ Plugin-facing messaging is layered on top of the core bridge.
 
 - The extension tracks readiness and plugin lifecycle state.
 - Webview plugin APIs send plugin-scoped actions through the provider bridge.
+- Plugin enablement and late external registration reprocess plugin-owned files instead of clearing the Graph Cache.
 - Shared payload ownership is explicit:
-- `src/shared/graph/types.ts` for graph data
-- `src/shared/files/info.ts` for file info
-- `src/shared/settings/` for settings snapshots and display/runtime modes
-- `src/shared/plugins/` for plugin status, decorations, and context menu payloads
-- `src/shared/view/types.ts` and `src/shared/timeline/types.ts` for view and timeline payloads
+  - `src/shared/graph/types.ts` for graph data
+  - `src/shared/files/info.ts` for file info
+  - `src/shared/settings/` for settings snapshots and display/runtime modes
+  - `src/shared/plugins/` for plugin status, decorations, and context menu payloads
+  - `src/shared/view/types.ts` and `src/shared/timeline/types.ts` for view and timeline payloads
 
 ## Practical rule
 

--- a/packages/extension/docs/plugin-lifecycle.md
+++ b/packages/extension/docs/plugin-lifecycle.md
@@ -24,12 +24,23 @@ The provider keeps these states separate and uses a single `_webviewReadyNotifie
 Once both sides are ready, the host can:
 
 - send plugin statuses
+- send graph controls
 - send context menu items
 - send decorations
 - send plugin webview injections
+
+## Graph Cache impact
+
+Plugin lifecycle changes should sync graph data without hiding the current **Visible Graph**.
+
+- Enabling a package plugin updates workspace settings, reloads workspace plugins, refreshes plugin/control state, and reprocesses files owned by that plugin.
+- Disabling a package plugin updates workspace settings and reloads workspace plugins, but keeps plugin-owned data in the Graph Cache. Disabled or unregistered plugin contributions are filtered from the **Visible Graph** at projection time.
+- Registering an external plugin after startup initializes the plugin, replays readiness when needed, and reprocesses plugin-owned files.
+- None of these paths should clear the Graph Cache as their first step.
 
 ## What to preserve
 
 - Keep readiness state explicit and testable.
 - Keep plugin initialization replay-safe.
 - Avoid hiding lifecycle transitions behind shared mutable globals.
+- Keep plugin changes as Graph Cache Sync work after a graph has already rendered.

--- a/packages/extension/src/extension/graphView/analysis/execution.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution.ts
@@ -19,6 +19,11 @@ interface GraphViewAnalyzerLike {
     disabledPlugins?: Set<string>,
     signal?: AbortSignal,
   ): Promise<IGraphData>;
+  loadCachedGraph?(
+    filterPatterns?: string[],
+    disabledPlugins?: Set<string>,
+    signal?: AbortSignal,
+  ): Promise<IGraphData>;
   analyze(
     filterPatterns?: string[],
     disabledPlugins?: Set<string>,

--- a/packages/extension/src/extension/graphView/analysis/execution/load.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/load.ts
@@ -15,9 +15,14 @@ import {
 import {
   analyzeGraphViewRawData,
   discoverGraphViewRawData,
+  loadCachedGraphViewRawData,
 } from './load/analyzerData';
 import { getGraphIndexFreshness } from './load/freshness';
 import { selectGraphViewRawDataLoadDecision } from './load/routing';
+
+function hasReplayableGraphData(graphData: IGraphData): boolean {
+  return graphData.nodes.length > 0 || graphData.edges.length > 0;
+}
 
 export async function loadGraphViewRawData(
   signal: AbortSignal,
@@ -30,7 +35,11 @@ export async function loadGraphViewRawData(
   }
 
   const indexFreshness = getGraphIndexFreshness(analyzer);
-  const decision = selectGraphViewRawDataLoadDecision(state.mode, indexFreshness);
+  const decision = selectGraphViewRawDataLoadDecision(
+    state.mode,
+    indexFreshness,
+    typeof analyzer.loadCachedGraph === 'function',
+  );
   const forwardProgress = createGraphViewAnalysisProgressForwarder(state.mode, handlers);
 
   if (!decision.shouldDiscover) {
@@ -40,6 +49,21 @@ export async function loadGraphViewRawData(
   if (decision.route === 'discover') {
     return {
       rawGraphData: await discoverGraphViewRawData(signal, state, analyzer),
+      shouldDiscover: decision.shouldDiscover,
+    };
+  }
+
+  if (decision.route === 'cached') {
+    const cachedGraphData = await loadCachedGraphViewRawData(signal, state, analyzer);
+    if (hasReplayableGraphData(cachedGraphData)) {
+      return {
+        rawGraphData: cachedGraphData,
+        shouldDiscover: decision.shouldDiscover,
+      };
+    }
+
+    return {
+      rawGraphData: await refreshGraphViewRawData(signal, state, forwardProgress),
       shouldDiscover: decision.shouldDiscover,
     };
   }

--- a/packages/extension/src/extension/graphView/analysis/execution/load/analyzerData.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/load/analyzerData.ts
@@ -32,3 +32,15 @@ export async function analyzeGraphViewRawData(
     forwardProgress,
   )) ?? EMPTY_GRAPH_DATA;
 }
+
+export async function loadCachedGraphViewRawData(
+  signal: AbortSignal,
+  state: GraphViewAnalysisExecutionState,
+  analyzer: GraphViewAnalyzer,
+): Promise<IGraphData> {
+  return (await analyzer.loadCachedGraph?.(
+    state.filterPatterns,
+    state.disabledPlugins,
+    signal,
+  )) ?? EMPTY_GRAPH_DATA;
+}

--- a/packages/extension/src/extension/graphView/analysis/execution/load/policy.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/load/policy.ts
@@ -14,5 +14,5 @@ export function shouldRefreshGraphIndex(
 ): boolean {
   return mode === 'index'
     || mode === 'refresh'
-    || (freshness === 'stale' && (mode === 'load' || mode === 'analyze'));
+    || (freshness === 'stale' && mode === 'load');
 }

--- a/packages/extension/src/extension/graphView/analysis/execution/load/routing.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/load/routing.ts
@@ -2,7 +2,7 @@ import type { CodeGraphyIndexFreshness } from '../../../../repoSettings/freshnes
 import type { GraphViewAnalysisExecutionState } from '../../execution';
 import { shouldDiscoverGraph, shouldRefreshGraphIndex } from './policy';
 
-export type GraphViewRawDataLoadRoute = 'discover' | 'refresh' | 'incremental' | 'analyze';
+export type GraphViewRawDataLoadRoute = 'discover' | 'cached' | 'refresh' | 'incremental' | 'analyze';
 
 export interface GraphViewRawDataLoadDecision {
   route: GraphViewRawDataLoadRoute;
@@ -12,10 +12,15 @@ export interface GraphViewRawDataLoadDecision {
 export function selectGraphViewRawDataLoadDecision(
   mode: GraphViewAnalysisExecutionState['mode'],
   freshness: CodeGraphyIndexFreshness,
+  canLoadCachedGraph = false,
 ): GraphViewRawDataLoadDecision {
   const shouldDiscover = shouldDiscoverGraph(mode, freshness);
   if (shouldDiscover) {
     return { route: 'discover', shouldDiscover };
+  }
+
+  if (mode === 'load' && freshness === 'stale' && canLoadCachedGraph) {
+    return { route: 'cached', shouldDiscover };
   }
 
   if (shouldRefreshGraphIndex(mode, freshness)) {

--- a/packages/extension/src/extension/graphView/provider/analysis/methods.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/methods.ts
@@ -123,6 +123,10 @@ export function createGraphViewProviderAnalysisMethods(
 ): GraphViewProviderAnalysisMethods {
   let fullIndexAnalysisPromise: Promise<void> | undefined;
 
+  const canReplayStaleCache = (): boolean =>
+    source._analyzer?.getIndexStatus?.().freshness === 'stale'
+    && typeof source._analyzer.loadCachedGraph === 'function';
+
   const waitForFullIndexAnalysis = async (): Promise<boolean> => {
     if (!fullIndexAnalysisPromise) {
       return false;
@@ -154,6 +158,14 @@ export function createGraphViewProviderAnalysisMethods(
         fullIndexAnalysisPromise = undefined;
       }
     }
+  };
+
+  const runFullIndexAnalysisInBackground = (
+    runAnalysis: () => Promise<void>,
+  ): void => {
+    void runFullIndexAnalysis(runAnalysis).catch(error => {
+      dependencies.logError('[CodeGraphy] Background cache sync failed:', error);
+    });
   };
 
   const runAfterFullIndexAnalysis = async (
@@ -260,6 +272,10 @@ export function createGraphViewProviderAnalysisMethods(
       }
 
       await _loadAndSendData();
+      const shouldSyncStaleCache = canReplayStaleCache();
+      if (shouldSyncStaleCache) {
+        runFullIndexAnalysisInBackground(_analyzeAndSendData);
+      }
     },
     _indexAndSendData: () => runFullIndexAnalysis(_indexAndSendData),
     _analyzeAndSendData: () => runAfterFullIndexAnalysis(_analyzeAndSendData),

--- a/packages/extension/src/extension/graphView/provider/plugin/externalRegistration.ts
+++ b/packages/extension/src/extension/graphView/provider/plugin/externalRegistration.ts
@@ -59,7 +59,14 @@ export function createGraphViewProviderExternalPluginRegistration(
         sendGraphViewContributionStatuses: () => broadcasts._sendGraphViewContributionStatuses(),
         sendPluginWebviewInjections: () => broadcasts._sendPluginWebviewInjections(),
         invalidateTimelineCache: () => source._invalidateTimelineCache(),
-        analyzeAndSendData: () => source._analyzeAndSendData(),
+        reprocessPluginFiles: async (pluginIds) => {
+          const invalidatedFilePaths = source.invalidatePluginFiles(pluginIds);
+          if (invalidatedFilePaths.length === 0) {
+            return;
+          }
+
+          await source.refreshChangedFiles(invalidatedFilePaths);
+        },
       },
     );
   };

--- a/packages/extension/src/extension/graphView/provider/plugin/methods.ts
+++ b/packages/extension/src/extension/graphView/provider/plugin/methods.ts
@@ -65,6 +65,8 @@ export interface GraphViewProviderPluginMethodsSource {
   _sendMessage(message: ExtensionToWebviewMessage): void;
   _invalidateTimelineCache(): Promise<void>;
   _analyzeAndSendData(): Promise<void>;
+  invalidatePluginFiles(pluginIds: readonly string[]): string[];
+  refreshChangedFiles(filePaths: readonly string[]): Promise<void>;
 }
 
 export interface GraphViewProviderPluginMethods {

--- a/packages/extension/src/extension/graphView/provider/source/contracts.ts
+++ b/packages/extension/src/extension/graphView/provider/source/contracts.ts
@@ -134,6 +134,7 @@ export interface GraphViewProviderMethodSourceOwner {
   _extensionUri: vscode.Uri;
   _context: vscode.ExtensionContext;
   _methodContainers: GraphViewProviderMethodContainers;
+  invalidatePluginFiles(pluginIds: readonly string[]): string[];
   readonly _analysisMethods: GraphViewProviderMethodContainers['analysis'];
   readonly _commandMethods: GraphViewProviderMethodContainers['command'];
   readonly _fileActionMethods: GraphViewProviderMethodContainers['fileAction'];

--- a/packages/extension/src/extension/graphView/provider/source/delegates/public.ts
+++ b/packages/extension/src/extension/graphView/provider/source/delegates/public.ts
@@ -15,6 +15,7 @@ export function createGraphViewProviderPublicMethodDelegates(
     | 'refreshIndex'
     | 'refreshChangedFiles'
     | 'clearCacheAndRefresh'
+    | 'invalidatePluginFiles'
     | '_notifyExtensionMessage'
   > {
   return {
@@ -26,6 +27,7 @@ export function createGraphViewProviderPublicMethodDelegates(
     refreshIndex: () => owner._methodContainers.refresh.refreshIndex(),
     refreshChangedFiles: filePaths => owner._methodContainers.refresh.refreshChangedFiles(filePaths),
     clearCacheAndRefresh: () => owner._methodContainers.refresh.clearCacheAndRefresh(),
+    invalidatePluginFiles: pluginIds => owner.invalidatePluginFiles(pluginIds),
     _notifyExtensionMessage: message => owner._notifyExtensionMessage(message),
   };
 }

--- a/packages/extension/src/extension/graphView/webview/plugins/registration/followUp.ts
+++ b/packages/extension/src/extension/graphView/webview/plugins/registration/followUp.ts
@@ -35,6 +35,6 @@ export async function runExternalPluginRegistrationFollowUp(
   state.analyzer?.registry.replayReadinessForPlugin(pluginId);
   await handlers.invalidateTimelineCache?.();
   if (state.analyzerInitialized) {
-    await handlers.analyzeAndSendData();
+    await handlers.reprocessPluginFiles([pluginId]);
   }
 }

--- a/packages/extension/src/extension/graphView/webview/plugins/registration/register.ts
+++ b/packages/extension/src/extension/graphView/webview/plugins/registration/register.ts
@@ -45,7 +45,7 @@ export interface GraphViewExternalPluginRegistrationHandlers {
   sendGraphViewContributionStatuses?(): void;
   sendPluginWebviewInjections(): void;
   invalidateTimelineCache?(): Promise<void>;
-  analyzeAndSendData(): Promise<void>;
+  reprocessPluginFiles(pluginIds: readonly string[]): Promise<void>;
 }
 
 export function registerGraphViewExternalPlugin(
@@ -59,11 +59,9 @@ export function registerGraphViewExternalPlugin(
     return;
   }
 
-  const analyzer = state.analyzer;
   storeExternalPluginExtensionUri(pluginId, options, state, handlers);
   const shouldDeferReadinessReplay = shouldDeferExternalPluginReadinessReplay(state);
   registerExternalPlugin(plugin as IPlugin, shouldDeferReadinessReplay, state);
-  analyzer.clearCache?.();
   sendExternalPluginRegistrationUpdates(handlers);
   void (async () => {
     try {

--- a/packages/extension/src/extension/graphView/webview/settingsMessages/toggle.ts
+++ b/packages/extension/src/extension/graphView/webview/settingsMessages/toggle.ts
@@ -51,6 +51,12 @@ export async function applySettingsToggleMessage(
         handlers.sendContextMenuItems?.();
         handlers.sendPluginToolbarActions?.();
         handlers.sendGraphViewContributionStatuses?.();
+        handlers.sendGraphControls();
+        if (message.payload.enabled) {
+          await handlers.reprocessPluginFiles([message.payload.pluginId]);
+          return true;
+        }
+
         await handlers.analyzeAndSendData();
         return true;
       }

--- a/packages/extension/src/extension/pipeline/plugins/statusBuilder.ts
+++ b/packages/extension/src/extension/pipeline/plugins/statusBuilder.ts
@@ -23,6 +23,42 @@ export interface IWorkspacePluginStatusOptions {
   workspaceEnabledPackageNames?: ReadonlySet<string>;
 }
 
+function shouldReplaceDuplicatePluginStatus(
+  existing: IPluginStatus,
+  next: IPluginStatus,
+): boolean {
+  if (existing.enabled !== next.enabled) {
+    return next.enabled;
+  }
+
+  if (existing.status === 'unavailable' && next.status !== 'unavailable') {
+    return true;
+  }
+
+  return false;
+}
+
+function dedupePluginStatuses(statuses: readonly IPluginStatus[]): IPluginStatus[] {
+  const deduped: IPluginStatus[] = [];
+  const indexById = new Map<string, number>();
+
+  for (const status of statuses) {
+    const existingIndex = indexById.get(status.id);
+    if (existingIndex === undefined) {
+      indexById.set(status.id, deduped.length);
+      deduped.push(status);
+      continue;
+    }
+
+    const existing = deduped[existingIndex];
+    if (shouldReplaceDuplicatePluginStatus(existing, status)) {
+      deduped[existingIndex] = status;
+    }
+  }
+
+  return deduped;
+}
+
 export function buildWorkspacePluginStatuses(options: IWorkspacePluginStatusOptions): IPluginStatus[] {
   const {
     disabledPlugins,
@@ -55,7 +91,7 @@ export function buildWorkspacePluginStatuses(options: IWorkspacePluginStatusOpti
   }
 
   if (installedPlugins.length === 0) {
-    return registeredStatusesInPluginOrder;
+    return dedupePluginStatuses(registeredStatusesInPluginOrder);
   }
 
   const statuses: IPluginStatus[] = [];
@@ -78,5 +114,5 @@ export function buildWorkspacePluginStatuses(options: IWorkspacePluginStatusOpti
     statuses.push(status);
   }
 
-  return statuses;
+  return dedupePluginStatuses(statuses);
 }

--- a/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
@@ -1,5 +1,11 @@
+import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { readCodeGraphyWorkspaceStatus } from '@codegraphy-dev/core';
+import {
+  type IDiscoveredFile,
+  projectFileAnalysisConnections,
+  readCodeGraphyWorkspaceStatus,
+  throwIfWorkspaceAnalysisAborted,
+} from '@codegraphy-dev/core';
 import type { IProjectedConnection } from '../../../core/plugins/types/contracts';
 import type { IGraphData } from '../../../shared/graph/contracts';
 import type { IPluginFilterPatternGroup } from '../../../shared/protocol/extensionToWebview';
@@ -20,6 +26,32 @@ import {
   rebuildWorkspacePipelineGraph,
 } from './runtime/run';
 import { createEmptyWorkspaceAnalysisCache } from '../cache';
+
+function createCachedDiscoveredFiles(
+  workspaceRoot: string,
+  filePaths: readonly string[],
+): IDiscoveredFile[] {
+  return filePaths.map(relativePath => ({
+    absolutePath: path.join(workspaceRoot, relativePath),
+    extension: path.extname(relativePath),
+    name: path.basename(relativePath),
+    relativePath,
+  }));
+}
+
+function collectCachedDirectoryPaths(filePaths: readonly string[]): string[] {
+  const directories = new Set<string>();
+
+  for (const filePath of filePaths) {
+    let directory = path.posix.dirname(filePath.replace(/\\/g, '/'));
+    while (directory && directory !== '.') {
+      directories.add(directory);
+      directory = path.posix.dirname(directory);
+    }
+  }
+
+  return [...directories].sort();
+}
 
 export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipelineInternalBase {
   private _workspacePluginReloadQueue: Promise<void> = Promise.resolve();
@@ -153,6 +185,42 @@ export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipeline
       onProgress,
       signal,
       async () => this._persistIndexMetadata(),
+    );
+  }
+
+  async loadCachedGraph(
+    _filterPatterns: string[] = [],
+    disabledPlugins: Set<string> = new Set(),
+    signal?: AbortSignal,
+  ): Promise<IGraphData> {
+    throwIfWorkspaceAnalysisAborted(signal);
+
+    const workspaceRoot = this._getWorkspaceRoot();
+    if (!workspaceRoot) {
+      return { nodes: [], edges: [] };
+    }
+
+    const fileAnalysis = new Map(
+      Object.entries(this._cache.files).map(([filePath, entry]) => [
+        filePath,
+        entry.analysis,
+      ]),
+    );
+    const cachedFilePaths = Object.keys(this._cache.files);
+
+    this._lastDiscoveredFiles = createCachedDiscoveredFiles(workspaceRoot, cachedFilePaths);
+    this._lastDiscoveredDirectories = collectCachedDirectoryPaths(cachedFilePaths);
+    this._lastFileAnalysis = fileAnalysis;
+    this._lastFileConnections = projectFileAnalysisConnections(fileAnalysis, workspaceRoot);
+    this._lastWorkspaceRoot = workspaceRoot;
+
+    throwIfWorkspaceAnalysisAborted(signal);
+
+    return this._buildGraphDataFromAnalysis(
+      fileAnalysis,
+      workspaceRoot,
+      this._config.getAll().showOrphans,
+      disabledPlugins,
     );
   }
 

--- a/packages/extension/src/extension/pipeline/serviceAdapters.ts
+++ b/packages/extension/src/extension/pipeline/serviceAdapters.ts
@@ -84,6 +84,15 @@ export function buildWorkspacePipelineGraphData(
   disabledPlugins: Set<string> = new Set(),
   directoryPaths: readonly string[] = [],
 ): IGraphData {
+  const activePluginIds = new Set(registry.list().map(info => info.plugin.id));
+  const effectiveDisabledPlugins = new Set(disabledPlugins);
+  for (const connections of fileConnections.values()) {
+    for (const connection of connections) {
+      if (connection.pluginId && !activePluginIds.has(connection.pluginId)) {
+        effectiveDisabledPlugins.add(connection.pluginId);
+      }
+    }
+  }
   const source: WorkspacePipelineGraphSource = {
     _cache: cache,
     _lastDiscoveredDirectories: directoryPaths,
@@ -99,9 +108,34 @@ export function buildWorkspacePipelineGraphData(
     fileConnections,
     workspaceRoot,
     showOrphans,
-    disabledPlugins,
+    effectiveDisabledPlugins,
     churnCounts,
   );
+}
+
+function filterWorkspacePipelineAnalysisByActivePlugins(
+  fileAnalysis: Map<string, IFileAnalysisResult>,
+  activePluginIds: ReadonlySet<string>,
+  disabledPlugins: ReadonlySet<string>,
+): Map<string, IFileAnalysisResult> {
+  const filtered = new Map<string, IFileAnalysisResult>();
+
+  for (const [filePath, analysis] of fileAnalysis.entries()) {
+    const relations = analysis.relations ?? [];
+    const activeRelations = relations.filter(relation =>
+      !relation.pluginId
+      || (activePluginIds.has(relation.pluginId) && !disabledPlugins.has(relation.pluginId)),
+    );
+
+    filtered.set(
+      filePath,
+      activeRelations.length === relations.length
+        ? analysis
+        : { ...analysis, relations: activeRelations },
+    );
+  }
+
+  return filtered;
 }
 
 export function buildWorkspacePipelineGraphDataFromAnalysis(
@@ -114,6 +148,12 @@ export function buildWorkspacePipelineGraphDataFromAnalysis(
   disabledPlugins: Set<string> = new Set(),
   directoryPaths: readonly string[] = [],
 ): IGraphData {
+  const activePluginIds = new Set(registry.list().map(info => info.plugin.id));
+  const visibleFileAnalysis = filterWorkspacePipelineAnalysisByActivePlugins(
+    fileAnalysis,
+    activePluginIds,
+    disabledPlugins,
+  );
   const source: WorkspacePipelineGraphSource = {
     _cache: cache,
     _lastDiscoveredDirectories: directoryPaths,
@@ -129,7 +169,7 @@ export function buildWorkspacePipelineGraphDataFromAnalysis(
     churnCounts,
     directoryPaths: source._lastDiscoveredDirectories ?? [],
     disabledPlugins,
-    fileAnalysis,
+    fileAnalysis: visibleFileAnalysis,
     getPluginForFile: absolutePath => source._registry.getPluginForFile(absolutePath),
     showOrphans,
     workspaceRoot,

--- a/packages/extension/src/webview/store/actions/bootstrap.ts
+++ b/packages/extension/src/webview/store/actions/bootstrap.ts
@@ -37,10 +37,12 @@ export function createBootstrapActions(set: SetState) {
           ...state,
           pendingPluginAssetLoads,
         };
+        const initialLoadingFinished = canFinishInitialLoading(nextState);
 
         return {
           pendingPluginAssetLoads,
-          isLoading: canFinishInitialLoading(nextState) ? false : state.isLoading,
+          awaitingInitialBootstrap: initialLoadingFinished ? false : state.awaitingInitialBootstrap,
+          isLoading: initialLoadingFinished ? false : state.isLoading,
         };
       }),
   };

--- a/packages/extension/src/webview/store/messageHandlers/graph.ts
+++ b/packages/extension/src/webview/store/messageHandlers/graph.ts
@@ -15,9 +15,15 @@ export function handleGraphDataUpdated(
     state?.awaitingInitialBootstrap
     && (!state.bootstrapComplete || state.pendingPluginAssetLoads > 0),
   );
+  const initialBootstrapFinished = Boolean(
+    state?.awaitingInitialBootstrap
+    && state.bootstrapComplete
+    && state.pendingPluginAssetLoads === 0,
+  );
 
   return {
     graphData: message.payload,
+    ...(initialBootstrapFinished ? { awaitingInitialBootstrap: false } : {}),
     isLoading: waitingForInitialBootstrap,
     graphIsIndexing: false,
     graphIndexProgress: null,
@@ -33,6 +39,7 @@ export function handleAppBootstrapComplete(
 
   return {
     bootstrapComplete: true,
+    awaitingInitialBootstrap: graphReady ? false : state.awaitingInitialBootstrap,
     isLoading: graphReady ? false : state.isLoading,
   };
 }

--- a/packages/extension/tests/extension/graphView/analysis/execution/load.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/load.test.ts
@@ -60,7 +60,46 @@ describe('graph view analysis execution load', () => {
     expect(analyze).toHaveBeenCalledOnce();
   });
 
-  it('reindexes the workspace when loading from a stale existing index', async () => {
+  it('loads cached graph data instead of blocking on refresh when a stale index can be replayed', async () => {
+    const cachedGraph: IGraphData = {
+      nodes: [{ id: 'src/cached.ts', label: 'src/cached.ts', color: '#ffffff' }],
+      edges: [],
+    };
+    const loadCachedGraph = vi.fn(async () => cachedGraph);
+    const refreshIndex = vi.fn(async () => ({
+      nodes: [{ id: 'src/reindexed.ts', label: 'src/reindexed.ts', color: '#ffffff' }],
+      edges: [],
+    }));
+    const analyze = vi.fn(async () => ({ nodes: [], edges: [] }));
+    const state = createExecutionState({
+      mode: 'load',
+      analyzer: createExecutionAnalyzer({
+        hasIndex: vi.fn(() => true),
+        getIndexStatus: vi.fn(() => ({
+          freshness: 'stale' as const,
+          detail: 'CodeGraphy Workspace Graph Cache is stale: enabled plugins changed.',
+        })),
+        loadCachedGraph,
+        analyze,
+        refreshIndex,
+      }),
+      analyzerInitialized: true,
+    });
+
+    const result = await loadGraphViewRawData(
+      new AbortController().signal,
+      state,
+      createExecutionHandlers().handlers,
+    );
+
+    expect(result.shouldDiscover).toBe(false);
+    expect(result.rawGraphData).toEqual(cachedGraph);
+    expect(loadCachedGraph).toHaveBeenCalledOnce();
+    expect(refreshIndex).not.toHaveBeenCalled();
+    expect(analyze).not.toHaveBeenCalled();
+  });
+
+  it('falls back to full refresh when stale cache cannot be replayed', async () => {
     const refreshedGraph: IGraphData = {
       nodes: [{ id: 'src/app.ts', label: 'src/app.ts', color: '#ffffff' }],
       edges: [
@@ -122,13 +161,16 @@ describe('graph view analysis execution load', () => {
     expect(analyze).not.toHaveBeenCalled();
   });
 
-  it('reindexes stale cache in analyze mode before publishing graph data', async () => {
-    const refreshedGraph = {
-      nodes: [{ id: 'src/reindexed.ts', label: 'src/reindexed.ts', color: '#ffffff' }],
+  it('syncs stale cache in analyze mode without forcing a full index refresh', async () => {
+    const analyzedGraph = {
+      nodes: [{ id: 'src/synced.ts', label: 'src/synced.ts', color: '#ffffff' }],
       edges: [],
     };
-    const analyze = vi.fn(async () => ({ nodes: [], edges: [] }));
-    const refreshIndex = vi.fn(async () => refreshedGraph);
+    const analyze = vi.fn(async () => analyzedGraph);
+    const refreshIndex = vi.fn(async () => ({
+      nodes: [{ id: 'src/reindexed.ts', label: 'src/reindexed.ts', color: '#ffffff' }],
+      edges: [],
+    }));
     const state = createExecutionState({
       mode: 'analyze',
       analyzer: createExecutionAnalyzer({
@@ -148,9 +190,9 @@ describe('graph view analysis execution load', () => {
       createExecutionHandlers().handlers,
     );
 
-    expect(result.rawGraphData).toEqual(refreshedGraph);
-    expect(refreshIndex).toHaveBeenCalledOnce();
-    expect(analyze).not.toHaveBeenCalled();
+    expect(result.rawGraphData).toEqual(analyzedGraph);
+    expect(analyze).toHaveBeenCalledOnce();
+    expect(refreshIndex).not.toHaveBeenCalled();
   });
 
   it('runs explicit full refresh through the analyzer refresh path', async () => {

--- a/packages/extension/tests/extension/graphView/analysis/execution/load/routing.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/load/routing.test.ts
@@ -10,7 +10,7 @@ describe('graph view analysis execution load routing', () => {
     ['load', 'stale', 'refresh', false],
     ['index', 'fresh', 'refresh', false],
     ['refresh', 'missing', 'refresh', false],
-    ['analyze', 'stale', 'refresh', false],
+    ['analyze', 'stale', 'analyze', false],
     ['analyze', 'missing', 'analyze', false],
     ['incremental', 'stale', 'incremental', false],
   ] as const)(

--- a/packages/extension/tests/extension/graphView/provider/analysis/methods.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/analysis/methods.test.ts
@@ -322,6 +322,53 @@ describe('graphView/provider/analysis/methods', () => {
     expect(runAnalysisRequest).toHaveBeenCalledOnce();
   });
 
+  it('starts stale cache sync in the background after cached load returns', async () => {
+    const source = createSource({
+      _analyzer: {
+        getIndexStatus: vi.fn(() => ({
+          freshness: 'stale',
+          detail: 'CodeGraphy Workspace Graph Cache is stale: enabled plugins changed.',
+        })),
+        loadCachedGraph: vi.fn(async () => ({ nodes: [], edges: [] })),
+        analyze: vi.fn(async () => ({ nodes: [], edges: [] })),
+        refreshIndex: vi.fn(async () => ({ nodes: [], edges: [] })),
+        registry: {
+          notifyWorkspaceReady: vi.fn(),
+        },
+      },
+    });
+    const events: string[] = [];
+    let finishCacheSync: (() => void) | undefined;
+    const runAnalysisRequest = vi.fn(async state => {
+      events.push(`${state.mode}:start`);
+      if (state.mode === 'analyze') {
+        await new Promise<void>(resolve => {
+          finishCacheSync = resolve;
+        });
+      }
+      events.push(`${state.mode}:end`);
+    });
+    const methods = createGraphViewProviderAnalysisMethods(source as never, {
+      runAnalysisRequest,
+      executeAnalysis: vi.fn(async () => undefined),
+      markWorkspaceReady: vi.fn(),
+      isAnalysisStale: vi.fn(() => false),
+      isAbortError: vi.fn(() => false),
+      hasWorkspace: vi.fn(() => true),
+      logError: vi.fn(),
+    });
+
+    await methods._loadAndSendData();
+    await Promise.resolve();
+
+    expect(events).toEqual(['load:start', 'load:end', 'analyze:start']);
+
+    finishCacheSync?.();
+    await Promise.resolve();
+
+    expect(events).toEqual(['load:start', 'load:end', 'analyze:start', 'analyze:end']);
+  });
+
   it('falls back to the delegate wrappers when source-owned analysis methods are unavailable', async () => {
     const source = createSource({
       _analyzer: undefined,

--- a/packages/extension/tests/extension/graphView/provider/plugin/externalRegistration.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/plugin/externalRegistration.test.ts
@@ -57,7 +57,7 @@ describe('graphView/provider/plugin/externalRegistration', () => {
         sendGraphViewContributionStatuses: expect.any(Function),
         sendPluginWebviewInjections: expect.any(Function),
         invalidateTimelineCache: expect.any(Function),
-        analyzeAndSendData: expect.any(Function),
+        reprocessPluginFiles: expect.any(Function),
       }),
     );
 
@@ -70,6 +70,33 @@ describe('graphView/provider/plugin/externalRegistration', () => {
     expect(initialState.readyNotified).toBe(true);
     expect(initialState.analyzerInitialized).toBe(false);
     expect(initialState.analyzerInitPromise).toBeInstanceOf(Promise);
+  });
+
+  it('reprocesses files owned by the newly registered plugin without clearing the graph cache', async () => {
+    const registerExternalPlugin = vi.fn();
+    const source = createPluginSource({
+      invalidatePluginFiles: vi.fn(() => ['/workspace/src/index.ts']),
+      refreshChangedFiles: vi.fn(async () => undefined),
+    });
+    const register = createGraphViewProviderExternalPluginRegistration(
+      source,
+      {
+        registerExternalPlugin,
+        getWorkspaceFolders: vi.fn(() => [{ uri: vscode.Uri.file('/workspace') }] as never),
+      },
+      createBroadcasts(),
+    );
+
+    register({ id: 'plugin.test' });
+
+    const handlers = registerExternalPlugin.mock.calls[0]?.[3] as {
+      reprocessPluginFiles(pluginIds: readonly string[]): Promise<void>;
+    };
+    await handlers.reprocessPluginFiles(['plugin.test']);
+
+    expect(source.invalidatePluginFiles).toHaveBeenCalledWith(['plugin.test']);
+    expect(source.refreshChangedFiles).toHaveBeenCalledWith(['/workspace/src/index.ts']);
+    expect(source._analyzeAndSendData).not.toHaveBeenCalled();
   });
 
   it('reads the workspace root lazily from the current folders', () => {

--- a/packages/extension/tests/extension/graphView/provider/plugin/methods.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/plugin/methods.test.ts
@@ -50,6 +50,8 @@ function createSource(
     _sendMessage: vi.fn(),
     _analyzeAndSendData: vi.fn(async () => undefined),
     _invalidateTimelineCache: vi.fn(async () => undefined),
+    invalidatePluginFiles: vi.fn(() => []),
+    refreshChangedFiles: vi.fn(async () => undefined),
     ...overrides,
   };
 
@@ -279,7 +281,7 @@ describe('graphView/provider/plugin/methods', () => {
           sendGraphViewContributionStatuses: expect.any(Function),
           sendPluginWebviewInjections: expect.any(Function),
           invalidateTimelineCache: expect.any(Function),
-          analyzeAndSendData: expect.any(Function),
+          reprocessPluginFiles: expect.any(Function),
         }),
       );
 
@@ -335,10 +337,12 @@ describe('graphView/provider/plugin/methods', () => {
     const sendGraphViewContributionStatuses = vi.fn();
     const sendPluginWebviewInjections = vi.fn();
     const sendDepthState = vi.fn();
-    const analyzeAndSendData = vi.fn(async () => undefined);
+    const invalidatePluginFiles = vi.fn(() => ['/workspace/src/index.ts']);
+    const refreshChangedFiles = vi.fn(async () => undefined);
     const invalidateTimelineCache = vi.fn(async () => undefined);
     const source = createSource({
-      _analyzeAndSendData: analyzeAndSendData,
+      invalidatePluginFiles,
+      refreshChangedFiles,
       _invalidateTimelineCache: invalidateTimelineCache,
     });
     const methods = createGraphViewProviderPluginMethods(
@@ -367,7 +371,7 @@ describe('graphView/provider/plugin/methods', () => {
       sendGraphViewContributionStatuses(): void;
       sendPluginWebviewInjections(): void;
       invalidateTimelineCache(): Promise<void>;
-      analyzeAndSendData(): Promise<void>;
+      reprocessPluginFiles(pluginIds: readonly string[]): Promise<void>;
     };
 
     registrationHandlers.sendDepthState();
@@ -377,7 +381,7 @@ describe('graphView/provider/plugin/methods', () => {
     registrationHandlers.sendGraphViewContributionStatuses();
     registrationHandlers.sendPluginWebviewInjections();
     await registrationHandlers.invalidateTimelineCache();
-    await registrationHandlers.analyzeAndSendData();
+    await registrationHandlers.reprocessPluginFiles(['plugin.test']);
 
     expect(sendDepthState).toHaveBeenCalledOnce();
     expect(sendPluginStatuses).toHaveBeenCalledOnce();
@@ -386,6 +390,8 @@ describe('graphView/provider/plugin/methods', () => {
     expect(sendGraphViewContributionStatuses).toHaveBeenCalledOnce();
     expect(sendPluginWebviewInjections).toHaveBeenCalledOnce();
     expect(source._invalidateTimelineCache).toHaveBeenCalledOnce();
-    expect(analyzeAndSendData).toHaveBeenCalledOnce();
+    expect(invalidatePluginFiles).toHaveBeenCalledWith(['plugin.test']);
+    expect(refreshChangedFiles).toHaveBeenCalledWith(['/workspace/src/index.ts']);
+    expect(source._analyzeAndSendData).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/tests/extension/graphView/provider/plugin/source.ts
+++ b/packages/extension/tests/extension/graphView/provider/plugin/source.ts
@@ -46,6 +46,8 @@ export function createPluginSource(
     _sendMessage: vi.fn(),
     _analyzeAndSendData: vi.fn(async () => undefined),
     _invalidateTimelineCache: vi.fn(async () => undefined),
+    invalidatePluginFiles: vi.fn(() => []),
+    refreshChangedFiles: vi.fn(async () => undefined),
     ...overrides,
   };
 

--- a/packages/extension/tests/extension/graphView/provider/source/delegates/public.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/source/delegates/public.test.ts
@@ -13,6 +13,7 @@ describe('source/delegates/public', () => {
     await delegates.setDepthLimit(4);
     expect(await delegates.undo()).toBe('undo');
     expect(await delegates.redo()).toBe('redo');
+    expect(delegates.invalidatePluginFiles(['plugin.test'])).toEqual(['src/app.ts']);
     delegates._notifyExtensionMessage({ type: 'EXTENSION_MESSAGE' });
 
     expect(owner._viewSelectionMethods.setDepthMode).toHaveBeenCalledWith(true);
@@ -20,6 +21,7 @@ describe('source/delegates/public', () => {
     expect(owner._viewSelectionMethods.setDepthLimit).toHaveBeenCalledWith(4);
     expect(owner._commandMethods.undo).toHaveBeenCalledTimes(1);
     expect(owner._commandMethods.redo).toHaveBeenCalledTimes(1);
+    expect(owner.invalidatePluginFiles).toHaveBeenCalledWith(['plugin.test']);
     expect(owner._notifyExtensionMessage).toHaveBeenCalledWith({
       type: 'EXTENSION_MESSAGE',
     });

--- a/packages/extension/tests/extension/graphView/provider/source/fakes.ts
+++ b/packages/extension/tests/extension/graphView/provider/source/fakes.ts
@@ -69,6 +69,14 @@ export function createMethodSourceOwnerStub(): GraphViewProviderMethodSourceOwne
   const refreshMethods = {
     _rebuildAndSend: vi.fn(async () => undefined),
     _smartRebuild: vi.fn(async () => undefined),
+    refreshIndex: vi.fn(async () => undefined),
+    refreshChangedFiles: vi.fn(async () => undefined),
+    clearCacheAndRefresh: vi.fn(async () => undefined),
+    refresh: vi.fn(async () => undefined),
+    refreshGroupSettings: vi.fn(),
+    refreshPhysicsSettings: vi.fn(),
+    refreshSettings: vi.fn(),
+    refreshToggleSettings: vi.fn(),
   };
   const settingsStateMethods = {
     _loadDisabledRulesAndPlugins: vi.fn(() => false),
@@ -166,6 +174,7 @@ export function createMethodSourceOwnerStub(): GraphViewProviderMethodSourceOwne
       viewSelection: viewSelectionMethods,
       webview: webviewMethods,
     },
+    invalidatePluginFiles: vi.fn(() => ['src/app.ts']),
     _analysisMethods: analysisMethods,
     _commandMethods: commandMethods,
     _fileActionMethods: fileActionMethods,

--- a/packages/extension/tests/extension/graphView/webview/plugins/registration.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/plugins/registration.test.ts
@@ -26,6 +26,20 @@ function createState(
   };
 }
 
+function createHandlers(overrides: Record<string, unknown> = {}) {
+  return {
+    normalizeExtensionUri: () => undefined,
+    getWorkspaceRoot: () => '/test/workspace',
+    refreshWebviewResourceRoots: vi.fn(),
+    sendDepthState: vi.fn(),
+    sendPluginStatuses: vi.fn(),
+    sendContextMenuItems: vi.fn(),
+    sendPluginWebviewInjections: vi.fn(),
+    reprocessPluginFiles: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
 async function flushPluginRegistration(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -43,16 +57,7 @@ describe('graphView/webview/plugins/registration', () => {
       'plugin.test',
       undefined,
       state,
-      {
-        normalizeExtensionUri: () => undefined,
-        getWorkspaceRoot: () => '/test/workspace',
-        refreshWebviewResourceRoots,
-        sendDepthState: vi.fn(),
-        sendPluginStatuses: vi.fn(),
-        sendContextMenuItems: vi.fn(),
-        sendPluginWebviewInjections: vi.fn(),
-        analyzeAndSendData: vi.fn(),
-      },
+      createHandlers({ refreshWebviewResourceRoots }),
     );
 
     expect(state.analyzer?.registry.register).not.toHaveBeenCalled();
@@ -69,16 +74,7 @@ describe('graphView/webview/plugins/registration', () => {
       },
       undefined,
       state,
-      {
-        normalizeExtensionUri: () => undefined,
-        getWorkspaceRoot: () => '/test/workspace',
-        refreshWebviewResourceRoots,
-        sendDepthState: vi.fn(),
-        sendPluginStatuses: vi.fn(),
-        sendContextMenuItems: vi.fn(),
-        sendPluginWebviewInjections: vi.fn(),
-        analyzeAndSendData: vi.fn(),
-      },
+      createHandlers({ refreshWebviewResourceRoots }),
     );
 
     expect(state.analyzer?.registry.register).not.toHaveBeenCalled();
@@ -91,7 +87,7 @@ describe('graphView/webview/plugins/registration', () => {
     const sendPluginStatuses = vi.fn();
     const sendContextMenuItems = vi.fn();
     const sendPluginWebviewInjections = vi.fn();
-    const analyzeAndSendData = vi.fn(async () => undefined);
+    const reprocessPluginFiles = vi.fn(async () => undefined);
     const state = createState();
     const plugin = {
       id: 'plugin.test',
@@ -115,7 +111,7 @@ describe('graphView/webview/plugins/registration', () => {
         sendPluginStatuses,
         sendContextMenuItems,
         sendPluginWebviewInjections,
-        analyzeAndSendData,
+        reprocessPluginFiles,
       },
     );
 
@@ -125,7 +121,7 @@ describe('graphView/webview/plugins/registration', () => {
     expect(state.analyzer?.registry.register).toHaveBeenCalledWith(plugin, {
       deferReadinessReplay: false,
     });
-    expect(state.analyzer?.clearCache).toHaveBeenCalledOnce();
+    expect(state.analyzer?.clearCache).not.toHaveBeenCalled();
     expect(state.analyzer?.registry.initializePlugin).toHaveBeenCalledWith(
       'plugin.test',
       '/test/workspace',
@@ -135,7 +131,7 @@ describe('graphView/webview/plugins/registration', () => {
     expect(sendPluginStatuses).toHaveBeenCalledOnce();
     expect(sendContextMenuItems).toHaveBeenCalledOnce();
     expect(sendPluginWebviewInjections).toHaveBeenCalledOnce();
-    expect(analyzeAndSendData).not.toHaveBeenCalled();
+    expect(reprocessPluginFiles).not.toHaveBeenCalled();
   });
 
   it('defers readiness replay after first analysis even before the webview is marked ready', async () => {
@@ -156,16 +152,7 @@ describe('graphView/webview/plugins/registration', () => {
       },
       undefined,
       state,
-      {
-        normalizeExtensionUri: () => undefined,
-        getWorkspaceRoot: () => '/test/workspace',
-        refreshWebviewResourceRoots: vi.fn(),
-        sendDepthState: vi.fn(),
-        sendPluginStatuses: vi.fn(),
-        sendContextMenuItems: vi.fn(),
-        sendPluginWebviewInjections: vi.fn(),
-        analyzeAndSendData: vi.fn(async () => undefined),
-      },
+      createHandlers(),
     );
 
     await flushPluginRegistration();
@@ -174,6 +161,7 @@ describe('graphView/webview/plugins/registration', () => {
       deferReadinessReplay: true,
     });
     expect(state.analyzer?.registry.replayReadinessForPlugin).toHaveBeenCalledWith('plugin.test');
+    expect(state.analyzer?.clearCache).not.toHaveBeenCalled();
   });
 
   it('replays readiness and still initializes the plugin after the first analysis/webview-ready phase', async () => {
@@ -182,7 +170,7 @@ describe('graphView/webview/plugins/registration', () => {
       readyNotified: true,
       analyzerInitialized: false,
     });
-    const analyzeAndSendData = vi.fn(async () => undefined);
+    const reprocessPluginFiles = vi.fn(async () => undefined);
 
     registerGraphViewExternalPlugin(
       {
@@ -195,16 +183,7 @@ describe('graphView/webview/plugins/registration', () => {
       },
       undefined,
       state,
-      {
-        normalizeExtensionUri: () => undefined,
-        getWorkspaceRoot: () => '/test/workspace',
-        refreshWebviewResourceRoots: vi.fn(),
-        sendDepthState: vi.fn(),
-        sendPluginStatuses: vi.fn(),
-        sendContextMenuItems: vi.fn(),
-        sendPluginWebviewInjections: vi.fn(),
-        analyzeAndSendData,
-      },
+      createHandlers({ reprocessPluginFiles }),
     );
 
     await flushPluginRegistration();
@@ -217,7 +196,8 @@ describe('graphView/webview/plugins/registration', () => {
       'plugin.test',
       '/test/workspace',
     );
-    expect(analyzeAndSendData).not.toHaveBeenCalled();
+    expect(state.analyzer?.clearCache).not.toHaveBeenCalled();
+    expect(reprocessPluginFiles).not.toHaveBeenCalled();
   });
 
   it('skips plugin initialization when there is no workspace root', async () => {
@@ -225,7 +205,7 @@ describe('graphView/webview/plugins/registration', () => {
     const sendPluginStatuses = vi.fn();
     const sendContextMenuItems = vi.fn();
     const sendPluginWebviewInjections = vi.fn();
-    const analyzeAndSendData = vi.fn(async () => undefined);
+    const reprocessPluginFiles = vi.fn(async () => undefined);
     const state = createState();
 
     registerGraphViewExternalPlugin(
@@ -247,7 +227,7 @@ describe('graphView/webview/plugins/registration', () => {
         sendPluginStatuses,
         sendContextMenuItems,
         sendPluginWebviewInjections,
-        analyzeAndSendData,
+        reprocessPluginFiles,
       },
     );
 
@@ -258,7 +238,8 @@ describe('graphView/webview/plugins/registration', () => {
     expect(sendPluginStatuses).toHaveBeenCalledOnce();
     expect(sendContextMenuItems).toHaveBeenCalledOnce();
     expect(sendPluginWebviewInjections).toHaveBeenCalledOnce();
-    expect(analyzeAndSendData).not.toHaveBeenCalled();
+    expect(state.analyzer?.clearCache).not.toHaveBeenCalled();
+    expect(reprocessPluginFiles).not.toHaveBeenCalled();
   });
 
   it('waits for analyzer initialization to settle before replaying readiness and reanalyzing', async () => {
@@ -272,7 +253,7 @@ describe('graphView/webview/plugins/registration', () => {
     });
     const initializePlugin = vi.fn(async () => undefined);
     const replayReadinessForPlugin = vi.fn();
-    const analyzeAndSendData = vi.fn(async () => undefined);
+    const reprocessPluginFiles = vi.fn(async () => undefined);
     const state: GraphViewExternalPluginRegistrationState = {
       pluginExtensionUris: new Map<string, vscode.Uri>(),
       analyzer: {
@@ -308,16 +289,7 @@ describe('graphView/webview/plugins/registration', () => {
       },
       undefined,
       state,
-      {
-        normalizeExtensionUri: () => undefined,
-        getWorkspaceRoot: () => '/test/workspace',
-        refreshWebviewResourceRoots: vi.fn(),
-        sendDepthState: vi.fn(),
-        sendPluginStatuses: vi.fn(),
-        sendContextMenuItems: vi.fn(),
-        sendPluginWebviewInjections: vi.fn(),
-        analyzeAndSendData,
-      },
+      createHandlers({ reprocessPluginFiles }),
     );
 
     await Promise.resolve();
@@ -329,12 +301,12 @@ describe('graphView/webview/plugins/registration', () => {
 
     expect(initializePlugin).toHaveBeenCalledWith('plugin.test', '/test/workspace');
     expect(replayReadinessForPlugin).toHaveBeenCalledWith('plugin.test');
-    expect(analyzeAndSendData).toHaveBeenCalledOnce();
+    expect(reprocessPluginFiles).toHaveBeenCalledWith(['plugin.test']);
   });
 
   it('invalidates cached timeline history after registering an external plugin', async () => {
     const invalidateTimelineCache = vi.fn(async () => undefined);
-    const analyzeAndSendData = vi.fn(async () => undefined);
+    const reprocessPluginFiles = vi.fn(async () => undefined);
     const state = createState({
       firstAnalysis: false,
       readyNotified: true,
@@ -351,33 +323,23 @@ describe('graphView/webview/plugins/registration', () => {
       },
       undefined,
       state,
-      {
-        normalizeExtensionUri: () => undefined,
-        getWorkspaceRoot: () => '/test/workspace',
-        refreshWebviewResourceRoots: vi.fn(),
-        sendDepthState: vi.fn(),
-        sendPluginStatuses: vi.fn(),
-        sendContextMenuItems: vi.fn(),
-        sendPluginWebviewInjections: vi.fn(),
-        invalidateTimelineCache,
-        analyzeAndSendData,
-      },
+      createHandlers({ invalidateTimelineCache, reprocessPluginFiles }),
     );
 
     await flushPluginRegistration();
 
     expect(invalidateTimelineCache).toHaveBeenCalledOnce();
-    expect(analyzeAndSendData).toHaveBeenCalledOnce();
+    expect(reprocessPluginFiles).toHaveBeenCalledWith(['plugin.test']);
     expect(invalidateTimelineCache.mock.invocationCallOrder[0]).toBeLessThan(
-      analyzeAndSendData.mock.invocationCallOrder[0],
+      reprocessPluginFiles.mock.invocationCallOrder[0],
     );
   });
 
   it('logs follow-up failures instead of leaking unhandled rejections', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const initializePlugin = vi.fn(async () => undefined);
-    const analyzeAndSendData = vi.fn(async () => {
-      throw new Error('reanalysis failed');
+    const reprocessPluginFiles = vi.fn(async () => {
+      throw new Error('plugin reprocess failed');
     });
     const state = createState({
       firstAnalysis: false,
@@ -403,22 +365,13 @@ describe('graphView/webview/plugins/registration', () => {
       },
       undefined,
       state,
-      {
-        normalizeExtensionUri: () => undefined,
-        getWorkspaceRoot: () => '/test/workspace',
-        refreshWebviewResourceRoots: vi.fn(),
-        sendDepthState: vi.fn(),
-        sendPluginStatuses: vi.fn(),
-        sendContextMenuItems: vi.fn(),
-        sendPluginWebviewInjections: vi.fn(),
-        analyzeAndSendData,
-      },
+      createHandlers({ reprocessPluginFiles }),
     );
 
     await flushPluginRegistration();
 
     expect(initializePlugin).toHaveBeenCalledWith('plugin.test', '/test/workspace');
-    expect(analyzeAndSendData).toHaveBeenCalledOnce();
+    expect(reprocessPluginFiles).toHaveBeenCalledWith(['plugin.test']);
     expect(consoleError).toHaveBeenCalledWith(
       '[CodeGraphy] External plugin registration follow-up failed for plugin.test:',
       expect.any(Error),
@@ -434,16 +387,10 @@ describe('graphView/webview/plugins/registration', () => {
       null,
       undefined,
       createState({ analyzer: undefined }),
-      {
-        normalizeExtensionUri: () => undefined,
+      createHandlers({
         getWorkspaceRoot: () => undefined,
         refreshWebviewResourceRoots,
-        sendDepthState: vi.fn(),
-        sendPluginStatuses: vi.fn(),
-        sendContextMenuItems: vi.fn(),
-        sendPluginWebviewInjections: vi.fn(),
-        analyzeAndSendData: vi.fn(),
-      },
+      }),
     );
 
     expect(refreshWebviewResourceRoots).not.toHaveBeenCalled();

--- a/packages/extension/tests/extension/graphView/webview/settingsMessages/router.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/settingsMessages/router.test.ts
@@ -230,7 +230,7 @@ describe('graph view settings router', () => {
     expect(handlers.sendGraphControls).toHaveBeenCalledOnce();
   });
 
-  it('enables package-backed plugins and reloads workspace plugins before analysis', async () => {
+  it('enables package-backed plugins and reloads workspace plugins before reprocessing plugin files', async () => {
     const state = createState();
     const handlers = createHandlers();
 
@@ -251,9 +251,9 @@ describe('graph view settings router', () => {
       { package: '@codegraphy-dev/plugin-python' },
     ]);
     expect(handlers.reloadWorkspacePlugins).toHaveBeenCalledOnce();
-    expect(handlers.analyzeAndSendData).toHaveBeenCalledOnce();
+    expect(handlers.reprocessPluginFiles).toHaveBeenCalledWith(['codegraphy.python']);
+    expect(handlers.analyzeAndSendData).not.toHaveBeenCalled();
     expect(handlers.smartRebuild).not.toHaveBeenCalled();
-    expect(handlers.reprocessPluginFiles).not.toHaveBeenCalled();
   });
 
   it('returns false for unrelated messages', async () => {

--- a/packages/extension/tests/extension/graphView/webview/settingsMessages/toggle.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/settingsMessages/toggle.test.ts
@@ -101,45 +101,13 @@ describe('graph view settings toggle message', () => {
     expect(handlers.reloadWorkspacePlugins).toHaveBeenCalledOnce();
     expect(handlers.analyzeAndSendData).toHaveBeenCalledOnce();
     expect(handlers.smartRebuild).not.toHaveBeenCalled();
-  });
-
-  it('removes package-backed plugins from workspace plugins when toggled off', async () => {
-    const state = createState();
-    const handlers = createHandlers({
-      getConfig: vi.fn(<T>(key: string, defaultValue: T): T => {
-        if (key === 'plugins') {
-          return [
-            { package: '@codegraphy-dev/plugin-markdown' },
-            { package: '@acme/graph-tools' },
-          ] as T;
-        }
-        return defaultValue;
-      }),
-    });
-
-    const handled = await applySettingsToggleMessage(
-      {
-        type: 'TOGGLE_PLUGIN',
-        payload: {
-          pluginId: 'acme.graph-tools',
-          packageName: '@acme/graph-tools',
-          enabled: false,
-        },
-      },
-      state,
-      handlers,
-    );
-
-    expect(handled).toBe(true);
-    expect(handlers.updateConfig).toHaveBeenCalledWith('plugins', [
-      { package: '@codegraphy-dev/plugin-markdown' },
-    ]);
-    expect(handlers.reloadWorkspacePlugins).toHaveBeenCalledOnce();
-    expect(handlers.analyzeAndSendData).toHaveBeenCalledOnce();
+    expect(handlers.reprocessPluginFiles).not.toHaveBeenCalled();
   });
 
   it('enables package-backed plugins by adding them to the workspace plugins list', async () => {
     const state = createState();
+    const reprocessPluginFiles = vi.fn(() => Promise.resolve());
+    const analyzeAndSendData = vi.fn(() => Promise.resolve());
     const handlers = createHandlers({
       getConfig: vi.fn(<T>(key: string, defaultValue: T): T => {
         if (key === 'plugins') {
@@ -147,6 +115,8 @@ describe('graph view settings toggle message', () => {
         }
         return defaultValue;
       }),
+      reprocessPluginFiles,
+      analyzeAndSendData,
     });
 
     const handled = await applySettingsToggleMessage(
@@ -168,7 +138,8 @@ describe('graph view settings toggle message', () => {
       { package: '@codegraphy-dev/plugin-python' },
     ]);
     expect(handlers.reloadWorkspacePlugins).toHaveBeenCalledOnce();
-    expect(handlers.analyzeAndSendData).toHaveBeenCalledOnce();
+    expect(reprocessPluginFiles).toHaveBeenCalledWith(['codegraphy.python']);
+    expect(analyzeAndSendData).not.toHaveBeenCalled();
     expect(handlers.smartRebuild).not.toHaveBeenCalled();
   });
 
@@ -231,37 +202,6 @@ describe('graph view settings toggle message', () => {
     expect(handled).toBe(false);
   });
 
-  it('reloads package plugins instead of only rebuilding cached plugin edges', async () => {
-    const state = createState();
-    const handlers = createHandlers({
-      getConfig: vi.fn(<T>(key: string, defaultValue: T): T => {
-        if (key === 'plugins') {
-          return [{ package: '@codegraphy-dev/plugin-python' }] as T;
-        }
-        return defaultValue;
-      }),
-      reprocessPluginFiles: vi.fn(() => new Promise<void>(() => undefined)),
-    });
-    const handled = await applySettingsToggleMessage(
-      {
-        type: 'TOGGLE_PLUGIN',
-        payload: {
-          pluginId: 'codegraphy.python',
-          packageName: '@codegraphy-dev/plugin-python',
-          enabled: false,
-        },
-      },
-      state,
-      handlers,
-    );
-
-    expect(handled).toBe(true);
-    expect(handlers.reloadWorkspacePlugins).toHaveBeenCalledOnce();
-    expect(handlers.analyzeAndSendData).toHaveBeenCalledOnce();
-    expect(handlers.smartRebuild).not.toHaveBeenCalled();
-    expect(handlers.reprocessPluginFiles).not.toHaveBeenCalled();
-  });
-
   it('sends fresh graph view contribution statuses after package toggles reload plugins', async () => {
     const state = createState();
     const reloadWorkspacePlugins = vi.fn(() => Promise.resolve());
@@ -302,6 +242,44 @@ describe('graph view settings toggle message', () => {
     expect(reloadWorkspacePlugins.mock.invocationCallOrder[0])
       .toBeLessThan(sendGraphViewContributionStatuses.mock.invocationCallOrder[0]);
     expect(sendGraphViewContributionStatuses.mock.invocationCallOrder[0])
+      .toBeLessThan(analyzeAndSendData.mock.invocationCallOrder[0]);
+  });
+
+  it('sends graph controls after package toggles reload plugin contributions', async () => {
+    const state = createState();
+    const reloadWorkspacePlugins = vi.fn(() => Promise.resolve());
+    const sendGraphControls = vi.fn();
+    const analyzeAndSendData = vi.fn(() => Promise.resolve());
+    const handlers = createHandlers({
+      getConfig: vi.fn(<T>(key: string, defaultValue: T): T => {
+        if (key === 'plugins') {
+          return [{ package: '@codegraphy-dev/plugin-markdown' }] as T;
+        }
+        return defaultValue;
+      }),
+      reloadWorkspacePlugins,
+      sendGraphControls,
+      analyzeAndSendData,
+    });
+
+    const handled = await applySettingsToggleMessage(
+      {
+        type: 'TOGGLE_PLUGIN',
+        payload: {
+          pluginId: 'codegraphy.python',
+          packageName: '@codegraphy-dev/plugin-python',
+          enabled: false,
+        },
+      },
+      state,
+      handlers,
+    );
+
+    expect(handled).toBe(true);
+    expect(sendGraphControls).toHaveBeenCalledOnce();
+    expect(reloadWorkspacePlugins.mock.invocationCallOrder[0])
+      .toBeLessThan(sendGraphControls.mock.invocationCallOrder[0]);
+    expect(sendGraphControls.mock.invocationCallOrder[0])
       .toBeLessThan(analyzeAndSendData.mock.invocationCallOrder[0]);
   });
 
@@ -358,10 +336,11 @@ describe('graph view settings toggle message', () => {
       .toBeLessThan(analyzeAndSendData.mock.invocationCallOrder[0]);
   });
 
-  it('lets graph analysis publish webview injections after package toggles', async () => {
+  it('lets plugin file reprocessing publish webview injections after package toggles', async () => {
     const state = createState();
     const sendPluginWebviewInjections = vi.fn();
     const analyzeAndSendData = vi.fn(() => Promise.resolve());
+    const reprocessPluginFiles = vi.fn(() => Promise.resolve());
     const handlers = createHandlers({
       getConfig: vi.fn(<T>(key: string, defaultValue: T): T => {
         if (key === 'plugins') {
@@ -371,6 +350,7 @@ describe('graph view settings toggle message', () => {
       }),
       sendPluginWebviewInjections,
       analyzeAndSendData,
+      reprocessPluginFiles,
     });
 
     const handled = await applySettingsToggleMessage(
@@ -387,7 +367,8 @@ describe('graph view settings toggle message', () => {
     );
 
     expect(handled).toBe(true);
-    expect(analyzeAndSendData).toHaveBeenCalledOnce();
+    expect(reprocessPluginFiles).toHaveBeenCalledWith(['codegraphy.organize']);
+    expect(analyzeAndSendData).not.toHaveBeenCalled();
     expect(sendPluginWebviewInjections).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/tests/extension/pipeline/plugins/statusBuilder.test.ts
+++ b/packages/extension/tests/extension/pipeline/plugins/statusBuilder.test.ts
@@ -418,6 +418,54 @@ describe('pipeline/plugins/statusBuilder', () => {
     });
   });
 
+  it('deduplicates installed package aliases that advertise the same plugin id', () => {
+    const pluginInfos = [
+      {
+        ...createPluginInfo({
+          id: 'codegraphy.organize',
+          name: 'CodeGraphy Organize',
+          supportedExtensions: ['*'],
+        }),
+        sourcePackage: '@codegraphy-pro/organize',
+      },
+    ];
+
+    const statuses = buildWorkspacePluginStatuses({
+      disabledPlugins: new Set(),
+      discoveredFiles: [{ relativePath: 'src/index.ts' }],
+      fileConnections: new Map([['src/index.ts', []]]),
+      installedPlugins: [
+        {
+          package: '@codegraphy/organize',
+          pluginId: 'codegraphy.organize',
+          pluginName: 'CodeGraphy Organize',
+          version: '1.0.0',
+          apiVersion: '^2.0.0',
+          disclosures: [],
+          packageRoot: '/global/node_modules/@codegraphy/organize',
+        },
+        {
+          package: '@codegraphy-pro/organize',
+          pluginId: 'codegraphy.organize',
+          pluginName: 'CodeGraphy Organize',
+          version: '1.0.0',
+          apiVersion: '^2.0.0',
+          disclosures: [],
+          packageRoot: '/global/node_modules/@codegraphy-pro/organize',
+        },
+      ],
+      pluginInfos,
+      workspaceEnabledPackageNames: new Set(['@codegraphy-pro/organize']),
+    });
+
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0]).toMatchObject({
+      id: 'codegraphy.organize',
+      packageName: '@codegraphy-pro/organize',
+      enabled: true,
+    });
+  });
+
   it('keeps package plugins in installed order and preserves plugin names when toggled off', () => {
     const installedPlugins = [
       {

--- a/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
@@ -336,4 +336,57 @@ describe('pipeline/service/discoveryFacade', () => {
       total: 5,
     });
   });
+
+  it('loads cached graph data without clearing or reanalyzing the Graph Cache', async () => {
+    const facade = new TestDiscoveryFacade();
+    const disabledPlugins = new Set(['plugin.disabled']);
+    const cachedAnalysis = {
+      filePath: '/workspace/src/cached.ts',
+      relations: [],
+    };
+    facade._cache = {
+      version: 'test',
+      files: {
+        'src/cached.ts': {
+          mtime: 1,
+          analysis: cachedAnalysis,
+        },
+      },
+    } as never;
+    const buildGraphDataFromAnalysis = vi
+      .spyOn(
+        facade as unknown as {
+          _buildGraphDataFromAnalysis: (...args: unknown[]) => unknown;
+        },
+        '_buildGraphDataFromAnalysis',
+      )
+      .mockReturnValue({
+        nodes: [{ id: 'src/cached.ts', label: 'cached.ts', color: '#333333' }],
+        edges: [],
+      });
+
+    await expect(
+      facade.loadCachedGraph(['dist/**'], disabledPlugins, new AbortController().signal),
+    ).resolves.toEqual({
+      nodes: [{ id: 'src/cached.ts', label: 'cached.ts', color: '#333333' }],
+      edges: [],
+    });
+
+    expect(facade.clearCache).not.toHaveBeenCalled();
+    expect(analyzeWorkspacePipeline).not.toHaveBeenCalled();
+    expect(buildGraphDataFromAnalysis).toHaveBeenCalledWith(
+      new Map([['src/cached.ts', cachedAnalysis]]),
+      '/workspace',
+      true,
+      disabledPlugins,
+    );
+    expect(discoveryState(facade)._lastDiscoveredFiles).toEqual([
+      {
+        absolutePath: '/workspace/src/cached.ts',
+        extension: '.ts',
+        name: 'cached.ts',
+        relativePath: 'src/cached.ts',
+      },
+    ]);
+  });
 });

--- a/packages/extension/tests/extension/pipeline/serviceAdapters.test.ts
+++ b/packages/extension/tests/extension/pipeline/serviceAdapters.test.ts
@@ -194,4 +194,43 @@ describe('pipeline/serviceAdapters', () => {
       }),
     ]));
   });
+
+  it('hides cached relations owned by plugins that are no longer registered', () => {
+    const cache = {
+      files: {
+        'src/app.ts': { size: 12 },
+        'src/organize.ts': { size: 8 },
+      },
+    };
+    const workspaceState = {
+      get: vi.fn(() => undefined),
+      update: vi.fn(),
+    };
+    const registry = {
+      getPluginForFile: vi.fn(() => undefined),
+      list: vi.fn(() => []),
+    };
+
+    const graphData = buildWorkspacePipelineGraphData(
+      cache as never,
+      { workspaceState } as never,
+      registry as never,
+      new Map([
+        ['src/app.ts', [
+          {
+            kind: 'import',
+            pluginId: 'codegraphy.organize',
+            sourceId: 'organize-edge',
+            specifier: './organize',
+            resolvedPath: '/workspace/src/organize.ts',
+          },
+        ]],
+        ['src/organize.ts', []],
+      ]),
+      '/workspace',
+      true,
+    );
+
+    expect(graphData.edges).toEqual([]);
+  });
 });

--- a/packages/extension/tests/extension/pluginIntegration/typescript.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/typescript.test.ts
@@ -17,6 +17,7 @@ const mockState = vi.hoisted(() => ({
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
+    saveWorkspaceAnalysisDatabaseCache: vi.fn(),
     saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
   },
 }));
@@ -41,6 +42,7 @@ vi.mock('../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
+  saveWorkspaceAnalysisDatabaseCache: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache,
   saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
 }));
 
@@ -154,6 +156,8 @@ describe('extension/pluginIntegration/typescript', () => {
     expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
       workspaceFixture!.workspacePath,
     );
+    expect(mockState.databaseCache.clearWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
+    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache).toHaveBeenCalled();
     expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 });

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -180,6 +180,36 @@ describe('App', () => {
     });
   });
 
+  it('keeps the graph visible while indexing after startup', async () => {
+    render(<App />);
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [{ id: 'test.ts', label: 'test.ts', color: '#3B82F6' }],
+          edges: [],
+        },
+      });
+      sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Graph Scope')).toBeInTheDocument();
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_INDEX_PROGRESS',
+        payload: { phase: 'Indexing Workspace', current: 1, total: 4 },
+      });
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Graph Scope')).toBeInTheDocument();
+    expect(screen.getByTestId('graph-index-status')).toBeInTheDocument();
+    expect(screen.getByText('Indexing Workspace')).toBeInTheDocument();
+  });
+
   it('should send WEBVIEW_READY only once across initial graph load', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sentMessages = (globalThis as any).__vscodeSentMessages as Array<{ type?: string }>;

--- a/packages/extension/tests/webview/store/actions/bootstrap.test.ts
+++ b/packages/extension/tests/webview/store/actions/bootstrap.test.ts
@@ -44,6 +44,7 @@ describe('webview/store/actions/bootstrap', () => {
 
   it('keeps loading until bootstrap, graph data, and plugin assets are complete', () => {
     const { actions, getState } = createHarness({
+      awaitingInitialBootstrap: true,
       bootstrapComplete: true,
       graphData,
       isLoading: true,
@@ -64,6 +65,7 @@ describe('webview/store/actions/bootstrap', () => {
 
     actions.finishPluginAssetLoad();
     expect(getState()).toMatchObject({
+      awaitingInitialBootstrap: false,
       isLoading: false,
       pendingPluginAssetLoads: 0,
     });

--- a/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
+++ b/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   handleActiveFileUpdated,
+  handleAppBootstrapComplete,
   handleDepthLimitRangeUpdated,
   handleDepthLimitUpdated,
   handleDepthModeUpdated,
@@ -96,6 +97,44 @@ describe('webview/store/messageHandlers/graph', () => {
       isLoading: false,
       graphIsIndexing: false,
       graphIndexProgress: null,
+    });
+  });
+
+  it('settles initial bootstrap when graph data arrives after bootstrap and plugin assets are ready', () => {
+    const payload = { nodes: [{ id: 'src/app.ts', label: 'App', color: '#fff' }], edges: [] };
+    const state = createState({
+      awaitingInitialBootstrap: true,
+      bootstrapComplete: true,
+      pendingPluginAssetLoads: 0,
+    });
+
+    expect(handleGraphDataUpdated(
+      { type: 'GRAPH_DATA_UPDATED', payload },
+      { getState: () => state },
+    )).toEqual({
+      graphData: payload,
+      awaitingInitialBootstrap: false,
+      isLoading: false,
+      graphIsIndexing: false,
+      graphIndexProgress: null,
+    });
+  });
+
+  it('settles initial bootstrap when app bootstrap completes after graph data and plugin assets are ready', () => {
+    const state = createState({
+      graphData: { nodes: [{ id: 'src/app.ts', label: 'App', color: '#fff' }], edges: [] },
+      awaitingInitialBootstrap: true,
+      pendingPluginAssetLoads: 0,
+      isLoading: true,
+    });
+
+    expect(handleAppBootstrapComplete(
+      { type: 'APP_BOOTSTRAP_COMPLETE' },
+      { getState: () => state },
+    )).toEqual({
+      bootstrapComplete: true,
+      awaitingInitialBootstrap: false,
+      isLoading: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- replay stale-but-readable Graph Cache data immediately on startup and start Graph Cache Sync in the background instead of clearing/reindexing before the graph is visible
- make plugin enable/late registration reprocess plugin-owned files incrementally, while plugin disable keeps cached plugin data but filters it from the Visible Graph
- keep whole-view `Loading graph...` startup-only, with later index/full-refresh work shown as graph-local progress while the graph stays rendered
- dedupe duplicate plugin status rows by plugin id
- document the new Graph Cache lifecycle and prune redundant package-toggle tests so the remaining coverage maps to durable behavior contracts

## Lifecycle
```mermaid
flowchart TD
  A["Webview page opens"] --> B["Startup shell shows Loading graph..."]
  B --> C["Extension sends first graph payload and bootstrap completion"]
  C --> D{"Replayable Graph Cache exists?"}
  D -->|"Yes"| E["Render cached graph"]
  D -->|"No"| F["Initial index builds first graph"]
  F --> E
  E --> G["Initial loading is finished"]
  G --> H{"Later graph work needed?"}
  H -->|"Plugin, settings, or file changes"| I["Graph Cache Sync"]
  H -->|"Explicit full index / refresh"| J["Index runs"]
  I --> K["Graph stays visible with graph-local progress"]
  J --> K
  K --> L["Updated graph payload replaces the Visible Graph"]
  L --> G
```

## Terminology
`Graph Cache Sync` is the background catch-up pass after cached graph data has already been rendered. It compares the saved Graph Cache against the current runtime inputs, such as enabled plugins, settings signatures, schema metadata, and pending changed files, then updates the cache and Visible Graph without blocking the webview shell.

Plugin enablement now syncs plugin-owned files. Plugin disablement filters those plugin contributions from the Visible Graph but keeps their cached data on disk so re-enabling the plugin can reuse it.

## Validation
- `pnpm --filter @codegraphy-dev/extension test` - 988 files, 5,758 tests passed
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts packages/extension/tests/extension/graphView/webview/settingsMessages/toggle.test.ts packages/extension/tests/webview/app/shell/view.test.tsx`
- `pnpm run typecheck`
- `pnpm run lint`
- `git diff --check`
- `CI=1 pnpm --filter @codegraphy-dev/extension run test:playwright`
