### PR TITLE
Deepen Relationship Graph runtime state

### DIFF
--- a/.changeset/neat-graph-runtime.md
+++ b/.changeset/neat-graph-runtime.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Deepen the Graph View runtime boundary so graph selection, renderer state, context-menu state, and render caches are exposed through named runtime facets.

--- a/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
+++ b/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
@@ -42,6 +42,10 @@ Move toward a runtime module that exposes behavior-oriented surfaces, such as:
 4. What behavior is in scope for the first TDD slice: selection pruning, timeline alpha application, image cache invalidation, or interaction/runtime setup?
 5. Does this refactor need an ADR, or is the trade-off local and reversible enough to live only in this plan and tests?
 
+## Decisions
+
+- Return one named Graph View runtime object made of explicit facets, such as `selection`, `renderer`, `contextSelection`, and `renderCaches`. Avoid a flat `UseGraphStateResult` bag of refs, but also avoid one vague runtime object with unrelated behavior mixed together.
+
 ## First Slice Candidate
 
 Start with tests around the behavior that currently leaks through `UseGraphStateResult`:

--- a/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
+++ b/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
@@ -10,9 +10,9 @@ Trello card: https://trello.com/c/09objACH/159-architecture-deepen-relationship-
 
 Recommendation strength: Strong
 
-## Current Shape
+## Previous Shape
 
-`useGraphState` owns real runtime concerns, but its return type is still mostly a bag of implementation details:
+Before this slice, the Graph View runtime hook owned real runtime concerns, but its return type was mostly a bag of implementation details:
 
 - force graph refs
 - selection refs and setters
@@ -22,11 +22,11 @@ Recommendation strength: Strong
 - file info, sprite, mesh, node decoration, and edge decoration caches
 - computed force graph data and its backing ref
 
-`Graph` then fans these details back out into interaction runtime setup, auto-fit, debug API setup, callback option building, and viewport props.
+`Graph` then fanned these details back out into interaction runtime setup, auto-fit, debug API setup, callback option building, and viewport props.
 
 ## Target Direction
 
-Move toward a runtime module that exposes behavior-oriented surfaces, such as:
+Move the runtime module toward behavior-oriented surfaces, such as:
 
 - rendered graph data access for surfaces that must render the Visible Graph
 - selection behavior instead of raw selected-node refs and setters
@@ -36,28 +36,28 @@ Move toward a runtime module that exposes behavior-oriented surfaces, such as:
 
 ## Alignment Questions
 
-1. Should this slice create one cohesive `graphRuntime` object, or a small set of named runtime facets such as `selection`, `renderer`, `contextSelection`, and `renderCaches`?
+1. Should this slice create one cohesive `graphRuntime` object, or a small set of named runtime facets such as `selection`, `renderer`, `context`, and `renderCaches`?
 2. Which consumers are allowed to keep raw refs because they integrate with `react-force-graph`, and which should be forced through behavior methods?
-3. Should the public boundary continue to use React hook language like `UseGraphStateResult`, or should this become a Graph View runtime model with hook implementation hidden behind it?
+3. Should the public boundary continue to use React hook-result language, or should this become a Graph View runtime model with hook implementation hidden behind it?
 4. What behavior is in scope for the first TDD slice: selection pruning, timeline alpha application, image cache invalidation, or interaction/runtime setup?
 5. Does this refactor need an ADR, or is the trade-off local and reversible enough to live only in this plan and tests?
 
 ## Decisions
 
-- Return one named Graph View runtime object made of explicit facets, such as `selection`, `renderer`, `contextSelection`, and `renderCaches`. Avoid a flat `UseGraphStateResult` bag of refs, but also avoid one vague runtime object with unrelated behavior mixed together.
+- Return one named Graph View runtime object made of explicit facets: `selection`, `renderer`, `context`, and `renderCaches`. Avoid a flat bag of refs, but also avoid one vague runtime object with unrelated behavior mixed together.
 - Keep raw `react-force-graph` refs at the adapter edge only. Rendering surfaces and renderer lifecycle code may receive raw `fg2dRef`, `fg3dRef`, and container refs when they call the force-graph imperative API directly. Interaction, debug, viewport model, callbacks, and Graph View composition should receive behavior-oriented runtime facets unless they have a concrete renderer integration reason to use refs.
-- Treat the exported boundary as a Graph View runtime model, not a React hook result type. A hook such as `useGraphRuntime` can construct the model, but callers should depend on domain-shaped types such as `GraphRuntime` and explicit runtime facets rather than `UseGraphStateResult`.
+- Treat the exported boundary as a Graph View runtime model, not a React hook result type. `useGraphRuntime` constructs the model, but callers depend on domain-shaped types such as `GraphRuntime` and explicit runtime facets.
 - No ADR is needed for this slice. The change is local to the Graph View runtime boundary, is reversible through ordinary refactoring, and does not introduce a hard-to-reverse product or package contract decision.
 
-## First Slice Candidate
+## First Slice
 
-Start with tests around the behavior that currently leaks through `UseGraphStateResult`:
+The slice starts with tests around behavior that used to leak through the flat runtime object:
 
 - selection is pruned when selected nodes leave the Visible Graph
 - timeline alpha is applied through runtime behavior, not by callers knowing about 2D graph refs
 - image cache invalidation is triggered through a named behavior rather than exposed setter details
 
-Then narrow the interface exposed from `useGraphState` enough that `Graph` no longer passes every individual state ref by hand.
+Then it narrows the interface exposed by the runtime hook enough that `Graph` no longer passes every individual state ref by hand.
 
 ## Implemented Shape
 

--- a/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
+++ b/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
@@ -1,0 +1,53 @@
+# Issue 159: Relationship Graph Runtime State
+
+## Goal
+
+Deepen the Graph View runtime state boundary so callers ask for Relationship Graph behavior instead of reassembling refs, lifecycle details, render caches, timers, and Visible Graph data across the Graph View.
+
+## Source
+
+Trello card: https://trello.com/c/09objACH/159-architecture-deepen-relationship-graph-runtime-state
+
+Recommendation strength: Strong
+
+## Current Shape
+
+`useGraphState` owns real runtime concerns, but its return type is still mostly a bag of implementation details:
+
+- force graph refs
+- selection refs and setters
+- hover and highlight refs
+- context menu state
+- cursor and right-click timers
+- file info, sprite, mesh, node decoration, and edge decoration caches
+- computed force graph data and its backing ref
+
+`Graph` then fans these details back out into interaction runtime setup, auto-fit, debug API setup, callback option building, and viewport props.
+
+## Target Direction
+
+Move toward a runtime module that exposes behavior-oriented surfaces, such as:
+
+- rendered graph data access for surfaces that must render the Visible Graph
+- selection behavior instead of raw selected-node refs and setters
+- context-selection behavior instead of context-menu state plumbing
+- renderer refs and lifecycle behavior instead of individual force graph refs scattered through callers
+- render cache invalidation behavior instead of direct sprite, mesh, image-cache, and decoration refs
+
+## Alignment Questions
+
+1. Should this slice create one cohesive `graphRuntime` object, or a small set of named runtime facets such as `selection`, `renderer`, `contextSelection`, and `renderCaches`?
+2. Which consumers are allowed to keep raw refs because they integrate with `react-force-graph`, and which should be forced through behavior methods?
+3. Should the public boundary continue to use React hook language like `UseGraphStateResult`, or should this become a Graph View runtime model with hook implementation hidden behind it?
+4. What behavior is in scope for the first TDD slice: selection pruning, timeline alpha application, image cache invalidation, or interaction/runtime setup?
+5. Does this refactor need an ADR, or is the trade-off local and reversible enough to live only in this plan and tests?
+
+## First Slice Candidate
+
+Start with tests around the behavior that currently leaks through `UseGraphStateResult`:
+
+- selection is pruned when selected nodes leave the Visible Graph
+- timeline alpha is applied through runtime behavior, not by callers knowing about 2D graph refs
+- image cache invalidation is triggered through a named behavior rather than exposed setter details
+
+Then narrow the interface exposed from `useGraphState` enough that `Graph` no longer passes every individual state ref by hand.

--- a/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
+++ b/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
@@ -47,6 +47,7 @@ Move toward a runtime module that exposes behavior-oriented surfaces, such as:
 - Return one named Graph View runtime object made of explicit facets, such as `selection`, `renderer`, `contextSelection`, and `renderCaches`. Avoid a flat `UseGraphStateResult` bag of refs, but also avoid one vague runtime object with unrelated behavior mixed together.
 - Keep raw `react-force-graph` refs at the adapter edge only. Rendering surfaces and renderer lifecycle code may receive raw `fg2dRef`, `fg3dRef`, and container refs when they call the force-graph imperative API directly. Interaction, debug, viewport model, callbacks, and Graph View composition should receive behavior-oriented runtime facets unless they have a concrete renderer integration reason to use refs.
 - Treat the exported boundary as a Graph View runtime model, not a React hook result type. A hook such as `useGraphRuntime` can construct the model, but callers should depend on domain-shaped types such as `GraphRuntime` and explicit runtime facets rather than `UseGraphStateResult`.
+- No ADR is needed for this slice. The change is local to the Graph View runtime boundary, is reversible through ordinary refactoring, and does not introduce a hard-to-reverse product or package contract decision.
 
 ## First Slice Candidate
 
@@ -57,3 +58,14 @@ Start with tests around the behavior that currently leaks through `UseGraphState
 - image cache invalidation is triggered through a named behavior rather than exposed setter details
 
 Then narrow the interface exposed from `useGraphState` enough that `Graph` no longer passes every individual state ref by hand.
+
+## Implemented Shape
+
+The runtime hook is now `useGraphRuntime`, returning a `GraphRuntime` model with explicit facets:
+
+- `renderer` owns force-graph refs and runtime graph data.
+- `selection` owns selected node ids, the selected-node ref, and selection updates.
+- `context` owns context selection and right-click/context-menu lifecycle refs.
+- `renderCaches` owns file info, sprite, mesh, and image invalidation cache behavior.
+
+Graph View composition now consumes these facets when wiring interaction, auto-fit, debug, callbacks, and viewport rendering. The focused TDD slice covers selection pruning through `runtime.selection` and render-cache image invalidation through `runtime.renderCaches`.

--- a/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
+++ b/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
@@ -46,6 +46,7 @@ Move toward a runtime module that exposes behavior-oriented surfaces, such as:
 
 - Return one named Graph View runtime object made of explicit facets, such as `selection`, `renderer`, `contextSelection`, and `renderCaches`. Avoid a flat `UseGraphStateResult` bag of refs, but also avoid one vague runtime object with unrelated behavior mixed together.
 - Keep raw `react-force-graph` refs at the adapter edge only. Rendering surfaces and renderer lifecycle code may receive raw `fg2dRef`, `fg3dRef`, and container refs when they call the force-graph imperative API directly. Interaction, debug, viewport model, callbacks, and Graph View composition should receive behavior-oriented runtime facets unless they have a concrete renderer integration reason to use refs.
+- Treat the exported boundary as a Graph View runtime model, not a React hook result type. A hook such as `useGraphRuntime` can construct the model, but callers should depend on domain-shaped types such as `GraphRuntime` and explicit runtime facets rather than `UseGraphStateResult`.
 
 ## First Slice Candidate
 

--- a/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
+++ b/docs/plans/2026-05-29-issue-159-relationship-graph-runtime-state.md
@@ -45,6 +45,7 @@ Move toward a runtime module that exposes behavior-oriented surfaces, such as:
 ## Decisions
 
 - Return one named Graph View runtime object made of explicit facets, such as `selection`, `renderer`, `contextSelection`, and `renderCaches`. Avoid a flat `UseGraphStateResult` bag of refs, but also avoid one vague runtime object with unrelated behavior mixed together.
+- Keep raw `react-force-graph` refs at the adapter edge only. Rendering surfaces and renderer lifecycle code may receive raw `fg2dRef`, `fg3dRef`, and container refs when they call the force-graph imperative API directly. Interaction, debug, viewport model, callbacks, and Graph View composition should receive behavior-oriented runtime facets unless they have a concrete renderer integration reason to use refs.
 
 ## First Slice Candidate
 

--- a/packages/extension/src/webview/components/graph/contextMenuOpening/runtime.ts
+++ b/packages/extension/src/webview/components/graph/contextMenuOpening/runtime.ts
@@ -35,16 +35,16 @@ export interface GraphContextMenuOpeningRuntime {
 }
 
 export interface GraphContextMenuOpeningOptions {
-  fileInfoCacheRef: GraphRuntime['fileInfoCacheRef'];
+  fileInfoCacheRef: GraphRuntime['renderCaches']['fileInfoCacheRef'];
   getActionContext(): GraphContextActionContext;
   hoveredNodeRef: MutableRefObject<FGNode | null>;
   interactionHandlers: GraphInteractionHandlersRuntime;
-  lastContainerContextMenuEventRef: GraphRuntime['lastContainerContextMenuEventRef'];
-  lastGraphContextEventRef: GraphRuntime['lastGraphContextEventRef'];
+  lastContainerContextMenuEventRef: GraphRuntime['context']['lastContainerContextMenuEventRef'];
+  lastGraphContextEventRef: GraphRuntime['context']['lastGraphContextEventRef'];
   openFilterPatternPrompt?: (patterns: string[]) => void;
   openLegendRulePrompt?: (rule: { pattern: string; color: string; target: 'node' | 'edge' }) => void;
   refs: Pick<
-    GraphRuntime,
+    GraphRuntime['context'],
     | 'rightClickFallbackTimerRef'
     | 'rightMouseDownRef'
   >;

--- a/packages/extension/src/webview/components/graph/contextMenuOpening/runtime.ts
+++ b/packages/extension/src/webview/components/graph/contextMenuOpening/runtime.ts
@@ -15,7 +15,7 @@ import {
 } from '../contextMenuRuntime/controller';
 import type { createGraphInteractionHandlers } from '../interactionRuntime/handlers';
 import type { FGLink, FGNode } from '../model/build';
-import type { UseGraphStateResult } from '../runtime/use/state';
+import type { GraphRuntime } from '../runtime/use/state';
 import { postMessage } from '../../../vscodeApi';
 
 type GraphInteractionHandlersRuntime = ReturnType<typeof createGraphInteractionHandlers>;
@@ -35,16 +35,16 @@ export interface GraphContextMenuOpeningRuntime {
 }
 
 export interface GraphContextMenuOpeningOptions {
-  fileInfoCacheRef: UseGraphStateResult['fileInfoCacheRef'];
+  fileInfoCacheRef: GraphRuntime['fileInfoCacheRef'];
   getActionContext(): GraphContextActionContext;
   hoveredNodeRef: MutableRefObject<FGNode | null>;
   interactionHandlers: GraphInteractionHandlersRuntime;
-  lastContainerContextMenuEventRef: UseGraphStateResult['lastContainerContextMenuEventRef'];
-  lastGraphContextEventRef: UseGraphStateResult['lastGraphContextEventRef'];
+  lastContainerContextMenuEventRef: GraphRuntime['lastContainerContextMenuEventRef'];
+  lastGraphContextEventRef: GraphRuntime['lastGraphContextEventRef'];
   openFilterPatternPrompt?: (patterns: string[]) => void;
   openLegendRulePrompt?: (rule: { pattern: string; color: string; target: 'node' | 'edge' }) => void;
   refs: Pick<
-    UseGraphStateResult,
+    GraphRuntime,
     | 'rightClickFallbackTimerRef'
     | 'rightMouseDownRef'
   >;

--- a/packages/extension/src/webview/components/graph/debug/options.ts
+++ b/packages/extension/src/webview/components/graph/debug/options.ts
@@ -1,5 +1,5 @@
 import type { UseGraphInteractionRuntimeResult } from '../runtime/use/interaction';
-import type { UseGraphStateResult } from '../runtime/use/state';
+import type { GraphRuntime } from '../runtime/use/state';
 import type { GraphDebugControls } from './contracts/protocol';
 
 export function buildGraphDebugOptions({
@@ -9,25 +9,25 @@ export function buildGraphDebugOptions({
   win,
 }: {
   graphMode: '2d' | '3d';
-  graphState: UseGraphStateResult;
+  graphState: GraphRuntime;
   interactions: UseGraphInteractionRuntimeResult;
   win?: Window;
 }): {
-  containerRef: UseGraphStateResult['containerRef'];
+  containerRef: GraphRuntime['renderer']['containerRef'];
   fitView(this: void): void;
   fg2dRef: { current: GraphDebugControls | undefined };
   fg3dRef: { current: GraphDebugControls | undefined };
-  graphDataRef: UseGraphStateResult['graphDataRef'];
+  graphDataRef: GraphRuntime['renderer']['graphDataRef'];
   graphMode: '2d' | '3d';
   openNodeContextMenu: UseGraphInteractionRuntimeResult['handleNodeContextMenuById'];
   win?: Window;
 } {
   return {
-    containerRef: graphState.containerRef,
+    containerRef: graphState.renderer.containerRef,
     fitView: interactions.interactionHandlers.fitView,
-    fg2dRef: graphState.fg2dRef,
-    fg3dRef: graphState.fg3dRef,
-    graphDataRef: graphState.graphDataRef,
+    fg2dRef: graphState.renderer.fg2dRef,
+    fg3dRef: graphState.renderer.fg3dRef,
+    graphDataRef: graphState.renderer.graphDataRef,
     graphMode,
     openNodeContextMenu: interactions.handleNodeContextMenuById,
     win,

--- a/packages/extension/src/webview/components/graph/rendering/useGraphCallbacks.ts
+++ b/packages/extension/src/webview/components/graph/rendering/useGraphCallbacks.ts
@@ -18,14 +18,14 @@ import {
   paintNodePointerArea,
   renderNodeCanvas,
 } from './nodes/canvas2d';
-import type { UseGraphStateResult } from '../runtime/use/state';
+import type { GraphRuntime } from '../runtime/use/state';
 import type { FGLink, FGNode } from '../model/build';
 import type { WebviewPluginHost } from '../../../pluginHost/manager';
 
 export interface UseGraphCallbacksOptions {
   pluginHost?: WebviewPluginHost;
   refs: Pick<
-    UseGraphStateResult,
+    GraphRuntime,
     | 'directionColorRef'
     | 'directionModeRef'
     | 'edgeDecorationsRef'

--- a/packages/extension/src/webview/components/graph/rendering/useGraphCallbacks.ts
+++ b/packages/extension/src/webview/components/graph/rendering/useGraphCallbacks.ts
@@ -32,13 +32,14 @@ export interface UseGraphCallbacksOptions {
     | 'graphAppearanceRef'
     | 'highlightedNeighborsRef'
     | 'highlightedNodeRef'
-    | 'meshesRef'
     | 'nodeDecorationsRef'
-    | 'selectedNodesSetRef'
     | 'showLabelsRef'
-    | 'spritesRef'
     | 'themeRef'
-  >;
+  > & {
+    meshesRef: GraphRuntime['renderCaches']['meshesRef'];
+    selectedNodesSetRef: GraphRuntime['selection']['selectedNodeIdsRef'];
+    spritesRef: GraphRuntime['renderCaches']['spritesRef'];
+  };
   triggerImageRerender(this: void): void;
 }
 

--- a/packages/extension/src/webview/components/graph/runtime/use/events/effects.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/events/effects.ts
@@ -14,22 +14,22 @@ import { exportAsSvg } from '../../../../../export/svg/export';
 import { postMessage } from '../../../../../vscodeApi';
 import { graphStore } from '../../../../../store/state';
 import type { FGLink, FGNode } from '../../../model/build';
-import type { UseGraphStateResult } from '../state';
+import type { GraphRuntime } from '../state';
 import type { UseGraphInteractionRuntimeResult } from '../interaction';
 
 export interface UseGraphEventEffectsOptions {
   containerRef: MutableRefObject<HTMLDivElement | null>;
   dataRef: MutableRefObject<IGraphData>;
-  directionColorRef: UseGraphStateResult['directionColorRef'];
-  directionModeRef: UseGraphStateResult['directionModeRef'];
+  directionColorRef: GraphRuntime['directionColorRef'];
+  directionModeRef: GraphRuntime['directionModeRef'];
   graphDataRef: MutableRefObject<{ links: FGLink[]; nodes: FGNode[] }>;
   graphMode: '2d' | '3d';
   interactionHandlers: UseGraphInteractionRuntimeResult['interactionHandlers'];
   fileInfoCacheRef: MutableRefObject<Map<string, IFileInfo>>;
   selectedNodes: string[];
   setTooltipData: UseGraphInteractionRuntimeResult['setTooltipData'];
-  showLabelsRef: UseGraphStateResult['showLabelsRef'];
-  themeRef: UseGraphStateResult['themeRef'];
+  showLabelsRef: GraphRuntime['showLabelsRef'];
+  themeRef: GraphRuntime['themeRef'];
   tooltipPath: string;
 }
 

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/contracts.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/contracts.ts
@@ -12,30 +12,30 @@ import type { FGNode } from '../../../model/build';
 import type { GraphCursorStyle } from '../../../support/dom';
 import type { WebviewPluginHost } from '../../../../../pluginHost/manager';
 import type { useGraphTooltip } from '../tooltip/hook';
-import type { UseGraphStateResult } from '../state';
+import type { GraphRuntime } from '../state';
 
 export type GraphInteractionHandlersRuntime = ReturnType<typeof createGraphInteractionHandlers>;
 
 export interface UseGraphInteractionRuntimeOptions {
   dataRef: MutableRefObject<IGraphData>;
   depthMode: boolean;
-  fileInfoCacheRef: UseGraphStateResult['fileInfoCacheRef'];
+  fileInfoCacheRef: GraphRuntime['fileInfoCacheRef'];
   graphContextSelection: GraphContextSelection;
   graphCursorRef: MutableRefObject<GraphCursorStyle>;
-  graphDataRef: UseGraphStateResult['graphDataRef'];
+  graphDataRef: GraphRuntime['graphDataRef'];
   graphViewContributions?: CoreGraphViewContributionSet;
   graphMode: '2d' | '3d';
-  highlightedNeighborsRef: UseGraphStateResult['highlightedNeighborsRef'];
-  highlightedNodeRef: UseGraphStateResult['highlightedNodeRef'];
+  highlightedNeighborsRef: GraphRuntime['highlightedNeighborsRef'];
+  highlightedNodeRef: GraphRuntime['highlightedNodeRef'];
   isMacPlatform: boolean;
-  lastClickRef: UseGraphStateResult['lastClickRef'];
-  lastContainerContextMenuEventRef: UseGraphStateResult['lastContainerContextMenuEventRef'];
-  lastGraphContextEventRef: UseGraphStateResult['lastGraphContextEventRef'];
+  lastClickRef: GraphRuntime['lastClickRef'];
+  lastContainerContextMenuEventRef: GraphRuntime['lastContainerContextMenuEventRef'];
+  lastGraphContextEventRef: GraphRuntime['lastGraphContextEventRef'];
   openFilterPatternPrompt?: (patterns: string[]) => void;
   openLegendRulePrompt?: (rule: { pattern: string; color: string; target: 'node' | 'edge' }) => void;
   pluginHost?: WebviewPluginHost;
   refs: Pick<
-    UseGraphStateResult,
+    GraphRuntime,
     | 'containerRef'
     | 'fg2dRef'
     | 'fg3dRef'

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/contracts.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/contracts.ts
@@ -19,30 +19,29 @@ export type GraphInteractionHandlersRuntime = ReturnType<typeof createGraphInter
 export interface UseGraphInteractionRuntimeOptions {
   dataRef: MutableRefObject<IGraphData>;
   depthMode: boolean;
-  fileInfoCacheRef: GraphRuntime['fileInfoCacheRef'];
+  fileInfoCacheRef: GraphRuntime['renderCaches']['fileInfoCacheRef'];
   graphContextSelection: GraphContextSelection;
   graphCursorRef: MutableRefObject<GraphCursorStyle>;
-  graphDataRef: GraphRuntime['graphDataRef'];
+  graphDataRef: GraphRuntime['renderer']['graphDataRef'];
   graphViewContributions?: CoreGraphViewContributionSet;
   graphMode: '2d' | '3d';
   highlightedNeighborsRef: GraphRuntime['highlightedNeighborsRef'];
   highlightedNodeRef: GraphRuntime['highlightedNodeRef'];
   isMacPlatform: boolean;
   lastClickRef: GraphRuntime['lastClickRef'];
-  lastContainerContextMenuEventRef: GraphRuntime['lastContainerContextMenuEventRef'];
-  lastGraphContextEventRef: GraphRuntime['lastGraphContextEventRef'];
+  lastContainerContextMenuEventRef: GraphRuntime['context']['lastContainerContextMenuEventRef'];
+  lastGraphContextEventRef: GraphRuntime['context']['lastGraphContextEventRef'];
   openFilterPatternPrompt?: (patterns: string[]) => void;
   openLegendRulePrompt?: (rule: { pattern: string; color: string; target: 'node' | 'edge' }) => void;
   pluginHost?: WebviewPluginHost;
-  refs: Pick<
-    GraphRuntime,
-    | 'containerRef'
-    | 'fg2dRef'
-    | 'fg3dRef'
-    | 'rightClickFallbackTimerRef'
-    | 'rightMouseDownRef'
-    | 'selectedNodesSetRef'
-  >;
+  refs: {
+    containerRef: GraphRuntime['renderer']['containerRef'];
+    fg2dRef: GraphRuntime['renderer']['fg2dRef'];
+    fg3dRef: GraphRuntime['renderer']['fg3dRef'];
+    rightClickFallbackTimerRef: GraphRuntime['context']['rightClickFallbackTimerRef'];
+    rightMouseDownRef: GraphRuntime['context']['rightMouseDownRef'];
+    selectedNodesSetRef: GraphRuntime['selection']['selectedNodeIdsRef'];
+  };
   setContextSelection: Dispatch<SetStateAction<GraphContextSelection>>;
   setHighlightVersion: Dispatch<SetStateAction<number>>;
   setSelectedNodes: Dispatch<SetStateAction<string[]>>;

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/marquee/state.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/marquee/state.ts
@@ -8,7 +8,7 @@ import {
   type GraphMarqueeSelectionState,
   type MarqueePoint,
 } from '../../../../marqueeSelection/model';
-import type { UseGraphStateResult } from '../../state';
+import type { GraphRuntime } from '../../state';
 import type { GraphInteractionHandlersRuntime } from '../contracts';
 
 const MARQUEE_DRAG_THRESHOLD_PX = 6;
@@ -22,13 +22,13 @@ export interface MarqueeDragState {
 }
 
 export interface GraphMarqueeSelectionRuntimeOptions {
-  containerRef: UseGraphStateResult['containerRef'];
-  fg2dRef: UseGraphStateResult['fg2dRef'];
-  graphDataRef: UseGraphStateResult['graphDataRef'];
+  containerRef: GraphRuntime['containerRef'];
+  fg2dRef: GraphRuntime['fg2dRef'];
+  graphDataRef: GraphRuntime['graphDataRef'];
   graphMode: '2d' | '3d';
   hoveredNodeRef: MutableRefObject<FGNode | null>;
   interactionHandlers: GraphInteractionHandlersRuntime;
-  selectedNodesSetRef: UseGraphStateResult['selectedNodesSetRef'];
+  selectedNodesSetRef: GraphRuntime['selectedNodesSetRef'];
 }
 
 export interface GraphMarqueeSelectionRuntime {

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/marquee/state.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/marquee/state.ts
@@ -22,13 +22,13 @@ export interface MarqueeDragState {
 }
 
 export interface GraphMarqueeSelectionRuntimeOptions {
-  containerRef: GraphRuntime['containerRef'];
-  fg2dRef: GraphRuntime['fg2dRef'];
-  graphDataRef: GraphRuntime['graphDataRef'];
+  containerRef: GraphRuntime['renderer']['containerRef'];
+  fg2dRef: GraphRuntime['renderer']['fg2dRef'];
+  graphDataRef: GraphRuntime['renderer']['graphDataRef'];
   graphMode: '2d' | '3d';
   hoveredNodeRef: MutableRefObject<FGNode | null>;
   interactionHandlers: GraphInteractionHandlersRuntime;
-  selectedNodesSetRef: GraphRuntime['selectedNodesSetRef'];
+  selectedNodesSetRef: GraphRuntime['selection']['selectedNodeIdsRef'];
 }
 
 export interface GraphMarqueeSelectionRuntime {

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/coordinates.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/coordinates.ts
@@ -1,10 +1,10 @@
 import type { MarqueePoint } from '../../../../marqueeSelection/model';
-import type { UseGraphStateResult } from '../../state';
+import type { GraphRuntime } from '../../state';
 import { isFiniteNumber } from '../positions';
 import type { ViewportPanDragState } from './state';
 
 export function readViewportPanCenter(
-  graph: UseGraphStateResult['fg2dRef']['current'],
+  graph: GraphRuntime['fg2dRef']['current'],
   container: HTMLDivElement | null,
 ): { x: number; y: number } {
   const rect = container?.getBoundingClientRect();
@@ -17,7 +17,7 @@ export function readViewportPanCenter(
 }
 
 export function readViewportPanZoom(
-  graph: UseGraphStateResult['fg2dRef']['current'],
+  graph: GraphRuntime['fg2dRef']['current'],
 ): number {
   const zoom = graph?.zoom?.();
   return isFiniteNumber(zoom) && zoom !== 0 ? zoom : 1;
@@ -26,7 +26,7 @@ export function readViewportPanZoom(
 export function applyViewportPanDrag(
   drag: ViewportPanDragState,
   current: MarqueePoint,
-  graph: UseGraphStateResult['fg2dRef']['current'],
+  graph: GraphRuntime['fg2dRef']['current'],
 ): void {
   graph?.centerAt?.(
     drag.center.x - ((current.x - drag.start.x) / drag.zoom),

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/coordinates.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/coordinates.ts
@@ -4,7 +4,7 @@ import { isFiniteNumber } from '../positions';
 import type { ViewportPanDragState } from './state';
 
 export function readViewportPanCenter(
-  graph: GraphRuntime['fg2dRef']['current'],
+  graph: GraphRuntime['renderer']['fg2dRef']['current'],
   container: HTMLDivElement | null,
 ): { x: number; y: number } {
   const rect = container?.getBoundingClientRect();
@@ -17,7 +17,7 @@ export function readViewportPanCenter(
 }
 
 export function readViewportPanZoom(
-  graph: GraphRuntime['fg2dRef']['current'],
+  graph: GraphRuntime['renderer']['fg2dRef']['current'],
 ): number {
   const zoom = graph?.zoom?.();
   return isFiniteNumber(zoom) && zoom !== 0 ? zoom : 1;
@@ -26,7 +26,7 @@ export function readViewportPanZoom(
 export function applyViewportPanDrag(
   drag: ViewportPanDragState,
   current: MarqueePoint,
-  graph: GraphRuntime['fg2dRef']['current'],
+  graph: GraphRuntime['renderer']['fg2dRef']['current'],
 ): void {
   graph?.centerAt?.(
     drag.center.x - ((current.x - drag.start.x) / drag.zoom),

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/state.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/state.ts
@@ -24,10 +24,10 @@ export interface ViewportPanDragState {
 }
 
 export interface GraphViewportPanRuntimeOptions {
-  containerRef: GraphRuntime['containerRef'];
-  fg2dRef: GraphRuntime['fg2dRef'];
+  containerRef: GraphRuntime['renderer']['containerRef'];
+  fg2dRef: GraphRuntime['renderer']['fg2dRef'];
   graphMode: '2d' | '3d';
-  rightMouseDownRef: GraphRuntime['rightMouseDownRef'];
+  rightMouseDownRef: GraphRuntime['context']['rightMouseDownRef'];
   suppressContextMenu(this: void): void;
 }
 
@@ -45,7 +45,7 @@ function isViewportPanButton(event: ReactMouseEvent<HTMLDivElement>): boolean {
 
 export function createViewportPanDragState(
   event: ReactMouseEvent<HTMLDivElement>,
-  graph: GraphRuntime['fg2dRef']['current'],
+  graph: GraphRuntime['renderer']['fg2dRef']['current'],
   container: HTMLDivElement | null,
 ): ViewportPanDragState {
   return {

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/state.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/state.ts
@@ -6,7 +6,7 @@ import {
   isMarqueePastThreshold,
   type MarqueePoint,
 } from '../../../../marqueeSelection/model';
-import type { UseGraphStateResult } from '../../state';
+import type { GraphRuntime } from '../../state';
 import {
   readViewportPanCenter,
   readViewportPanZoom,
@@ -24,10 +24,10 @@ export interface ViewportPanDragState {
 }
 
 export interface GraphViewportPanRuntimeOptions {
-  containerRef: UseGraphStateResult['containerRef'];
-  fg2dRef: UseGraphStateResult['fg2dRef'];
+  containerRef: GraphRuntime['containerRef'];
+  fg2dRef: GraphRuntime['fg2dRef'];
   graphMode: '2d' | '3d';
-  rightMouseDownRef: UseGraphStateResult['rightMouseDownRef'];
+  rightMouseDownRef: GraphRuntime['rightMouseDownRef'];
   suppressContextMenu(this: void): void;
 }
 
@@ -45,7 +45,7 @@ function isViewportPanButton(event: ReactMouseEvent<HTMLDivElement>): boolean {
 
 export function createViewportPanDragState(
   event: ReactMouseEvent<HTMLDivElement>,
-  graph: UseGraphStateResult['fg2dRef']['current'],
+  graph: GraphRuntime['fg2dRef']['current'],
   container: HTMLDivElement | null,
 ): ViewportPanDragState {
   return {

--- a/packages/extension/src/webview/components/graph/runtime/use/state.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/state.ts
@@ -56,7 +56,13 @@ export interface UseGraphStateOptions {
   timelineActive: boolean;
 }
 
-export interface UseGraphStateResult {
+export interface GraphRuntimeSelection {
+  selectedNodeIds: string[];
+  selectedNodeIdsRef: MutableRefObject<Set<string>>;
+  setSelectedNodeIds: Dispatch<SetStateAction<string[]>>;
+}
+
+export interface GraphRuntime {
   containerRef: MutableRefObject<HTMLDivElement | null>;
   contextSelection: GraphContextSelection;
   dataRef: MutableRefObject<IGraphData>;
@@ -83,6 +89,7 @@ export interface UseGraphStateResult {
   nodeSizeModeRef: MutableRefObject<NodeSizeMode>;
   rightClickFallbackTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
   rightMouseDownRef: MutableRefObject<GraphMouseState | null>;
+  selection: GraphRuntimeSelection;
   selectedNodes: string[];
   selectedNodesSetRef: MutableRefObject<Set<string>>;
   setContextSelection: Dispatch<SetStateAction<GraphContextSelection>>;
@@ -94,6 +101,8 @@ export interface UseGraphStateResult {
   timelineActiveRef: MutableRefObject<boolean>;
   triggerImageRerender(this: void): void;
 }
+
+export type UseGraphStateResult = GraphRuntime;
 
 export interface TimelineAlphaGraph {
   d3Alpha?: (value: number) => unknown;
@@ -138,7 +147,7 @@ export function useGraphState({
   showLabels,
   theme,
   timelineActive,
-}: UseGraphStateOptions): UseGraphStateResult {
+}: UseGraphStateOptions): GraphRuntime {
   const timelineActiveRef = useRef(timelineActive);
   timelineActiveRef.current = timelineActive;
 
@@ -256,6 +265,11 @@ export function useGraphState({
     nodeSizeModeRef,
     rightClickFallbackTimerRef,
     rightMouseDownRef,
+    selection: {
+      selectedNodeIds: selectedNodes,
+      selectedNodeIdsRef: selectedNodesSetRef,
+      setSelectedNodeIds: setSelectedNodes,
+    },
     selectedNodes,
     selectedNodesSetRef,
     setContextSelection,

--- a/packages/extension/src/webview/components/graph/runtime/use/state.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/state.ts
@@ -56,8 +56,6 @@ export interface GraphRuntimeOptions {
   timelineActive: boolean;
 }
 
-export type UseGraphStateOptions = GraphRuntimeOptions;
-
 export interface GraphRuntimeSelection {
   selectedNodeIds: string[];
   selectedNodeIdsRef: MutableRefObject<Set<string>>;
@@ -90,49 +88,28 @@ export interface GraphRuntimeRenderCaches {
 }
 
 export interface GraphRuntime {
-  containerRef: MutableRefObject<HTMLDivElement | null>;
   context: GraphRuntimeContextSelection;
-  contextSelection: GraphContextSelection;
   dataRef: MutableRefObject<IGraphData>;
   directionColorRef: MutableRefObject<string>;
   directionModeRef: MutableRefObject<DirectionMode>;
   edgeDecorationsRef: MutableRefObject<Record<string, EdgeDecorationPayload> | undefined>;
   favoritesRef: MutableRefObject<Set<string>>;
-  fg2dRef: MutableRefObject<FG2DMethods<FGNode, FGLink> | undefined>;
-  fg3dRef: MutableRefObject<FG3DMethods<FGNode, FGLink> | undefined>;
-  fileInfoCacheRef: MutableRefObject<Map<string, IFileInfo>>;
   graphCursorRef: MutableRefObject<GraphCursorStyle>;
   graphAppearanceRef: MutableRefObject<GraphAppearance>;
-  graphData: { links: FGLink[]; nodes: FGNode[] };
-  graphDataRef: MutableRefObject<{ links: FGLink[]; nodes: FGNode[] }>;
-  imageCacheVersion: number;
   highlightVersion: number;
   highlightedNeighborsRef: MutableRefObject<Set<string>>;
   highlightedNodeRef: MutableRefObject<string | null>;
   lastClickRef: MutableRefObject<{ nodeId: string; time: number } | null>;
-  lastContainerContextMenuEventRef: MutableRefObject<number>;
-  lastGraphContextEventRef: MutableRefObject<number>;
-  meshesRef: MutableRefObject<Map<string, THREE.Mesh>>;
   nodeDecorationsRef: MutableRefObject<Record<string, NodeDecorationPayload> | undefined>;
   nodeSizeModeRef: MutableRefObject<NodeSizeMode>;
-  rightClickFallbackTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
-  rightMouseDownRef: MutableRefObject<GraphMouseState | null>;
   renderer: GraphRuntimeRenderer;
   renderCaches: GraphRuntimeRenderCaches;
   selection: GraphRuntimeSelection;
-  selectedNodes: string[];
-  selectedNodesSetRef: MutableRefObject<Set<string>>;
-  setContextSelection: Dispatch<SetStateAction<GraphContextSelection>>;
   setHighlightVersion: Dispatch<SetStateAction<number>>;
-  setSelectedNodes: Dispatch<SetStateAction<string[]>>;
   showLabelsRef: MutableRefObject<boolean>;
-  spritesRef: MutableRefObject<Map<string, SpriteText>>;
   themeRef: MutableRefObject<ThemeKind>;
   timelineActiveRef: MutableRefObject<boolean>;
-  triggerImageRerender(this: void): void;
 }
-
-export type UseGraphStateResult = GraphRuntime;
 
 export interface TimelineAlphaGraph {
   d3Alpha?: (value: number) => unknown;
@@ -269,7 +246,6 @@ export function useGraphRuntime({
   }, [graphData, selectedNodes]);
 
   return {
-    containerRef,
     context: {
       selection: contextSelection,
       setSelection: setContextSelection,
@@ -278,31 +254,19 @@ export function useGraphRuntime({
       rightClickFallbackTimerRef,
       rightMouseDownRef,
     },
-    contextSelection,
     dataRef,
     directionColorRef,
     directionModeRef,
     edgeDecorationsRef,
     favoritesRef,
-    fg2dRef,
-    fg3dRef,
-    fileInfoCacheRef,
     graphCursorRef,
     graphAppearanceRef,
-    graphData,
-    graphDataRef,
-    imageCacheVersion,
     highlightVersion,
     highlightedNeighborsRef,
     highlightedNodeRef,
     lastClickRef,
-    lastContainerContextMenuEventRef,
-    lastGraphContextEventRef,
-    meshesRef,
     nodeDecorationsRef,
     nodeSizeModeRef,
-    rightClickFallbackTimerRef,
-    rightMouseDownRef,
     renderer: {
       containerRef,
       fg2dRef,
@@ -322,17 +286,9 @@ export function useGraphRuntime({
       selectedNodeIdsRef: selectedNodesSetRef,
       setSelectedNodeIds: setSelectedNodes,
     },
-    selectedNodes,
-    selectedNodesSetRef,
-    setContextSelection,
     setHighlightVersion,
-    setSelectedNodes,
     showLabelsRef,
-    spritesRef,
     themeRef,
     timelineActiveRef,
-    triggerImageRerender,
   };
 }
-
-export const useGraphState = useGraphRuntime;

--- a/packages/extension/src/webview/components/graph/runtime/use/state.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/state.ts
@@ -39,7 +39,7 @@ export interface GraphMouseState {
   y: number;
 }
 
-export interface UseGraphStateOptions {
+export interface GraphRuntimeOptions {
   bidirectionalMode: BidirectionalEdgeMode;
   appearance?: GraphAppearance;
   data: IGraphData;
@@ -56,14 +56,42 @@ export interface UseGraphStateOptions {
   timelineActive: boolean;
 }
 
+export type UseGraphStateOptions = GraphRuntimeOptions;
+
 export interface GraphRuntimeSelection {
   selectedNodeIds: string[];
   selectedNodeIdsRef: MutableRefObject<Set<string>>;
   setSelectedNodeIds: Dispatch<SetStateAction<string[]>>;
 }
 
+export interface GraphRuntimeRenderer {
+  containerRef: MutableRefObject<HTMLDivElement | null>;
+  fg2dRef: MutableRefObject<FG2DMethods<FGNode, FGLink> | undefined>;
+  fg3dRef: MutableRefObject<FG3DMethods<FGNode, FGLink> | undefined>;
+  graphData: { links: FGLink[]; nodes: FGNode[] };
+  graphDataRef: MutableRefObject<{ links: FGLink[]; nodes: FGNode[] }>;
+}
+
+export interface GraphRuntimeContextSelection {
+  selection: GraphContextSelection;
+  setSelection: Dispatch<SetStateAction<GraphContextSelection>>;
+  lastContainerContextMenuEventRef: MutableRefObject<number>;
+  lastGraphContextEventRef: MutableRefObject<number>;
+  rightClickFallbackTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
+  rightMouseDownRef: MutableRefObject<GraphMouseState | null>;
+}
+
+export interface GraphRuntimeRenderCaches {
+  fileInfoCacheRef: MutableRefObject<Map<string, IFileInfo>>;
+  imageCacheVersion: number;
+  invalidateImages(this: void): void;
+  meshesRef: MutableRefObject<Map<string, THREE.Mesh>>;
+  spritesRef: MutableRefObject<Map<string, SpriteText>>;
+}
+
 export interface GraphRuntime {
   containerRef: MutableRefObject<HTMLDivElement | null>;
+  context: GraphRuntimeContextSelection;
   contextSelection: GraphContextSelection;
   dataRef: MutableRefObject<IGraphData>;
   directionColorRef: MutableRefObject<string>;
@@ -89,6 +117,8 @@ export interface GraphRuntime {
   nodeSizeModeRef: MutableRefObject<NodeSizeMode>;
   rightClickFallbackTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
   rightMouseDownRef: MutableRefObject<GraphMouseState | null>;
+  renderer: GraphRuntimeRenderer;
+  renderCaches: GraphRuntimeRenderCaches;
   selection: GraphRuntimeSelection;
   selectedNodes: string[];
   selectedNodesSetRef: MutableRefObject<Set<string>>;
@@ -132,7 +162,7 @@ function getVisibleSelection(
   return selectedNodeIds.filter((nodeId) => visibleNodeIds.has(nodeId));
 }
 
-export function useGraphState({
+export function useGraphRuntime({
   bidirectionalMode,
   appearance = DEFAULT_GRAPH_APPEARANCE,
   data,
@@ -147,7 +177,7 @@ export function useGraphState({
   showLabels,
   theme,
   timelineActive,
-}: UseGraphStateOptions): GraphRuntime {
+}: GraphRuntimeOptions): GraphRuntime {
   const timelineActiveRef = useRef(timelineActive);
   timelineActiveRef.current = timelineActive;
 
@@ -240,6 +270,14 @@ export function useGraphState({
 
   return {
     containerRef,
+    context: {
+      selection: contextSelection,
+      setSelection: setContextSelection,
+      lastContainerContextMenuEventRef,
+      lastGraphContextEventRef,
+      rightClickFallbackTimerRef,
+      rightMouseDownRef,
+    },
     contextSelection,
     dataRef,
     directionColorRef,
@@ -265,6 +303,20 @@ export function useGraphState({
     nodeSizeModeRef,
     rightClickFallbackTimerRef,
     rightMouseDownRef,
+    renderer: {
+      containerRef,
+      fg2dRef,
+      fg3dRef,
+      graphData,
+      graphDataRef,
+    },
+    renderCaches: {
+      fileInfoCacheRef,
+      imageCacheVersion,
+      invalidateImages: triggerImageRerender,
+      meshesRef,
+      spritesRef,
+    },
     selection: {
       selectedNodeIds: selectedNodes,
       selectedNodeIdsRef: selectedNodesSetRef,
@@ -282,3 +334,5 @@ export function useGraphState({
     triggerImageRerender,
   };
 }
+
+export const useGraphState = useGraphRuntime;

--- a/packages/extension/src/webview/components/graph/view/callbackOptions.ts
+++ b/packages/extension/src/webview/components/graph/view/callbackOptions.ts
@@ -1,12 +1,12 @@
 import type { WebviewPluginHost } from '../../../pluginHost/manager';
 import type { UseGraphCallbacksOptions } from '../rendering/useGraphCallbacks';
-import type { UseGraphStateResult } from '../runtime/use/state';
+import type { GraphRuntime } from '../runtime/use/state';
 
 export function buildGraphCallbackOptions({
   graphState,
   pluginHost,
 }: {
-  graphState: UseGraphStateResult;
+  graphState: GraphRuntime;
   pluginHost?: WebviewPluginHost;
 }): UseGraphCallbacksOptions {
   return {
@@ -18,13 +18,13 @@ export function buildGraphCallbackOptions({
       graphAppearanceRef: graphState.graphAppearanceRef,
       highlightedNeighborsRef: graphState.highlightedNeighborsRef,
       highlightedNodeRef: graphState.highlightedNodeRef,
-      meshesRef: graphState.meshesRef,
+      meshesRef: graphState.renderCaches.meshesRef,
       nodeDecorationsRef: graphState.nodeDecorationsRef,
-      selectedNodesSetRef: graphState.selectedNodesSetRef,
+      selectedNodesSetRef: graphState.selection.selectedNodeIdsRef,
       showLabelsRef: graphState.showLabelsRef,
-      spritesRef: graphState.spritesRef,
+      spritesRef: graphState.renderCaches.spritesRef,
       themeRef: graphState.themeRef,
     },
-    triggerImageRerender: graphState.triggerImageRerender,
+    triggerImageRerender: graphState.renderCaches.invalidateImages,
   };
 }

--- a/packages/extension/src/webview/components/graph/view/component.tsx
+++ b/packages/extension/src/webview/components/graph/view/component.tsx
@@ -20,7 +20,7 @@ import { detectMacPlatform } from '../environment/platform';
 import { useGraphViewStoreState } from './store';
 import { useGraphCallbacks } from '../rendering/useGraphCallbacks';
 import { useGraphInteractionRuntime } from '../runtime/use/interaction';
-import { useGraphState } from '../runtime/use/state';
+import { useGraphRuntime } from '../runtime/use/state';
 import { isPhysicsGraphReady, selectActivePhysicsGraph } from '../runtime/physicsLifecycle/readiness';
 import { GraphViewportShell } from '../viewport/shell';
 import { ThemeKind } from '../../../theme/useTheme';
@@ -98,7 +98,7 @@ export default function Graph({
     pluginHost,
   );
 
-  const graphState = useGraphState({
+  const graphRuntime = useGraphRuntime({
     appearance,
     bidirectionalMode: viewState.bidirectionalMode,
     data,
@@ -114,50 +114,50 @@ export default function Graph({
     theme,
     timelineActive: viewState.timelineActive,
   });
-  const graphDataLayoutKey = buildGraphDataLayoutKey(graphState.graphData, viewState.nodeSizeMode);
+  const graphDataLayoutKey = buildGraphDataLayoutKey(graphRuntime.renderer.graphData, viewState.nodeSizeMode);
   const isMacPlatform = detectMacPlatform(getGraphNavigator());
 
   const interactions = useGraphInteractionRuntime({
-    dataRef: graphState.dataRef,
+    dataRef: graphRuntime.dataRef,
     depthMode: viewState.depthMode,
-    fileInfoCacheRef: graphState.fileInfoCacheRef,
-    graphContextSelection: graphState.contextSelection,
-    graphCursorRef: graphState.graphCursorRef,
-    graphDataRef: graphState.graphDataRef,
+    fileInfoCacheRef: graphRuntime.renderCaches.fileInfoCacheRef,
+    graphContextSelection: graphRuntime.context.selection,
+    graphCursorRef: graphRuntime.graphCursorRef,
+    graphDataRef: graphRuntime.renderer.graphDataRef,
     graphViewContributions: resolvedGraphViewContributions,
     graphMode: viewState.graphMode,
-    highlightedNeighborsRef: graphState.highlightedNeighborsRef,
-    highlightedNodeRef: graphState.highlightedNodeRef,
+    highlightedNeighborsRef: graphRuntime.highlightedNeighborsRef,
+    highlightedNodeRef: graphRuntime.highlightedNodeRef,
     isMacPlatform,
-    lastClickRef: graphState.lastClickRef,
-    lastContainerContextMenuEventRef: graphState.lastContainerContextMenuEventRef,
-    lastGraphContextEventRef: graphState.lastGraphContextEventRef,
+    lastClickRef: graphRuntime.lastClickRef,
+    lastContainerContextMenuEventRef: graphRuntime.context.lastContainerContextMenuEventRef,
+    lastGraphContextEventRef: graphRuntime.context.lastGraphContextEventRef,
     openFilterPatternPrompt: onAddFilterRequested,
     openLegendRulePrompt: onAddLegendRequested,
     pluginHost,
     refs: {
-      containerRef: graphState.containerRef,
-      fg2dRef: graphState.fg2dRef,
-      fg3dRef: graphState.fg3dRef,
-      rightClickFallbackTimerRef: graphState.rightClickFallbackTimerRef,
-      rightMouseDownRef: graphState.rightMouseDownRef,
-      selectedNodesSetRef: graphState.selectedNodesSetRef,
+      containerRef: graphRuntime.renderer.containerRef,
+      fg2dRef: graphRuntime.renderer.fg2dRef,
+      fg3dRef: graphRuntime.renderer.fg3dRef,
+      rightClickFallbackTimerRef: graphRuntime.context.rightClickFallbackTimerRef,
+      rightMouseDownRef: graphRuntime.context.rightMouseDownRef,
+      selectedNodesSetRef: graphRuntime.selection.selectedNodeIdsRef,
     },
-    setContextSelection: graphState.setContextSelection,
-    setHighlightVersion: graphState.setHighlightVersion,
-    setSelectedNodes: graphState.setSelectedNodes,
+    setContextSelection: graphRuntime.context.setSelection,
+    setHighlightVersion: graphRuntime.setHighlightVersion,
+    setSelectedNodes: graphRuntime.selection.setSelectedNodeIds,
     timelineActive: viewState.timelineActive,
   });
 
   const activeGraph = selectActivePhysicsGraph(
     viewState.graphMode,
-    graphState.fg2dRef.current,
-    graphState.fg3dRef.current,
+    graphRuntime.renderer.fg2dRef.current,
+    graphRuntime.renderer.fg3dRef.current,
   );
 
   const handleEngineStop = useGraphAutoFit({
     fitView: interactions.interactionHandlers.fitView,
-    graphData: graphState.graphData,
+    graphData: graphRuntime.renderer.graphData,
     graphMode: viewState.graphMode,
     graphReady: isPhysicsGraphReady(viewState.graphMode, activeGraph),
     handleEngineStop: interactions.handleEngineStop,
@@ -165,19 +165,19 @@ export default function Graph({
 
   useGraphDebugApi(buildGraphDebugOptions({
     graphMode: viewState.graphMode,
-    graphState,
+    graphState: graphRuntime,
     interactions,
     win: getGraphWindow(),
   }));
 
-  const callbacks = useGraphCallbacks(buildGraphCallbackOptions({ graphState, pluginHost }));
+  const callbacks = useGraphCallbacks(buildGraphCallbackOptions({ graphState: graphRuntime, pluginHost }));
 
   return (
     <GraphViewportShell
       appearance={appearance}
       callbacks={callbacks}
       graphDataLayoutKey={graphDataLayoutKey}
-      graphState={graphState}
+      graphState={graphRuntime}
       graphViewContributions={resolvedGraphViewContributions}
       handleEngineStop={handleEngineStop}
       interactions={interactions}

--- a/packages/extension/src/webview/components/graph/view/layoutKey.ts
+++ b/packages/extension/src/webview/components/graph/view/layoutKey.ts
@@ -2,7 +2,7 @@ import type { NodeSizeMode } from '../../../../shared/settings/modes';
 import type { GraphRuntime } from '../runtime/use/state';
 
 export function buildGraphDataLayoutKey(
-  graphData: GraphRuntime['graphData'],
+  graphData: GraphRuntime['renderer']['graphData'],
   nodeSizeMode: NodeSizeMode,
 ): string {
   const nodeIds = graphData.nodes.map(node => node.id).join('|');

--- a/packages/extension/src/webview/components/graph/view/layoutKey.ts
+++ b/packages/extension/src/webview/components/graph/view/layoutKey.ts
@@ -1,8 +1,8 @@
 import type { NodeSizeMode } from '../../../../shared/settings/modes';
-import type { UseGraphStateResult } from '../runtime/use/state';
+import type { GraphRuntime } from '../runtime/use/state';
 
 export function buildGraphDataLayoutKey(
-  graphData: UseGraphStateResult['graphData'],
+  graphData: GraphRuntime['graphData'],
   nodeSizeMode: NodeSizeMode,
 ): string {
   const nodeIds = graphData.nodes.map(node => node.id).join('|');

--- a/packages/extension/src/webview/components/graph/view/sharedPropsOptions.ts
+++ b/packages/extension/src/webview/components/graph/view/sharedPropsOptions.ts
@@ -15,7 +15,7 @@ export function buildGraphSharedPropsOptions({
   containerSize: { width: number; height: number };
   dagMode: DagMode;
   damping: number;
-  graphData: GraphRuntime['graphData'];
+  graphData: GraphRuntime['renderer']['graphData'];
   handleEngineStop(this: void): void;
   interactions: UseGraphInteractionRuntimeResult;
   timelineActive: boolean;

--- a/packages/extension/src/webview/components/graph/view/sharedPropsOptions.ts
+++ b/packages/extension/src/webview/components/graph/view/sharedPropsOptions.ts
@@ -1,6 +1,6 @@
 import type { BuildSharedGraphPropsOptions } from '../rendering/surface/sharedProps';
 import type { UseGraphInteractionRuntimeResult } from '../runtime/use/interaction';
-import type { UseGraphStateResult } from '../runtime/use/state';
+import type { GraphRuntime } from '../runtime/use/state';
 import type { DagMode } from '../../../../shared/settings/modes';
 
 export function buildGraphSharedPropsOptions({
@@ -15,7 +15,7 @@ export function buildGraphSharedPropsOptions({
   containerSize: { width: number; height: number };
   dagMode: DagMode;
   damping: number;
-  graphData: UseGraphStateResult['graphData'];
+  graphData: GraphRuntime['graphData'];
   handleEngineStop(this: void): void;
   interactions: UseGraphInteractionRuntimeResult;
   timelineActive: boolean;

--- a/packages/extension/src/webview/components/graph/viewport/model.ts
+++ b/packages/extension/src/webview/components/graph/viewport/model.ts
@@ -8,7 +8,7 @@ import { buildGraphContextMenuEntries } from '../contextMenu/build/entries';
 import { getGraphContextMutationAvailability } from '../contextMenu/mutationAvailability';
 import type { UseGraphInteractionRuntimeResult } from '../runtime/use/interaction';
 import type { UseGraphRenderingRuntimeResult } from '../runtime/use/rendering';
-import type { UseGraphStateResult } from '../runtime/use/state';
+import type { GraphRuntime } from '../runtime/use/state';
 import { buildSharedGraphProps } from '../rendering/surface/sharedProps';
 import { buildGraphSharedPropsOptions } from '../view/sharedPropsOptions';
 import { handleGraphSurface3dError } from '../rendering/surface/error';
@@ -27,7 +27,7 @@ export interface GraphViewportModel {
 }
 
 export interface GraphViewportModelOptions {
-  graphState: Pick<UseGraphStateResult, 'contextSelection' | 'graphData'>;
+  graphState: Pick<GraphRuntime, 'contextSelection' | 'graphData'>;
   graphViewContributions?: CoreGraphViewContributionSet;
   interactions: UseGraphInteractionRuntimeResult;
   handleEngineStop(this: void): void;

--- a/packages/extension/src/webview/components/graph/viewport/model.ts
+++ b/packages/extension/src/webview/components/graph/viewport/model.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { CoreGraphViewContributionSet } from '@codegraphy-dev/core';
 import type { GraphViewStoreState } from '../view/store';
 import type {
+  GraphContextSelection,
   GraphContextMenuEntry,
 } from '../contextMenu/contracts';
 import { buildGraphContextMenuEntries } from '../contextMenu/build/entries';
@@ -27,7 +28,10 @@ export interface GraphViewportModel {
 }
 
 export interface GraphViewportModelOptions {
-  graphState: Pick<GraphRuntime, 'contextSelection' | 'graphData'>;
+  graphState: {
+    contextSelection: GraphContextSelection;
+    graphData: GraphRuntime['renderer']['graphData'];
+  };
   graphViewContributions?: CoreGraphViewContributionSet;
   interactions: UseGraphInteractionRuntimeResult;
   handleEngineStop(this: void): void;

--- a/packages/extension/src/webview/components/graph/viewport/shell.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/shell.tsx
@@ -6,7 +6,7 @@ import type { WebviewPluginHost } from '../../../pluginHost/manager';
 import type { GraphViewStoreState } from '../view/store';
 import type { UseGraphCallbacksResult } from '../rendering/useGraphCallbacks';
 import type { UseGraphInteractionRuntimeResult } from '../runtime/use/interaction';
-import type { UseGraphStateResult } from '../runtime/use/state';
+import type { GraphRuntime } from '../runtime/use/state';
 import { useGraphRenderingRuntime } from '../runtime/use/rendering';
 import { useGraphEventEffects } from '../runtime/use/events/effects';
 import { Viewport } from './view';
@@ -24,7 +24,7 @@ export interface GraphViewportShellProps {
   appearance?: GraphAppearance;
   callbacks: UseGraphCallbacksResult;
   graphDataLayoutKey: string;
-  graphState: UseGraphStateResult;
+  graphState: GraphRuntime;
   graphViewContributions?: CoreGraphViewContributionSet;
   handleEngineStop(this: void): void;
   interactions: UseGraphInteractionRuntimeResult;
@@ -58,15 +58,15 @@ export function GraphViewportShell({
   }));
 
   useGraphEventEffects({
-    containerRef: graphState.containerRef,
+    containerRef: graphState.renderer.containerRef,
     dataRef: graphState.dataRef,
     directionColorRef: graphState.directionColorRef,
     directionModeRef: graphState.directionModeRef,
-    graphDataRef: graphState.graphDataRef,
+    graphDataRef: graphState.renderer.graphDataRef,
     graphMode: viewState.graphMode,
     interactionHandlers: interactions.interactionHandlers,
-    fileInfoCacheRef: graphState.fileInfoCacheRef,
-    selectedNodes: graphState.selectedNodes,
+    fileInfoCacheRef: graphState.renderCaches.fileInfoCacheRef,
+    selectedNodes: graphState.selection.selectedNodeIds,
     setTooltipData: interactions.setTooltipData,
     showLabelsRef: graphState.showLabelsRef,
     themeRef: graphState.themeRef,
@@ -97,12 +97,12 @@ export function GraphViewportShell({
       return;
     }
 
-    const graph = graphState.fg2dRef.current as GraphViewport2dControls | undefined;
+    const graph = graphState.renderer.fg2dRef.current as GraphViewport2dControls | undefined;
     pluginHost.setGraphViewViewportState(createGraphViewViewportState({
       globalScale,
       graph,
       graphMode: viewState.graphMode,
-      nodes: graphState.graphDataRef.current.nodes,
+      nodes: graphState.renderer.graphDataRef.current.nodes,
       timelineActive: viewState.timelineActive,
     }));
   };
@@ -130,7 +130,7 @@ export function GraphViewportShell({
       canvasBackgroundColor={viewportModel.canvasBackgroundColor}
       containerBackgroundColor={viewportModel.containerBackgroundColor}
       borderColor={viewportModel.borderColor}
-      containerRef={graphState.containerRef}
+      containerRef={graphState.renderer.containerRef}
       directionMode={viewState.directionMode}
       graphMode={viewState.graphMode}
       handleContextMenu={interactions.handleContextMenu}

--- a/packages/extension/src/webview/components/graph/viewport/shell/modelOptions.ts
+++ b/packages/extension/src/webview/components/graph/viewport/shell/modelOptions.ts
@@ -2,13 +2,13 @@ import type { CoreGraphViewContributionSet } from '@codegraphy-dev/core';
 import type { GraphAppearance } from '../../appearance/model';
 import type { UseGraphInteractionRuntimeResult } from '../../runtime/use/interaction';
 import type { UseGraphRenderingRuntimeResult } from '../../runtime/use/rendering';
-import type { UseGraphStateResult } from '../../runtime/use/state';
+import type { GraphRuntime } from '../../runtime/use/state';
 import type { GraphViewStoreState } from '../../view/store';
 import { useGraphViewportModel } from '../model';
 
 export interface UseGraphViewportModelOptionsInput {
 	appearance?: GraphAppearance;
-	graphState: UseGraphStateResult;
+	graphState: GraphRuntime;
 	graphViewContributions?: CoreGraphViewContributionSet;
 	interactions: UseGraphInteractionRuntimeResult;
 	handleEngineStop(this: void): void;
@@ -27,8 +27,8 @@ export function useGraphViewportModelOptions({
 }: UseGraphViewportModelOptionsInput) {
 	return useGraphViewportModel({
 		graphState: {
-			contextSelection: graphState.contextSelection,
-			graphData: graphState.graphData,
+			contextSelection: graphState.context.selection,
+			graphData: graphState.renderer.graphData,
 		},
 		graphViewContributions,
 		handleEngineStop,

--- a/packages/extension/src/webview/components/graph/viewport/shell/runtimeOptions.ts
+++ b/packages/extension/src/webview/components/graph/viewport/shell/runtimeOptions.ts
@@ -6,14 +6,14 @@ import type { UseGraphCallbacksResult } from '../../rendering/useGraphCallbacks'
 import type {
 	UseGraphRenderingRuntimeOptions,
 } from '../../runtime/use/rendering';
-import type { UseGraphStateResult } from '../../runtime/use/state';
+import type { GraphRuntime } from '../../runtime/use/state';
 import type { GraphViewStoreState } from '../../view/store';
 
 export interface BuildRenderingRuntimeOptionsInput {
 	appearance?: GraphAppearance;
 	callbacks: UseGraphCallbacksResult;
 	graphDataLayoutKey: string;
-	graphState: UseGraphStateResult;
+	graphState: GraphRuntime;
 	graphViewContributions?: CoreGraphViewContributionSet;
 	pluginHost?: WebviewPluginHost;
 	theme: ThemeKind;
@@ -32,31 +32,31 @@ export function buildRenderingRuntimeOptions({
 }: BuildRenderingRuntimeOptionsInput): UseGraphRenderingRuntimeOptions {
 	return {
 		appearance,
-		containerRef: graphState.containerRef,
+		containerRef: graphState.renderer.containerRef,
 		dataRef: graphState.dataRef,
-		fg2dRef: graphState.fg2dRef,
-		fg3dRef: graphState.fg3dRef,
+		fg2dRef: graphState.renderer.fg2dRef,
+		fg3dRef: graphState.renderer.fg3dRef,
 		getArrowColor: callbacks.getArrowColor,
 		getArrowRelPos: callbacks.getArrowRelPos,
 		getLinkParticles: callbacks.getLinkParticles,
 		getParticleColor: callbacks.getParticleColor,
-		graphDataRef: graphState.graphDataRef,
+		graphDataRef: graphState.renderer.graphDataRef,
 		graphViewContributions,
 		graphDataLayoutKey,
 		graphMode: viewState.graphMode,
 		highlightVersion: graphState.highlightVersion,
 		highlightedNeighborsRef: graphState.highlightedNeighborsRef,
 		highlightedNodeRef: graphState.highlightedNodeRef,
-		meshesRef: graphState.meshesRef,
+		meshesRef: graphState.renderCaches.meshesRef,
 		nodeSizeMode: viewState.nodeSizeMode,
 		particleSize: viewState.particleSize,
 		particleSpeed: viewState.particleSpeed,
 		physicsPaused: viewState.physicsPaused,
 		physicsSettings: viewState.physicsSettings,
 		pluginHost,
-		selectedNodesSetRef: graphState.selectedNodesSetRef,
+		selectedNodesSetRef: graphState.selection.selectedNodeIdsRef,
 		showLabels: viewState.showLabels,
-		spritesRef: graphState.spritesRef,
+		spritesRef: graphState.renderCaches.spritesRef,
 		theme,
 		timelineActive: viewState.timelineActive,
 		favorites: viewState.favorites,

--- a/packages/extension/src/webview/components/graph/viewport/shell/surfaceProps.ts
+++ b/packages/extension/src/webview/components/graph/viewport/shell/surfaceProps.ts
@@ -1,11 +1,11 @@
 import type { UseGraphCallbacksResult } from '../../rendering/useGraphCallbacks';
-import type { UseGraphStateResult } from '../../runtime/use/state';
+import type { GraphRuntime } from '../../runtime/use/state';
 import type { GraphViewStoreState } from '../../view/store';
 import type { ViewportProps } from '../view';
 
 export interface CreateGraphViewportSurfacePropsInput {
 	callbacks: UseGraphCallbacksResult;
-	graphState: UseGraphStateResult;
+	graphState: GraphRuntime;
 	onRenderFramePost: ViewportProps['surface2dProps']['onRenderFramePost'];
 	sharedProps: ViewportProps['surface2dProps']['sharedProps'];
 	viewState: Pick<GraphViewStoreState, 'particleSize' | 'particleSpeed'>;
@@ -20,7 +20,7 @@ export function createGraphViewportSurfaceProps({
 }: CreateGraphViewportSurfacePropsInput): Pick<ViewportProps, 'surface2dProps' | 'surface3dProps'> {
 	return {
 		surface2dProps: {
-			fg2dRef: graphState.fg2dRef,
+			fg2dRef: graphState.renderer.fg2dRef,
 			getArrowColor: callbacks.getArrowColor,
 			getArrowRelPos: callbacks.getArrowRelPos,
 			getLinkColor: callbacks.getLinkColor,
@@ -36,7 +36,7 @@ export function createGraphViewportSurfaceProps({
 			sharedProps,
 		},
 		surface3dProps: {
-			fg3dRef: graphState.fg3dRef,
+			fg3dRef: graphState.renderer.fg3dRef,
 			getArrowColor: callbacks.getArrowColor,
 			getLinkColor: callbacks.getLinkColor,
 			getLinkParticles: callbacks.getLinkParticles,

--- a/packages/extension/src/webview/components/graph/viewport/shell/viewportState.ts
+++ b/packages/extension/src/webview/components/graph/viewport/shell/viewportState.ts
@@ -2,7 +2,7 @@ import type {
 	GraphViewViewportNode,
 	GraphViewViewportState,
 } from '../../../../pluginHost/api/contracts/webview';
-import type { UseGraphStateResult } from '../../runtime/use/state';
+import type { GraphRuntime } from '../../runtime/use/state';
 
 export interface GraphViewport2dControls {
 	d3ReheatSimulation?(): void;
@@ -16,7 +16,7 @@ export interface CreateGraphViewViewportStateOptions {
 	globalScale: number;
 	graph: GraphViewport2dControls | undefined;
 	graphMode: '2d' | '3d';
-	nodes: UseGraphStateResult['graphData']['nodes'];
+	nodes: GraphRuntime['graphData']['nodes'];
 	timelineActive: boolean;
 }
 
@@ -29,7 +29,7 @@ function readViewportNumber(value: unknown): number | undefined {
 }
 
 export function toGraphViewViewportNodes(
-	nodes: UseGraphStateResult['graphData']['nodes'],
+	nodes: GraphRuntime['graphData']['nodes'],
 ): GraphViewViewportNode[] {
 	return nodes.map(node => {
 		const viewportNode = node as GraphViewViewportNode;
@@ -54,7 +54,7 @@ export function toGraphViewViewportNodes(
 }
 
 export function updateGraphViewViewportNode(
-	nodes: UseGraphStateResult['graphData']['nodes'],
+	nodes: GraphRuntime['graphData']['nodes'],
 	nodeId: string,
 	updates: Record<string, unknown>,
 ): boolean {

--- a/packages/extension/src/webview/components/graph/viewport/shell/viewportState.ts
+++ b/packages/extension/src/webview/components/graph/viewport/shell/viewportState.ts
@@ -16,7 +16,7 @@ export interface CreateGraphViewViewportStateOptions {
 	globalScale: number;
 	graph: GraphViewport2dControls | undefined;
 	graphMode: '2d' | '3d';
-	nodes: GraphRuntime['graphData']['nodes'];
+	nodes: GraphRuntime['renderer']['graphData']['nodes'];
 	timelineActive: boolean;
 }
 
@@ -29,7 +29,7 @@ function readViewportNumber(value: unknown): number | undefined {
 }
 
 export function toGraphViewViewportNodes(
-	nodes: GraphRuntime['graphData']['nodes'],
+	nodes: GraphRuntime['renderer']['graphData']['nodes'],
 ): GraphViewViewportNode[] {
 	return nodes.map(node => {
 		const viewportNode = node as GraphViewViewportNode;
@@ -54,7 +54,7 @@ export function toGraphViewViewportNodes(
 }
 
 export function updateGraphViewViewportNode(
-	nodes: GraphRuntime['graphData']['nodes'],
+	nodes: GraphRuntime['renderer']['graphData']['nodes'],
 	nodeId: string,
 	updates: Record<string, unknown>,
 ): boolean {

--- a/packages/extension/tests/webview/Graph.wiring.test.tsx
+++ b/packages/extension/tests/webview/Graph.wiring.test.tsx
@@ -3,7 +3,7 @@ import { act, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IGraphData } from '../../src/shared/graph/contracts';
 import Graph from '../../src/webview/components/graph/view/component';
-import type { UseGraphStateResult } from '../../src/webview/components/graph/runtime/use/state';
+import type { GraphRuntime } from '../../src/webview/components/graph/runtime/use/state';
 import { graphStore } from '../../src/webview/store/state';
 
 const harness = vi.hoisted(() => ({
@@ -13,7 +13,7 @@ const harness = vi.hoisted(() => ({
 	useGraphCallbacks: vi.fn(),
 	useGraphDebugApi: vi.fn(),
 	useGraphInteractionRuntime: vi.fn(),
-	useGraphState: vi.fn(),
+	useGraphRuntime: vi.fn(),
 }));
 
 vi.mock('../../src/webview/components/graph/viewport/shell', () => ({
@@ -29,7 +29,7 @@ vi.mock('../../src/webview/components/graph/debug/options', () => ({
 }));
 
 vi.mock('../../src/webview/components/graph/runtime/use/state', () => ({
-	useGraphState: harness.useGraphState,
+	useGraphRuntime: harness.useGraphRuntime,
 }));
 
 vi.mock('../../src/webview/components/graph/runtime/use/interaction', () => ({
@@ -53,48 +53,75 @@ const baseData: IGraphData = {
 };
 
 function createGraphState(graphData: IGraphData = baseData) {
+	const containerRef = { current: null };
+	const fg2dRef = { current: undefined };
+	const fg3dRef = { current: undefined } as GraphRuntime['renderer']['fg3dRef'];
+	const graphDataRuntime = {
+		nodes: graphData.nodes.map(node => ({ ...node })),
+		links: graphData.edges.map(edge => ({ ...edge })),
+	};
+	const graphDataRef = {
+		current: {
+			nodes: graphData.nodes.map(node => ({ ...node })),
+			links: graphData.edges.map(edge => ({ ...edge })),
+		},
+	};
+	const fileInfoCacheRef = { current: new Map() };
+	const lastContainerContextMenuEventRef = { current: 0 };
+	const lastGraphContextEventRef = { current: 0 };
+	const meshesRef = { current: new Map() };
+	const rightClickFallbackTimerRef = { current: null };
+	const rightMouseDownRef = { current: null };
+	const selectedNodesSetRef = { current: new Set() };
+	const setContextSelection = vi.fn();
+	const setSelectedNodes = vi.fn();
+	const spritesRef = { current: new Map() };
+	const triggerImageRerender = vi.fn();
+
 	return {
-		containerRef: { current: null },
-		contextSelection: { kind: 'background', targets: [] },
+		context: {
+			selection: { kind: 'background', targets: [] },
+			setSelection: setContextSelection,
+			lastContainerContextMenuEventRef,
+			lastGraphContextEventRef,
+			rightClickFallbackTimerRef,
+			rightMouseDownRef,
+		},
 		dataRef: { current: graphData },
 		directionColorRef: { current: '#22c55e' },
 		directionModeRef: { current: 'arrows' },
 		edgeDecorationsRef: { current: {} },
-		fg2dRef: { current: undefined },
-		fg3dRef: { current: undefined } as UseGraphStateResult['fg3dRef'],
-		fileInfoCacheRef: { current: new Map() },
-		graphContextSelection: { kind: 'background', targets: [] },
 		graphCursorRef: { current: 'default' },
-		graphData: {
-			nodes: graphData.nodes.map(node => ({ ...node })),
-			links: graphData.edges.map(edge => ({ ...edge })),
-		},
-		graphDataRef: {
-			current: {
-				nodes: graphData.nodes.map(node => ({ ...node })),
-				links: graphData.edges.map(edge => ({ ...edge })),
-			},
-		},
+		graphAppearanceRef: { current: {} },
 		highlightVersion: 0,
 		highlightedNeighborsRef: { current: new Set() },
 		highlightedNodeRef: { current: null },
 		lastClickRef: { current: 0 },
-		lastContainerContextMenuEventRef: { current: 0 },
-		lastGraphContextEventRef: { current: 0 },
-		meshesRef: { current: new Map() },
 		nodeDecorationsRef: { current: {} },
-		rightClickFallbackTimerRef: { current: null },
-		rightMouseDownRef: { current: null },
-		selectedNodes: [],
-		selectedNodesSetRef: { current: new Set() },
-		setContextSelection: vi.fn(),
+		renderer: {
+			containerRef,
+			fg2dRef,
+			fg3dRef,
+			graphData: graphDataRuntime,
+			graphDataRef,
+		},
+		renderCaches: {
+			fileInfoCacheRef,
+			imageCacheVersion: 0,
+			invalidateImages: triggerImageRerender,
+			meshesRef,
+			spritesRef,
+		},
+		selection: {
+			selectedNodeIds: [],
+			selectedNodeIdsRef: selectedNodesSetRef,
+			setSelectedNodeIds: setSelectedNodes,
+		},
 		setHighlightVersion: vi.fn(),
-		setSelectedNodes: vi.fn(),
 		showLabelsRef: { current: true },
-		spritesRef: { current: new Map() },
 		themeRef: { current: 'dark' },
-		triggerImageRerender: vi.fn(),
-	};
+		timelineActiveRef: { current: false },
+	} as unknown as GraphRuntime;
 }
 
 function createInteractionRuntime() {
@@ -192,7 +219,7 @@ describe('Graph wiring', () => {
 			stageBorder: 'transparent',
 			transparent: 'transparent',
 		});
-		harness.useGraphState.mockImplementation(({ data }: { data: IGraphData }) => createGraphState(data));
+		harness.useGraphRuntime.mockImplementation(({ data }: { data: IGraphData }) => createGraphState(data));
 		harness.useGraphInteractionRuntime.mockReturnValue(createInteractionRuntime());
 		harness.useGraphCallbacks.mockReturnValue(createCallbacks());
 	});
@@ -220,7 +247,7 @@ describe('Graph wiring', () => {
 
 		render(<Graph data={baseData} theme="light" />);
 
-		expect(harness.useGraphState).toHaveBeenCalledWith(expect.objectContaining({
+		expect(harness.useGraphRuntime).toHaveBeenCalledWith(expect.objectContaining({
 			bidirectionalMode: 'line',
 			directionColor: '#38bdf8',
 			favorites,
@@ -242,7 +269,9 @@ describe('Graph wiring', () => {
 			}),
 			graphDataLayoutKey: expect.any(String),
 			graphState: expect.objectContaining({
-				graphData: expect.objectContaining({ nodes: expect.any(Array), links: expect.any(Array) }),
+				renderer: expect.objectContaining({
+					graphData: expect.objectContaining({ nodes: expect.any(Array), links: expect.any(Array) }),
+				}),
 			}),
 			interactions: expect.objectContaining({
 				handleMenuAction: expect.any(Function),
@@ -297,7 +326,7 @@ describe('Graph wiring', () => {
 		render(<Graph data={baseData} pluginHost={pluginHost as never} />);
 
 		expect(pluginHost.subscribeGraphViewContributions).toHaveBeenCalledWith(expect.any(Function));
-		expect(harness.useGraphState).toHaveBeenCalledWith(expect.objectContaining({
+		expect(harness.useGraphRuntime).toHaveBeenCalledWith(expect.objectContaining({
 			graphViewContributions,
 		}));
 		expect(harness.graphViewportShell.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
@@ -308,14 +337,14 @@ describe('Graph wiring', () => {
 	it('auto-fits after switching into 3d mode when the graph ref is ready', () => {
 		vi.useFakeTimers();
 		const graphState = createGraphState();
-		graphState.fg3dRef.current = {
+		graphState.renderer.fg3dRef.current = {
 			d3Force: vi.fn().mockReturnValue({}),
 			getGraphBbox: vi.fn().mockReturnValue({ x: [0, 1], y: [0, 1], z: [0, 1] }),
 			zoomToFit: vi.fn(),
-		} as unknown as NonNullable<UseGraphStateResult['fg3dRef']['current']>;
+		} as unknown as NonNullable<GraphRuntime['renderer']['fg3dRef']['current']>;
 		const interactionRuntime = createInteractionRuntime();
 		setStoreState({ graphMode: '3d' });
-		harness.useGraphState.mockReturnValue(graphState);
+		harness.useGraphRuntime.mockReturnValue(graphState);
 		harness.useGraphInteractionRuntime.mockReturnValue(interactionRuntime);
 
 		render(<Graph data={baseData} />);

--- a/packages/extension/tests/webview/graph/debug/options.test.ts
+++ b/packages/extension/tests/webview/graph/debug/options.test.ts
@@ -4,10 +4,12 @@ import { buildGraphDebugOptions } from '../../../../src/webview/components/graph
 describe('graph/debugOptions', () => {
   it('builds debug hook options from graph state and interactions', () => {
     const graphState = {
-      containerRef: { current: null },
-      fg2dRef: { current: undefined },
-      fg3dRef: { current: undefined },
-      graphDataRef: { current: { nodes: [] } },
+      renderer: {
+        containerRef: { current: null },
+        fg2dRef: { current: undefined },
+        fg3dRef: { current: undefined },
+        graphDataRef: { current: { nodes: [] } },
+      },
     };
     const fitView = vi.fn();
     const openNodeContextMenu = vi.fn();
@@ -27,11 +29,11 @@ describe('graph/debugOptions', () => {
         win,
       }),
     ).toEqual({
-      containerRef: graphState.containerRef,
+      containerRef: graphState.renderer.containerRef,
       fitView,
-      fg2dRef: graphState.fg2dRef,
-      fg3dRef: graphState.fg3dRef,
-      graphDataRef: graphState.graphDataRef,
+      fg2dRef: graphState.renderer.fg2dRef,
+      fg3dRef: graphState.renderer.fg3dRef,
+      graphDataRef: graphState.renderer.graphDataRef,
       graphMode: '3d',
       openNodeContextMenu,
       win,

--- a/packages/extension/tests/webview/graph/runtime/use/state.test.tsx
+++ b/packages/extension/tests/webview/graph/runtime/use/state.test.tsx
@@ -21,8 +21,8 @@ import {
   applyTimelineAlpha,
   createEmptyRuntimeGraphData,
   incrementImageCacheVersion,
-  useGraphState,
-  type UseGraphStateOptions,
+  useGraphRuntime,
+  type GraphRuntimeOptions,
 } from '../../../../../src/webview/components/graph/runtime/use/state';
 
 function createData(suffix: string): IGraphData {
@@ -75,8 +75,8 @@ function createBuiltGraph(id: string, x: number): { links: FGLink[]; nodes: FGNo
 }
 
 function createOptions(
-  overrides: Partial<UseGraphStateOptions> = {},
-): UseGraphStateOptions {
+  overrides: Partial<GraphRuntimeOptions> = {},
+): GraphRuntimeOptions {
   return {
     bidirectionalMode: 'combined',
     data: createData('alpha'),
@@ -93,7 +93,7 @@ function createOptions(
   };
 }
 
-describe('graph/runtime/useGraphState', () => {
+describe('graph/runtime/useGraphRuntime', () => {
   let frameCallbacks: FrameRequestCallback[];
 
   beforeEach(() => {
@@ -137,7 +137,7 @@ describe('graph/runtime/useGraphState', () => {
   });
 
   it('initializes refs and state from their expected defaults', () => {
-    const { result } = renderHook(() => useGraphState(createOptions()));
+    const { result } = renderHook(() => useGraphRuntime(createOptions()));
 
     expect(graphStateHarness.buildGraphData).toHaveBeenCalledWith(expect.objectContaining({
       previousNodes: [],
@@ -145,6 +145,11 @@ describe('graph/runtime/useGraphState', () => {
     expect(result.current.containerRef.current).toBeNull();
     expect(result.current.fg2dRef.current).toBeUndefined();
     expect(result.current.fg3dRef.current).toBeUndefined();
+    expect(result.current.renderer.containerRef).toBe(result.current.containerRef);
+    expect(result.current.renderer.fg2dRef).toBe(result.current.fg2dRef);
+    expect(result.current.renderer.fg3dRef).toBe(result.current.fg3dRef);
+    expect(result.current.renderer.graphDataRef).toBe(result.current.graphDataRef);
+    expect(result.current.renderer.graphData).toBe(result.current.graphData);
     expect(result.current.graphCursorRef.current).toBe('default');
     expect(result.current.graphDataRef.current).toBe(result.current.graphData);
     expect(result.current.imageCacheVersion).toBe(0);
@@ -152,6 +157,12 @@ describe('graph/runtime/useGraphState', () => {
     expect(result.current.selectedNodes).toEqual([]);
     expect(result.current.selectedNodesSetRef.current).toEqual(new Set());
     expect(result.current.contextSelection).toEqual({ kind: 'background', targets: [] });
+    expect(result.current.context.selection).toEqual({ kind: 'background', targets: [] });
+    expect(result.current.context.setSelection).toBe(result.current.setContextSelection);
+    expect(result.current.renderCaches.fileInfoCacheRef).toBe(result.current.fileInfoCacheRef);
+    expect(result.current.renderCaches.meshesRef).toBe(result.current.meshesRef);
+    expect(result.current.renderCaches.spritesRef).toBe(result.current.spritesRef);
+    expect(result.current.renderCaches.invalidateImages).toBe(result.current.triggerImageRerender);
   });
 
   it('updates mutable refs across rerender without rebuilding graph data for non-memo inputs', () => {
@@ -164,7 +175,7 @@ describe('graph/runtime/useGraphState', () => {
       'edge-alpha': { color: '#ef4444' },
     };
     const { result, rerender } = renderHook(
-      (options: UseGraphStateOptions) => useGraphState(options),
+      (options: GraphRuntimeOptions) => useGraphRuntime(options),
       { initialProps: initialOptions },
     );
     const firstGraphData = result.current.graphData;
@@ -206,7 +217,7 @@ describe('graph/runtime/useGraphState', () => {
       .mockReturnValueOnce(secondGraph);
 
     const { result, rerender } = renderHook(
-      (options: UseGraphStateOptions) => useGraphState(options),
+      (options: GraphRuntimeOptions) => useGraphRuntime(options),
       { initialProps: createOptions({ data: firstData, bidirectionalMode: 'combined' }) },
     );
 
@@ -236,7 +247,7 @@ describe('graph/runtime/useGraphState', () => {
       .mockReturnValueOnce(secondGraph);
 
     const { result, rerender } = renderHook(
-      (options: UseGraphStateOptions) => useGraphState(options),
+      (options: GraphRuntimeOptions) => useGraphRuntime(options),
       { initialProps: createOptions({ data: createData('alpha') }) },
     );
 
@@ -255,7 +266,7 @@ describe('graph/runtime/useGraphState', () => {
     const graph = { d3Alpha: vi.fn() };
     graphStateHarness.as2DExtMethods.mockReturnValue(graph);
 
-    renderHook(() => useGraphState(createOptions({ timelineActive: false })));
+    renderHook(() => useGraphRuntime(createOptions({ timelineActive: false })));
 
     expect(graphStateHarness.as2DExtMethods).not.toHaveBeenCalled();
     expect(requestAnimationFrame).not.toHaveBeenCalled();
@@ -265,7 +276,7 @@ describe('graph/runtime/useGraphState', () => {
   it('does not schedule a timeline alpha bump when the 2D graph api is unavailable', () => {
     graphStateHarness.as2DExtMethods.mockReturnValue(undefined);
 
-    renderHook(() => useGraphState(createOptions({ timelineActive: true })));
+    renderHook(() => useGraphRuntime(createOptions({ timelineActive: true })));
 
     expect(graphStateHarness.as2DExtMethods).toHaveBeenCalledTimes(1);
     expect(requestAnimationFrame).not.toHaveBeenCalled();
@@ -274,7 +285,7 @@ describe('graph/runtime/useGraphState', () => {
   it('keeps the data effect safe when the graph api has no d3Alpha function', () => {
     graphStateHarness.as2DExtMethods.mockReturnValue({});
 
-    renderHook(() => useGraphState(createOptions({ timelineActive: true })));
+    renderHook(() => useGraphRuntime(createOptions({ timelineActive: true })));
 
     expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
     expect(() => {
@@ -291,7 +302,7 @@ describe('graph/runtime/useGraphState', () => {
     graphStateHarness.as2DExtMethods.mockReturnValue(graph);
 
     const { rerender } = renderHook(
-      (options: UseGraphStateOptions) => useGraphState(options),
+      (options: GraphRuntimeOptions) => useGraphRuntime(options),
       { initialProps: createOptions({ data: firstData, timelineActive: true }) },
     );
 
@@ -313,11 +324,11 @@ describe('graph/runtime/useGraphState', () => {
 
   it('triggerImageRerender causes a rerender without rebuilding graph data', () => {
     const options = createOptions();
-    const { result } = renderHook(() => useGraphState(options));
+    const { result } = renderHook(() => useGraphRuntime(options));
     const firstGraphData = result.current.graphData;
 
     act(() => {
-      result.current.triggerImageRerender();
+      result.current.renderCaches.invalidateImages();
     });
 
     expect(result.current.imageCacheVersion).toBe(1);
@@ -325,7 +336,7 @@ describe('graph/runtime/useGraphState', () => {
     expect(result.current.graphData).toBe(firstGraphData);
 
     act(() => {
-      result.current.triggerImageRerender();
+      result.current.renderCaches.invalidateImages();
     });
 
     expect(result.current.imageCacheVersion).toBe(2);

--- a/packages/extension/tests/webview/graph/runtime/use/state.test.tsx
+++ b/packages/extension/tests/webview/graph/runtime/use/state.test.tsx
@@ -241,14 +241,14 @@ describe('graph/runtime/useGraphState', () => {
     );
 
     act(() => {
-      result.current.selectedNodesSetRef.current = new Set(['src/alpha.ts']);
-      result.current.setSelectedNodes(['src/alpha.ts']);
+      result.current.selection.selectedNodeIdsRef.current = new Set(['src/alpha.ts']);
+      result.current.selection.setSelectedNodeIds(['src/alpha.ts']);
     });
 
     rerender(createOptions({ data: createData('beta') }));
 
-    expect(result.current.selectedNodes).toEqual([]);
-    expect(result.current.selectedNodesSetRef.current).toEqual(new Set());
+    expect(result.current.selection.selectedNodeIds).toEqual([]);
+    expect(result.current.selection.selectedNodeIdsRef.current).toEqual(new Set());
   });
 
   it('does not schedule a timeline alpha bump when the timeline is inactive', () => {

--- a/packages/extension/tests/webview/graph/runtime/use/state.test.tsx
+++ b/packages/extension/tests/webview/graph/runtime/use/state.test.tsx
@@ -142,27 +142,16 @@ describe('graph/runtime/useGraphRuntime', () => {
     expect(graphStateHarness.buildGraphData).toHaveBeenCalledWith(expect.objectContaining({
       previousNodes: [],
     }));
-    expect(result.current.containerRef.current).toBeNull();
-    expect(result.current.fg2dRef.current).toBeUndefined();
-    expect(result.current.fg3dRef.current).toBeUndefined();
-    expect(result.current.renderer.containerRef).toBe(result.current.containerRef);
-    expect(result.current.renderer.fg2dRef).toBe(result.current.fg2dRef);
-    expect(result.current.renderer.fg3dRef).toBe(result.current.fg3dRef);
-    expect(result.current.renderer.graphDataRef).toBe(result.current.graphDataRef);
-    expect(result.current.renderer.graphData).toBe(result.current.graphData);
+    expect(result.current.renderer.containerRef.current).toBeNull();
+    expect(result.current.renderer.fg2dRef.current).toBeUndefined();
+    expect(result.current.renderer.fg3dRef.current).toBeUndefined();
     expect(result.current.graphCursorRef.current).toBe('default');
-    expect(result.current.graphDataRef.current).toBe(result.current.graphData);
-    expect(result.current.imageCacheVersion).toBe(0);
+    expect(result.current.renderer.graphDataRef.current).toBe(result.current.renderer.graphData);
+    expect(result.current.renderCaches.imageCacheVersion).toBe(0);
     expect(result.current.highlightedNeighborsRef.current).toEqual(new Set());
-    expect(result.current.selectedNodes).toEqual([]);
-    expect(result.current.selectedNodesSetRef.current).toEqual(new Set());
-    expect(result.current.contextSelection).toEqual({ kind: 'background', targets: [] });
+    expect(result.current.selection.selectedNodeIds).toEqual([]);
+    expect(result.current.selection.selectedNodeIdsRef.current).toEqual(new Set());
     expect(result.current.context.selection).toEqual({ kind: 'background', targets: [] });
-    expect(result.current.context.setSelection).toBe(result.current.setContextSelection);
-    expect(result.current.renderCaches.fileInfoCacheRef).toBe(result.current.fileInfoCacheRef);
-    expect(result.current.renderCaches.meshesRef).toBe(result.current.meshesRef);
-    expect(result.current.renderCaches.spritesRef).toBe(result.current.spritesRef);
-    expect(result.current.renderCaches.invalidateImages).toBe(result.current.triggerImageRerender);
   });
 
   it('updates mutable refs across rerender without rebuilding graph data for non-memo inputs', () => {
@@ -178,7 +167,7 @@ describe('graph/runtime/useGraphRuntime', () => {
       (options: GraphRuntimeOptions) => useGraphRuntime(options),
       { initialProps: initialOptions },
     );
-    const firstGraphData = result.current.graphData;
+    const firstGraphData = result.current.renderer.graphData;
 
     rerender(createOptions({
       data: initialOptions.data,
@@ -194,7 +183,7 @@ describe('graph/runtime/useGraphRuntime', () => {
     }));
 
     expect(graphStateHarness.buildGraphData).toHaveBeenCalledTimes(1);
-    expect(result.current.graphData).toBe(firstGraphData);
+    expect(result.current.renderer.graphData).toBe(firstGraphData);
     expect(result.current.themeRef.current).toBe('light');
     expect(result.current.directionModeRef.current).toBe('particles');
     expect(result.current.directionColorRef.current).toBe('#f59e0b');
@@ -235,8 +224,8 @@ describe('graph/runtime/useGraphRuntime', () => {
       data: secondData,
       previousNodes: firstGraph.nodes,
     }));
-    expect(result.current.graphData).toBe(secondGraph);
-    expect(result.current.graphDataRef.current).toBe(secondGraph);
+    expect(result.current.renderer.graphData).toBe(secondGraph);
+    expect(result.current.renderer.graphDataRef.current).toBe(secondGraph);
   });
 
   it('clears selected nodes that are no longer visible after graph data changes', () => {
@@ -325,22 +314,22 @@ describe('graph/runtime/useGraphRuntime', () => {
   it('triggerImageRerender causes a rerender without rebuilding graph data', () => {
     const options = createOptions();
     const { result } = renderHook(() => useGraphRuntime(options));
-    const firstGraphData = result.current.graphData;
+    const firstGraphData = result.current.renderer.graphData;
 
     act(() => {
       result.current.renderCaches.invalidateImages();
     });
 
-    expect(result.current.imageCacheVersion).toBe(1);
+    expect(result.current.renderCaches.imageCacheVersion).toBe(1);
     expect(graphStateHarness.buildGraphData).toHaveBeenCalledTimes(1);
-    expect(result.current.graphData).toBe(firstGraphData);
+    expect(result.current.renderer.graphData).toBe(firstGraphData);
 
     act(() => {
       result.current.renderCaches.invalidateImages();
     });
 
-    expect(result.current.imageCacheVersion).toBe(2);
+    expect(result.current.renderCaches.imageCacheVersion).toBe(2);
     expect(graphStateHarness.buildGraphData).toHaveBeenCalledTimes(1);
-    expect(result.current.graphData).toBe(firstGraphData);
+    expect(result.current.renderer.graphData).toBe(firstGraphData);
   });
 });

--- a/packages/extension/tests/webview/graph/view/callbackOptions.test.ts
+++ b/packages/extension/tests/webview/graph/view/callbackOptions.test.ts
@@ -2,19 +2,27 @@ import { describe, expect, it, vi } from 'vitest';
 import { buildGraphCallbackOptions } from '../../../../src/webview/components/graph/view/callbackOptions';
 
 function createGraphState() {
+  const invalidateImages = vi.fn();
+  const meshesRef = { current: new Map() };
+  const selectedNodeIdsRef = { current: new Set<string>() };
+  const spritesRef = { current: new Map() };
   return {
     directionColorRef: { current: '#f00' },
     directionModeRef: { current: 'arrows' },
     edgeDecorationsRef: { current: {} },
     highlightedNeighborsRef: { current: new Set<string>() },
     highlightedNodeRef: { current: null },
-    meshesRef: { current: new Map() },
     nodeDecorationsRef: { current: {} },
-    selectedNodesSetRef: { current: new Set<string>() },
+    renderCaches: {
+      invalidateImages,
+      meshesRef,
+      spritesRef,
+    },
+    selection: {
+      selectedNodeIdsRef,
+    },
     showLabelsRef: { current: true },
-    spritesRef: { current: new Map() },
     themeRef: { current: 'dark' },
-    triggerImageRerender: vi.fn(),
   };
 }
 
@@ -33,14 +41,14 @@ describe('graph/callbackOptions', () => {
         edgeDecorationsRef: graphState.edgeDecorationsRef,
         highlightedNeighborsRef: graphState.highlightedNeighborsRef,
         highlightedNodeRef: graphState.highlightedNodeRef,
-        meshesRef: graphState.meshesRef,
+        meshesRef: graphState.renderCaches.meshesRef,
         nodeDecorationsRef: graphState.nodeDecorationsRef,
-        selectedNodesSetRef: graphState.selectedNodesSetRef,
+        selectedNodesSetRef: graphState.selection.selectedNodeIdsRef,
         showLabelsRef: graphState.showLabelsRef,
-        spritesRef: graphState.spritesRef,
+        spritesRef: graphState.renderCaches.spritesRef,
         themeRef: graphState.themeRef,
       },
-      triggerImageRerender: graphState.triggerImageRerender,
+      triggerImageRerender: graphState.renderCaches.invalidateImages,
     });
   });
 });

--- a/packages/extension/tests/webview/graph/viewport/model.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/model.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../../../../src/webview/vscodeApi', () => ({
 	postMessage: harness.postMessage,
 }));
 
-function createGraphData(): GraphRuntime['graphData'] {
+function createGraphData(): GraphRuntime['renderer']['graphData'] {
 	return {
 		nodes: [{
 			baseOpacity: 1,
@@ -257,7 +257,7 @@ describe('graph/viewport/model', () => {
 				{ id: 'src/next.ts', label: 'next.ts', color: '#f59e0b' } as never,
 			],
 			links: [],
-		} as GraphRuntime['graphData'];
+		} as GraphRuntime['renderer']['graphData'];
 
 		rerender({
 			nextGraphData,

--- a/packages/extension/tests/webview/graph/viewport/model.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/model.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { IPhysicsSettings } from '../../../../src/shared/settings/physics';
 import type { GraphViewStoreState } from '../../../../src/webview/components/graph/view/store';
-import type { UseGraphStateResult } from '../../../../src/webview/components/graph/runtime/use/state';
+import type { GraphRuntime } from '../../../../src/webview/components/graph/runtime/use/state';
 import type { UseGraphInteractionRuntimeResult } from '../../../../src/webview/components/graph/runtime/use/interaction';
 import { useGraphViewportModel } from '../../../../src/webview/components/graph/viewport/model';
 
@@ -43,7 +43,7 @@ vi.mock('../../../../src/webview/vscodeApi', () => ({
 	postMessage: harness.postMessage,
 }));
 
-function createGraphData(): UseGraphStateResult['graphData'] {
+function createGraphData(): GraphRuntime['graphData'] {
 	return {
 		nodes: [{
 			baseOpacity: 1,
@@ -257,7 +257,7 @@ describe('graph/viewport/model', () => {
 				{ id: 'src/next.ts', label: 'next.ts', color: '#f59e0b' } as never,
 			],
 			links: [],
-		} as UseGraphStateResult['graphData'];
+		} as GraphRuntime['graphData'];
 
 		rerender({
 			nextGraphData,

--- a/packages/extension/tests/webview/graph/viewport/shell.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/shell.test.tsx
@@ -5,7 +5,7 @@ import type { IGraphData } from '../../../../src/shared/graph/contracts';
 import type { IPhysicsSettings } from '../../../../src/shared/settings/physics';
 import type { GraphViewStoreState } from '../../../../src/webview/components/graph/view/store';
 import type { UseGraphInteractionRuntimeResult } from '../../../../src/webview/components/graph/runtime/use/interaction';
-import type { UseGraphStateResult } from '../../../../src/webview/components/graph/runtime/use/state';
+import type { GraphRuntime } from '../../../../src/webview/components/graph/runtime/use/state';
 import { GraphViewportShell } from '../../../../src/webview/components/graph/viewport/shell';
 import { graphStore } from '../../../../src/webview/store/state';
 
@@ -40,7 +40,7 @@ vi.mock('../../../../src/webview/components/graph/viewport/view', () => ({
 	},
 }));
 
-function createGraphData(): UseGraphStateResult['graphData'] {
+function createGraphData(): GraphRuntime['graphData'] {
 	return {
 		nodes: [
 			{
@@ -83,7 +83,7 @@ function createGraphData(): UseGraphStateResult['graphData'] {
 	};
 }
 
-function createGraphState(graphData: UseGraphStateResult['graphData']): UseGraphStateResult {
+function createGraphState(graphData: GraphRuntime['graphData']): GraphRuntime {
 	const dataRefCurrent: IGraphData = {
 		nodes: graphData.nodes.map(node => ({ id: node.id, label: node.label, color: node.color })),
 		edges: graphData.links.map(link => ({
@@ -94,45 +94,87 @@ function createGraphState(graphData: UseGraphStateResult['graphData']): UseGraph
 			to: link.to,
 		})),
 	};
+	const containerRef = { current: null };
+	const fg2dRef = { current: undefined };
+	const fg3dRef = { current: undefined };
+	const graphDataRef = { current: { links: graphData.links.map(link => ({ ...link })), nodes: graphData.nodes.map(node => ({ ...node })) } };
+	const fileInfoCacheRef = { current: new Map() };
+	const lastContainerContextMenuEventRef = { current: 0 };
+	const lastGraphContextEventRef = { current: 0 };
+	const meshesRef = { current: new Map() };
+	const rightClickFallbackTimerRef = { current: null };
+	const rightMouseDownRef = { current: null };
+	const selectedNodesSetRef = { current: new Set() };
+	const setContextSelection = vi.fn();
+	const setSelectedNodes = vi.fn();
+	const spritesRef = { current: new Map() };
+	const triggerImageRerender = vi.fn();
 
 	return {
-		containerRef: { current: null },
+		containerRef,
+		context: {
+			selection: { kind: 'background', targets: [] },
+			setSelection: setContextSelection,
+			lastContainerContextMenuEventRef,
+			lastGraphContextEventRef,
+			rightClickFallbackTimerRef,
+			rightMouseDownRef,
+		},
 		contextSelection: { kind: 'background', targets: [] },
 		dataRef: { current: dataRefCurrent },
 		directionColorRef: { current: '#22c55e' },
 		directionModeRef: { current: 'arrows' },
-		fileInfoCacheRef: { current: new Map() },
-		fg2dRef: { current: undefined },
-		fg3dRef: { current: undefined },
+		fileInfoCacheRef,
+		fg2dRef,
+		fg3dRef,
 		graphData,
-		graphDataRef: { current: { links: graphData.links.map(link => ({ ...link })), nodes: graphData.nodes.map(node => ({ ...node })) } },
+		graphDataRef,
 		graphCursorRef: { current: 'default' },
 		highlightVersion: 0,
 		highlightedNeighborsRef: { current: new Set() },
 		highlightedNodeRef: { current: null },
 		lastClickRef: { current: null },
-		lastContainerContextMenuEventRef: { current: 0 },
-		lastGraphContextEventRef: { current: 0 },
-		meshesRef: { current: new Map() },
-		rightClickFallbackTimerRef: { current: null },
-		rightMouseDownRef: { current: null },
+		lastContainerContextMenuEventRef,
+		lastGraphContextEventRef,
+		meshesRef,
+		renderer: {
+			containerRef,
+			fg2dRef,
+			fg3dRef,
+			graphData,
+			graphDataRef,
+		},
+		renderCaches: {
+			fileInfoCacheRef,
+			imageCacheVersion: 0,
+			invalidateImages: triggerImageRerender,
+			meshesRef,
+			spritesRef,
+		},
+		rightClickFallbackTimerRef,
+		rightMouseDownRef,
+		selection: {
+			selectedNodeIds: [],
+			selectedNodeIdsRef: selectedNodesSetRef,
+			setSelectedNodeIds: setSelectedNodes,
+		},
 		selectedNodes: [],
-		selectedNodesSetRef: { current: new Set() },
+		selectedNodesSetRef,
 		edgeDecorationsRef: { current: {} },
 		favoritesRef: { current: new Set() },
 		graphContextSelection: { kind: 'background', targets: [] },
 		imageCacheVersion: 0,
 		nodeDecorationsRef: { current: {} },
 		nodeSizeModeRef: { current: 'connections' },
-		setContextSelection: vi.fn(),
+		setContextSelection,
 		setHighlightVersion: vi.fn(),
-		setSelectedNodes: vi.fn(),
+		setSelectedNodes,
 		timelineActiveRef: { current: true },
 		showLabelsRef: { current: true },
-		spritesRef: { current: new Map() },
+		spritesRef,
 		themeRef: { current: 'dark' },
-		triggerImageRerender: vi.fn(),
-	} as unknown as UseGraphStateResult;
+		triggerImageRerender,
+	} as unknown as GraphRuntime;
 }
 
 function createInteractions(): UseGraphInteractionRuntimeResult {

--- a/packages/extension/tests/webview/graph/viewport/shell.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/shell.test.tsx
@@ -111,7 +111,6 @@ function createGraphState(graphData: GraphRuntime['renderer']['graphData']): Gra
 	const triggerImageRerender = vi.fn();
 
 	return {
-		containerRef,
 		context: {
 			selection: { kind: 'background', targets: [] },
 			setSelection: setContextSelection,
@@ -120,23 +119,14 @@ function createGraphState(graphData: GraphRuntime['renderer']['graphData']): Gra
 			rightClickFallbackTimerRef,
 			rightMouseDownRef,
 		},
-		contextSelection: { kind: 'background', targets: [] },
 		dataRef: { current: dataRefCurrent },
 		directionColorRef: { current: '#22c55e' },
 		directionModeRef: { current: 'arrows' },
-		fileInfoCacheRef,
-		fg2dRef,
-		fg3dRef,
-		graphData,
-		graphDataRef,
 		graphCursorRef: { current: 'default' },
 		highlightVersion: 0,
 		highlightedNeighborsRef: { current: new Set() },
 		highlightedNodeRef: { current: null },
 		lastClickRef: { current: null },
-		lastContainerContextMenuEventRef,
-		lastGraphContextEventRef,
-		meshesRef,
 		renderer: {
 			containerRef,
 			fg2dRef,
@@ -151,29 +141,19 @@ function createGraphState(graphData: GraphRuntime['renderer']['graphData']): Gra
 			meshesRef,
 			spritesRef,
 		},
-		rightClickFallbackTimerRef,
-		rightMouseDownRef,
 		selection: {
 			selectedNodeIds: [],
 			selectedNodeIdsRef: selectedNodesSetRef,
 			setSelectedNodeIds: setSelectedNodes,
 		},
-		selectedNodes: [],
-		selectedNodesSetRef,
 		edgeDecorationsRef: { current: {} },
 		favoritesRef: { current: new Set() },
-		graphContextSelection: { kind: 'background', targets: [] },
-		imageCacheVersion: 0,
 		nodeDecorationsRef: { current: {} },
 		nodeSizeModeRef: { current: 'connections' },
-		setContextSelection,
 		setHighlightVersion: vi.fn(),
-		setSelectedNodes,
 		timelineActiveRef: { current: true },
 		showLabelsRef: { current: true },
-		spritesRef,
 		themeRef: { current: 'dark' },
-		triggerImageRerender,
 	} as unknown as GraphRuntime;
 }
 

--- a/packages/extension/tests/webview/graph/viewport/shell.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/shell.test.tsx
@@ -40,7 +40,7 @@ vi.mock('../../../../src/webview/components/graph/viewport/view', () => ({
 	},
 }));
 
-function createGraphData(): GraphRuntime['graphData'] {
+function createGraphData(): GraphRuntime['renderer']['graphData'] {
 	return {
 		nodes: [
 			{
@@ -83,7 +83,7 @@ function createGraphData(): GraphRuntime['graphData'] {
 	};
 }
 
-function createGraphState(graphData: GraphRuntime['graphData']): GraphRuntime {
+function createGraphState(graphData: GraphRuntime['renderer']['graphData']): GraphRuntime {
 	const dataRefCurrent: IGraphData = {
 		nodes: graphData.nodes.map(node => ({ id: node.id, label: node.label, color: node.color })),
 		edges: graphData.links.map(link => ({
@@ -313,7 +313,7 @@ describe('graph/viewport/shell', () => {
 	it('wires rendering runtime, viewport model, and the Viewport component', () => {
 		const graphData = createGraphData();
 		const graphState = createGraphState(graphData);
-		graphState.fg2dRef.current = {
+		graphState.renderer.fg2dRef.current = {
 			graph2ScreenCoords: (x: number, y: number) => ({ x: x + 10, y: y + 20 }),
 			screen2GraphCoords: (x: number, y: number) => ({ x: x - 10, y: y - 20 }),
 			zoom: () => 1.75,
@@ -341,28 +341,28 @@ describe('graph/viewport/shell', () => {
 		);
 
 		expect(harness.useGraphRenderingRuntime).toHaveBeenCalledWith(expect.objectContaining({
-			containerRef: graphState.containerRef,
+			containerRef: graphState.renderer.containerRef,
 			dataRef: graphState.dataRef,
-			fg2dRef: graphState.fg2dRef,
-			fg3dRef: graphState.fg3dRef,
+			fg2dRef: graphState.renderer.fg2dRef,
+			fg3dRef: graphState.renderer.fg3dRef,
 			getArrowColor: callbacks.getArrowColor,
 			getArrowRelPos: callbacks.getArrowRelPos,
 			getLinkParticles: callbacks.getLinkParticles,
 			getParticleColor: callbacks.getParticleColor,
-			graphDataRef: graphState.graphDataRef,
+			graphDataRef: graphState.renderer.graphDataRef,
 			graphDataLayoutKey: 'connections::',
 			graphViewContributions: undefined,
 			graphMode: '3d',
-			meshesRef: graphState.meshesRef,
+			meshesRef: graphState.renderCaches.meshesRef,
 			nodeSizeMode: 'connections',
 			particleSize: 3,
 			particleSpeed: 0.2,
 			physicsPaused: false,
 			physicsSettings: viewState.physicsSettings,
 			pluginHost,
-			selectedNodesSetRef: graphState.selectedNodesSetRef,
+			selectedNodesSetRef: graphState.selection.selectedNodeIdsRef,
 			showLabels: true,
-			spritesRef: graphState.spritesRef,
+			spritesRef: graphState.renderCaches.spritesRef,
 			theme: 'light',
 			favorites: viewState.favorites,
 			timelineActive: true,
@@ -370,7 +370,7 @@ describe('graph/viewport/shell', () => {
 		}));
 		expect(harness.useGraphViewportModel).toHaveBeenCalledWith(expect.objectContaining({
 			graphState: {
-				contextSelection: graphState.contextSelection,
+				contextSelection: graphState.context.selection,
 				graphData,
 			},
 			handleEngineStop,
@@ -379,15 +379,15 @@ describe('graph/viewport/shell', () => {
 			viewportRuntime: expect.objectContaining({ containerSize: { height: 320, width: 480 } }),
 		}));
 		expect(harness.useGraphEventEffects).toHaveBeenCalledWith(expect.objectContaining({
-			containerRef: graphState.containerRef,
+			containerRef: graphState.renderer.containerRef,
 			dataRef: graphState.dataRef,
 			directionColorRef: graphState.directionColorRef,
 			directionModeRef: graphState.directionModeRef,
-			graphDataRef: graphState.graphDataRef,
+			graphDataRef: graphState.renderer.graphDataRef,
 			graphMode: '3d',
 			interactionHandlers: interactions.interactionHandlers,
-			fileInfoCacheRef: graphState.fileInfoCacheRef,
-			selectedNodes: graphState.selectedNodes,
+			fileInfoCacheRef: graphState.renderCaches.fileInfoCacheRef,
+			selectedNodes: graphState.selection.selectedNodeIds,
 			setTooltipData: interactions.setTooltipData,
 			showLabelsRef: graphState.showLabelsRef,
 			themeRef: graphState.themeRef,
@@ -397,7 +397,7 @@ describe('graph/viewport/shell', () => {
 			canvasBackgroundColor: 'transparent',
 			containerBackgroundColor: 'var(--cg-popover-translucent)',
 			borderColor: 'rgb(63, 63, 70)',
-			containerRef: graphState.containerRef,
+			containerRef: graphState.renderer.containerRef,
 			directionMode: 'arrows',
 			graphMode: '3d',
 			handleContextMenu: interactions.handleContextMenu,
@@ -410,7 +410,7 @@ describe('graph/viewport/shell', () => {
 			onSurface3dError: expect.any(Function),
 			pluginHost,
 			surface2dProps: expect.objectContaining({
-				fg2dRef: graphState.fg2dRef,
+				fg2dRef: graphState.renderer.fg2dRef,
 				getArrowColor: callbacks.getArrowColor,
 				getLinkColor: callbacks.getLinkColor,
 				getParticleColor: callbacks.getParticleColor,
@@ -420,7 +420,7 @@ describe('graph/viewport/shell', () => {
 				sharedProps: expect.objectContaining({ dagMode: 'td' }),
 			}),
 			surface3dProps: expect.objectContaining({
-				fg3dRef: graphState.fg3dRef,
+				fg3dRef: graphState.renderer.fg3dRef,
 				getArrowColor: callbacks.getArrowColor,
 				getLinkColor: callbacks.getLinkColor,
 				getParticleColor: callbacks.getParticleColor,
@@ -456,7 +456,7 @@ describe('graph/viewport/shell', () => {
 		const graphState = createGraphState(graphData);
 		const reheatSimulation = vi.fn();
 		const resumeAnimation = vi.fn();
-		graphState.fg2dRef.current = {
+		graphState.renderer.fg2dRef.current = {
 			d3ReheatSimulation: reheatSimulation,
 			graph2ScreenCoords: (x: number, y: number) => ({ x, y }),
 			resumeAnimation,
@@ -504,7 +504,7 @@ describe('graph/viewport/shell', () => {
 			x: 42,
 			y: 24,
 		})).toBe(true);
-		expect(graphState.graphDataRef.current.nodes[0]).toMatchObject({
+		expect(graphState.renderer.graphDataRef.current.nodes[0]).toMatchObject({
 			fx: 42,
 			fy: 24,
 			sectionHeight: 144,


### PR DESCRIPTION
## Summary
- Adds the initial plan for Trello issue 159: deepening the Relationship Graph runtime state boundary.
- Captures current shallow-interface observations and the alignment questions to resolve before implementation.

## Trello
https://trello.com/c/09objACH/159-architecture-deepen-relationship-graph-runtime-state

## Current status
Planning/alignment only. No production implementation yet.

## Verification
- Not run: documentation-only planning commit.