### PR TITLE
Architecture: deepen graph context menu execution

### DIFF
--- a/.changeset/quiet-masks-wait.md
+++ b/.changeset/quiet-masks-wait.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Run Graph Context Menu actions against the selection that opened the menu and skip stale actions that no longer match that selection.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -435,8 +435,14 @@ _Avoid_: Graph export
 - Double-clicking a file node should select, focus, and **Open File** as a persistent tab.
 - Single-clicking a non-file node should select and focus it without opening a file.
 - Right-clicking an unselected node should select that node for **Context Selection** but should not preview or open it.
+- Right-clicking a node that is already part of a multi-node selection should keep the multi-node **Context Selection** and open the **Graph Context Menu** for that selected group.
+- Right-clicking a single node can switch the **Focused Node** to that node; right-clicking a selected group member should keep the existing **Focused Node** unchanged.
 - A **Graph Context Menu** is opened from the current **Context Selection** and should present actions that match that selection's target type.
+- A **Graph Context Menu** action should execute against the **Context Selection** snapshot that opened the menu, even if the live graph selection changes before the action runs.
+- A **Graph Context Menu** action that no longer matches its opening **Context Selection** snapshot should not run.
 - Graph Context Menu action availability can be decided by an explicit menu decision model; that model owns which actions appear, not right-click selection mechanics.
+- A multi-node **Context Selection** should only show **Graph Context Menu** actions that can apply to every selected node, unless a mixed-selection action has been explicitly defined.
+- Built-in actions and plugin contributions should follow the same **Graph Context Menu** selection rules.
 - A single **Folder Node** **Graph Context Menu** can offer child creation actions such as `New File...` and `New Folder...`; those actions target the selected folder.
 - A **File Node** **Graph Context Menu** stays file-focused and should not offer child creation actions by default.
 - Creating an empty directory from a **Folder Node** action should make that directory visible as a **Folder Node** after refresh or reindex.

--- a/packages/extension/src/webview/components/graph/contextActions/context.ts
+++ b/packages/extension/src/webview/components/graph/contextActions/context.ts
@@ -9,6 +9,7 @@ export interface GraphContextActionContext {
   selectionKind: GraphContextSelection['kind'];
   targetIds: readonly string[];
   primaryTargetId?: string;
+  edgeId?: string;
   edgeSourceId?: string;
   edgeTargetId?: string;
   primaryNode?: GraphContextMenuNode;
@@ -28,6 +29,7 @@ export function resolveGraphContextActionContext(
     selectionKind: selection.kind,
     targetIds: selection.targets,
     primaryTargetId,
+    edgeId: selection.edgeId,
     primaryNode: options.nodes?.find(node => node.id === primaryTargetId),
     edgeSourceId: isEdgeSelection ? primaryTargetId : undefined,
     edgeTargetId: isEdgeSelection ? secondaryTargetId : undefined,

--- a/packages/extension/src/webview/components/graph/contextMenu/build/entries.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/build/entries.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_GRAPH_CONTEXT_MUTATION_AVAILABILITY,
   type BuildGraphContextMenuOptions,
   type GraphContextMenuEntry,
+  type GraphContextSelection,
 } from '../contracts';
 import { decideGraphContextMenu } from '../decision/model';
 import { buildEdgeEntries } from '../edge/entries';
@@ -51,6 +52,25 @@ function insertCreateMenuEntries(
     ...createEntries,
     ...baseEntries.slice(separatorIndex),
   ];
+}
+
+function captureContextSelection(
+  entries: GraphContextMenuEntry[],
+  selection: GraphContextSelection,
+): GraphContextMenuEntry[] {
+  const contextSelection = cloneContextSelection(selection);
+  return entries.map(entry =>
+    entry.kind === 'item' ? { ...entry, contextSelection } : entry
+  );
+}
+
+function cloneContextSelection(selection: GraphContextSelection): GraphContextSelection {
+  return {
+    kind: selection.kind,
+    targets: [...selection.targets],
+    ...(selection.edgeId ? { edgeId: selection.edgeId } : {}),
+    ...(selection.graphPosition ? { graphPosition: { ...selection.graphPosition } } : {}),
+  };
 }
 
 export function buildGraphContextMenuEntries(
@@ -104,7 +124,7 @@ export function buildGraphContextMenuEntries(
     })
     : [];
   const positionedBaseEntries = insertCreateMenuEntries(baseEntries, graphViewCreateEntries);
-  return [
+  return captureContextSelection([
     ...positionedBaseEntries,
     ...buildPluginEntriesForDecision(decision, pluginItems),
     ...buildGraphViewContextMenuEntries({
@@ -116,5 +136,5 @@ export function buildGraphContextMenuEntries(
       selection,
       timelineActive,
     }),
-  ];
+  ], selection);
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
@@ -41,12 +41,18 @@ export type GraphContextMenuAction =
       run: GraphViewContextMenuContribution['run'];
     };
 
+export interface GraphContextMenuActionInvocation {
+  action: GraphContextMenuAction;
+  contextSelection: GraphContextSelection;
+}
+
 export type GraphContextMenuEntry =
   | {
       kind: 'item';
       id: string;
       label: string;
       action: GraphContextMenuAction;
+      contextSelection?: GraphContextSelection;
       destructive?: boolean;
       disabled?: boolean;
       shortcut?: string;

--- a/packages/extension/src/webview/components/graph/contextMenuOpening/runtime.ts
+++ b/packages/extension/src/webview/components/graph/contextMenuOpening/runtime.ts
@@ -6,7 +6,7 @@ import type {
 } from 'react';
 import type { GraphContextActionContext } from '../contextActions/context';
 import type {
-  GraphContextMenuAction,
+  GraphContextMenuActionInvocation,
   GraphContextSelection,
 } from '../contextMenu/contracts';
 import {
@@ -26,7 +26,7 @@ export interface GraphContextMenuOpeningRuntime {
   handleBackgroundRightClick(this: void, event: MouseEvent): void;
   handleContextMenu(this: void, event?: ReactMouseEvent<HTMLDivElement>): void;
   handleLinkRightClick(this: void, link: FGLink, event: MouseEvent): void;
-  handleMenuAction(this: void, action: GraphContextMenuAction): void;
+  handleMenuAction(this: void, invocation: GraphContextMenuActionInvocation): void;
   handleMouseDownCapture(this: void, event: ReactMouseEvent<HTMLDivElement>): void;
   handleMouseMoveCapture(this: void, event: ReactMouseEvent<HTMLDivElement>): void;
   handleMouseUpCapture(this: void, event: ReactMouseEvent<HTMLDivElement>): void;
@@ -36,7 +36,7 @@ export interface GraphContextMenuOpeningRuntime {
 
 export interface GraphContextMenuOpeningOptions {
   fileInfoCacheRef: GraphRuntime['renderCaches']['fileInfoCacheRef'];
-  getActionContext(): GraphContextActionContext;
+  getActionContext(selection: GraphContextSelection): GraphContextActionContext;
   hoveredNodeRef: MutableRefObject<FGNode | null>;
   interactionHandlers: GraphInteractionHandlersRuntime;
   lastContainerContextMenuEventRef: GraphRuntime['context']['lastContainerContextMenuEventRef'];
@@ -113,8 +113,11 @@ function createGraphContextMenuOpeningHandlers(
     handleLinkRightClick: (link, event) => {
       interactionHandlers.openEdgeContextMenu(link, event);
     },
-    handleMenuAction: action => {
-      contextMenuRuntime.handleMenuAction(action, getActionContext());
+    handleMenuAction: invocation => {
+      contextMenuRuntime.handleMenuAction(
+        invocation.action,
+        getActionContext(invocation.contextSelection),
+      );
     },
     handleMouseDownCapture: event => {
       contextMenuRuntime.handleMouseDownCapture({
@@ -156,7 +159,7 @@ export function createGraphContextMenuOpeningRuntime(
     ...createGraphContextMenuOpeningHandlers(
       contextMenuRuntime,
       options.interactionHandlers,
-      () => options.getActionContext(),
+      selection => options.getActionContext(selection),
       options.refs,
     ),
   };

--- a/packages/extension/src/webview/components/graph/contextMenuRuntime/effects.ts
+++ b/packages/extension/src/webview/components/graph/contextMenuRuntime/effects.ts
@@ -3,7 +3,7 @@ import {
   type GraphContextEffect,
 } from '../contextActions/effects';
 import type { GraphContextActionContext } from '../contextActions/context';
-import type { GraphContextMenuAction } from '../contextMenu/contracts';
+import type { BuiltInContextMenuAction, GraphContextMenuAction } from '../contextMenu/contracts';
 import { applyContextEffects as runContextEffects } from '../effects/contextMenu';
 import type { GraphContextMenuRuntimeDependencies } from './controller';
 
@@ -20,6 +20,117 @@ type GraphContextMenuEffectDependencies = Pick<
 export interface GraphContextMenuEffectRuntime {
   applyContextEffects(effects: GraphContextEffect[]): void;
   handleMenuAction(action: GraphContextMenuAction, context: GraphContextActionContext): void;
+}
+
+const NODE_ACTIONS = new Set<BuiltInContextMenuAction>([
+  'open',
+  'reveal',
+  'copyRelative',
+  'copyAbsolute',
+  'copySymbolId',
+  'copySymbolName',
+  'toggleFavorite',
+  'focus',
+  'addToFilter',
+  'addNodeLegend',
+  'rename',
+  'delete',
+]);
+
+const EDGE_ACTIONS = new Set<BuiltInContextMenuAction>([
+  'openEdgeSource',
+  'openEdgeTarget',
+  'copyEdgeSource',
+  'copyEdgeTarget',
+  'copyEdgeBoth',
+]);
+
+const BACKGROUND_ACTIONS = new Set<BuiltInContextMenuAction>([
+  'refresh',
+  'fitView',
+]);
+
+function isFolderCreationContext(context: GraphContextActionContext): boolean {
+  return context.selectionKind === 'background'
+    || context.primaryTargetId === '(root)'
+    || context.primaryNode?.nodeType === 'folder';
+}
+
+function isBuiltInActionValid(
+  action: BuiltInContextMenuAction,
+  context: GraphContextActionContext,
+): boolean {
+  if (BACKGROUND_ACTIONS.has(action)) {
+    return context.selectionKind === 'background';
+  }
+
+  if (action === 'createFile' || action === 'createFolder') {
+    return isFolderCreationContext(context);
+  }
+
+  if (EDGE_ACTIONS.has(action)) {
+    return context.selectionKind === 'edge';
+  }
+
+  if (NODE_ACTIONS.has(action)) {
+    return context.selectionKind === 'node';
+  }
+
+  return false;
+}
+
+function selectedIdsMatchContext(
+  selectedIds: readonly string[],
+  context: GraphContextActionContext,
+): boolean {
+  return selectedIds.length === context.targetIds.length
+    && selectedIds.every((id, index) => id === context.targetIds[index]);
+}
+
+function isGraphViewPluginActionValid(
+  action: Extract<GraphContextMenuAction, { kind: 'graphViewPlugin' }>,
+  context: GraphContextActionContext,
+): boolean {
+  if (context.selectionKind === 'background') {
+    return action.context.target.kind === 'background'
+      && action.context.selectedNodeIds.length === 0
+      && action.context.selectedEdgeIds.length === 0;
+  }
+
+  if (context.selectionKind === 'edge') {
+    return action.context.selectedEdgeIds.includes(context.edgeId ?? '')
+      && action.context.selectedNodeIds.length === 0;
+  }
+
+  return selectedIdsMatchContext(action.context.selectedNodeIds, context)
+    && action.context.selectedEdgeIds.length === 0;
+}
+
+function isPluginActionValid(
+  action: Extract<GraphContextMenuAction, { kind: 'plugin' }>,
+  context: GraphContextActionContext,
+): boolean {
+  if (action.targetType === 'node') {
+    return context.selectionKind === 'node' && context.targetIds.includes(action.targetId);
+  }
+
+  return context.selectionKind === 'edge'
+    && (action.targetId === context.edgeId || context.targetIds.includes(action.targetId));
+}
+
+function isMenuActionValid(
+  action: GraphContextMenuAction,
+  context: GraphContextActionContext,
+): boolean {
+  if (action.kind === 'builtin') {
+    return isBuiltInActionValid(action.action, context);
+  }
+
+  if (action.kind === 'plugin') {
+    return isPluginActionValid(action, context);
+  }
+
+  return isGraphViewPluginActionValid(action, context);
 }
 
 export function createContextMenuEffectRuntime(
@@ -40,6 +151,10 @@ export function createContextMenuEffectRuntime(
     action: GraphContextMenuAction,
     context: GraphContextActionContext,
   ): void => {
+    if (!isMenuActionValid(action, context)) {
+      return;
+    }
+
     applyContextEffects(getGraphContextActionEffects(action, context));
   };
 

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/contracts.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/contracts.ts
@@ -6,7 +6,7 @@ import type {
 } from 'react';
 import type { CoreGraphViewContributionSet } from '@codegraphy-dev/core';
 import type { IGraphData } from '../../../../../../shared/graph/contracts';
-import type { GraphContextMenuAction, GraphContextSelection } from '../../../contextMenu/contracts';
+import type { GraphContextMenuActionInvocation, GraphContextSelection } from '../../../contextMenu/contracts';
 import type { createGraphInteractionHandlers } from '../../../interactionRuntime/handlers';
 import type { FGNode } from '../../../model/build';
 import type { GraphCursorStyle } from '../../../support/dom';
@@ -54,7 +54,7 @@ export interface UseGraphInteractionRuntimeResult {
   handleContextMenu(this: void, event?: ReactMouseEvent<HTMLDivElement>): void;
   handleEngineStop(this: void): void;
   handleLinkRightClick: import('../../../contextMenuOpening/runtime').GraphContextMenuOpeningRuntime['handleLinkRightClick'];
-  handleMenuAction(this: void, action: GraphContextMenuAction): void;
+  handleMenuAction(this: void, invocation: GraphContextMenuActionInvocation): void;
   handleMouseDownCapture: import('../../../contextMenuOpening/runtime').GraphContextMenuOpeningRuntime['handleMouseDownCapture'];
   handleMouseLeave(this: void): void;
   handleMouseMoveCapture: import('../../../contextMenuOpening/runtime').GraphContextMenuOpeningRuntime['handleMouseMoveCapture'];

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/hook.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/hook.ts
@@ -6,6 +6,7 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from 'react';
 import { resolveGraphContextActionContext } from '../../../contextActions/context';
+import type { GraphContextSelection } from '../../../contextMenu/contracts';
 import { createGraphContextMenuOpeningRuntime } from '../../../contextMenuOpening/runtime';
 import { createGraphInteractionHandlers } from '../../../interactionRuntime/handlers';
 import { applyCursorToGraphSurface } from '../../../support/dom';
@@ -147,7 +148,7 @@ export function useGraphInteractionRuntime({
   });
 
   const getActionContext = useCallback(
-    () => resolveGraphContextActionContext(graphContextSelectionRef.current, {
+    (selection: GraphContextSelection) => resolveGraphContextActionContext(selection, {
       graphViewportScale: readGraphViewportScale(graphMode, refs.fg2dRef.current),
       nodes: graphDataRef.current.nodes,
     }),

--- a/packages/extension/src/webview/components/graph/viewport/view.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/view.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../ui/context/menu';
 import { NodeTooltip } from '../../nodeTooltip/view';
 import type {
-  GraphContextMenuAction,
+  GraphContextMenuActionInvocation,
   GraphContextMenuEntry,
 } from '../contextMenu/contracts';
 import {
@@ -35,7 +35,7 @@ export interface ViewportProps {
   directionMode: DirectionMode;
   graphMode: '2d' | '3d';
   handleContextMenu: (this: void, event: ReactMouseEvent<HTMLDivElement>) => void;
-  handleMenuAction: (this: void, action: GraphContextMenuAction) => void;
+  handleMenuAction: (this: void, invocation: GraphContextMenuActionInvocation) => void;
   handleMouseDownCapture: (this: void, event: ReactMouseEvent<HTMLDivElement>) => void;
   handleMouseLeave: (this: void) => void;
   handleMouseMoveCapture: (this: void, event: ReactMouseEvent<HTMLDivElement>) => void;
@@ -160,7 +160,14 @@ function ViewportContextMenuItems({
             key={entry.id}
             className={entry.destructive ? 'text-[var(--cg-error-foreground)] focus:text-[var(--cg-error-foreground)]' : undefined}
             disabled={entry.disabled}
-            onClick={() => handleMenuAction(entry.action)}
+            onClick={() => {
+              if (entry.contextSelection) {
+                handleMenuAction({
+                  action: entry.action,
+                  contextSelection: entry.contextSelection,
+                });
+              }
+            }}
           >
             {entry.label}
             {entry.shortcut ? <ContextMenuShortcut>{entry.shortcut}</ContextMenuShortcut> : null}

--- a/packages/extension/tests/webview/graph/contextMenu/model.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/model.test.ts
@@ -40,13 +40,21 @@ function builtInMenuItems(
 
 describe('graph/contextMenuModel', () => {
   it('uses Graph Revision mutability for background creation actions', () => {
+    const selection = makeBackgroundContextSelection();
     const liveEntries = buildGraphContextMenuEntries({
-      selection: makeBackgroundContextSelection(),
+      selection,
       timelineActive: false,
       favorites: new Set(),
       pluginItems: [],
     });
     expect(menuLabels(liveEntries)).toEqual(['New File...', 'New Folder...', 'Refresh', 'Fit All Nodes']);
+    selection.targets.push('src/late.ts');
+    expect(menuItems(liveEntries).map(entry => entry.contextSelection)).toEqual([
+      { kind: 'background', targets: [] },
+      { kind: 'background', targets: [] },
+      { kind: 'background', targets: [] },
+      { kind: 'background', targets: [] },
+    ]);
 
     const historicalEntries = buildGraphContextMenuEntries({
       selection: makeBackgroundContextSelection(),

--- a/packages/extension/tests/webview/graph/contextMenuOpening/runtime.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenuOpening/runtime.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { GraphContextMenuAction } from '../../../../src/webview/components/graph/contextMenu/contracts';
+import type {
+  GraphContextMenuAction,
+  GraphContextSelection,
+} from '../../../../src/webview/components/graph/contextMenu/contracts';
 import type { FGLink, FGNode } from '../../../../src/webview/components/graph/model/build';
 import { createGraphContextMenuOpeningRuntime } from '../../../../src/webview/components/graph/contextMenuOpening/runtime';
 
@@ -48,6 +51,10 @@ function createLink(id: string): FGLink {
   return { id } as FGLink;
 }
 
+function createSelection(targets: string[]): GraphContextSelection {
+  return { kind: 'node', targets };
+}
+
 function createOpeningOptions(overrides: Record<string, unknown> = {}) {
   const actionContext = {
     mutationDirectory: 'src/app.ts',
@@ -56,7 +63,7 @@ function createOpeningOptions(overrides: Record<string, unknown> = {}) {
     targetIds: ['src/app.ts'],
   };
   return {
-    getActionContext: vi.fn(() => actionContext),
+    getActionContext: vi.fn((_selection: GraphContextSelection) => actionContext),
     fileInfoCacheRef: { current: new Map([['src/stale.ts', { path: 'src/stale.ts' }]]) },
     hoveredNodeRef: { current: null },
     interactionHandlers: createInteractionHandlers(),
@@ -142,7 +149,8 @@ describe('graph/contextMenuOpening/runtime', () => {
     runtime.handleLinkRightClick(link, graphEvent);
     runtime.handleBackgroundRightClick(graphEvent);
     runtime.handleContextMenu(reactContextEvent);
-    runtime.handleMenuAction(action);
+    const contextSelection = createSelection(['src/app.ts']);
+    runtime.handleMenuAction({ action, contextSelection });
 
     expect(contextMenuRuntime.handleMouseDownCapture).toHaveBeenCalledWith({
       button: 2,
@@ -160,7 +168,7 @@ describe('graph/contextMenuOpening/runtime', () => {
     expect(options.interactionHandlers.openBackgroundContextMenu).toHaveBeenCalledWith(graphEvent);
     expect(options.interactionHandlers.getBackgroundGraphPosition).toHaveBeenCalledWith(graphEvent);
     expect(contextMenuRuntime.handleContextMenu).toHaveBeenCalledWith({ x: 24, y: -32 });
-    expect(options.getActionContext).toHaveBeenCalledTimes(1);
+    expect(options.getActionContext).toHaveBeenCalledWith(contextSelection);
     expect(contextMenuRuntime.handleMenuAction).toHaveBeenCalledWith(action, expect.objectContaining({
       primaryTargetId: 'src/app.ts',
     }));

--- a/packages/extension/tests/webview/graph/contextMenuRuntime/effects.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenuRuntime/effects.test.ts
@@ -80,6 +80,36 @@ describe('graph/contextMenuRuntime/effects', () => {
     expect(dependencies.postMessage).not.toHaveBeenCalled();
   });
 
+  it('skips built-in menu actions that are invalid for the execution selection', () => {
+    const dependencies = createDependencies();
+    const runtime = createContextMenuEffectRuntime(dependencies);
+
+    runtime.handleMenuAction(
+      { kind: 'builtin', action: 'createFile' },
+      nodeContext(['src/app.ts']),
+    );
+
+    expect(dependencies.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips plugin menu actions that are invalid for the execution selection', () => {
+    const dependencies = createDependencies();
+    const runtime = createContextMenuEffectRuntime(dependencies);
+
+    runtime.handleMenuAction(
+      {
+        kind: 'plugin',
+        pluginId: 'plugin.test',
+        index: 2,
+        targetId: 'src/app.ts->src/util.ts',
+        targetType: 'edge',
+      },
+      nodeContext(['src/app.ts']),
+    );
+
+    expect(dependencies.postMessage).not.toHaveBeenCalled();
+  });
+
   it('opens the legend prompt for add-node-legend actions', () => {
     const dependencies = createDependencies();
     const runtime = createContextMenuEffectRuntime(dependencies);

--- a/packages/extension/tests/webview/graph/runtime/use/interaction.test.tsx
+++ b/packages/extension/tests/webview/graph/runtime/use/interaction.test.tsx
@@ -367,10 +367,9 @@ describe('graph/runtime/useGraphInteractionRuntime', () => {
       },
     );
 
-    const latestNode = createNode('src/two.ts');
     rerender({
       graphContextSelection: createSelection(['src/two.ts']),
-      graphDataRef: { current: { links: [], nodes: [latestNode] } } as never,
+      graphDataRef: { current: { links: [], nodes: [createNode('src/two.ts')] } } as never,
       graphMode: '2d',
     });
 
@@ -378,13 +377,16 @@ describe('graph/runtime/useGraphInteractionRuntime', () => {
       action: 'focus',
       kind: 'builtin',
     };
-    result.current.handleMenuAction(action);
+    result.current.handleMenuAction({
+      action,
+      contextSelection: createSelection(['src/one.ts']),
+    });
 
     expect(contextMenuRuntime.handleMenuAction).toHaveBeenCalledWith(action, expect.objectContaining({
       graphViewportScale: 2,
-      mutationDirectory: 'src/two.ts',
-      primaryNode: latestNode,
-      primaryTargetId: 'src/two.ts',
+      mutationDirectory: 'src/one.ts',
+      primaryNode: undefined,
+      primaryTargetId: 'src/one.ts',
     }));
   });
 
@@ -455,7 +457,10 @@ describe('graph/runtime/useGraphInteractionRuntime', () => {
       action: 'focus',
       kind: 'builtin',
     };
-    result.current.handleMenuAction(firstAction);
+    result.current.handleMenuAction({
+      action: firstAction,
+      contextSelection: createSelection(['src/one.ts']),
+    });
 
     rerender({
       graphContextSelection: createSelection(['src/two.ts']),
@@ -465,7 +470,10 @@ describe('graph/runtime/useGraphInteractionRuntime', () => {
       action: 'reveal',
       kind: 'builtin',
     };
-    result.current.handleMenuAction(secondAction);
+    result.current.handleMenuAction({
+      action: secondAction,
+      contextSelection: createSelection(['src/two.ts']),
+    });
     result.current.handleEngineStop();
 
     expect(contextMenuRuntime.handleMouseDownCapture).toHaveBeenCalledWith({

--- a/packages/extension/tests/webview/graph/viewport/view.test.tsx
+++ b/packages/extension/tests/webview/graph/viewport/view.test.tsx
@@ -52,12 +52,14 @@ vi.mock('../../../../src/webview/components/ui/context/menu', () => ({
 }));
 
 function createMenuEntries(): GraphContextMenuEntry[] {
+  const contextSelection = { kind: 'node' as const, targets: ['src/app.ts'] };
   return [
     {
       id: 'open',
       kind: 'item',
       label: 'Open file',
       action: { kind: 'builtin', action: 'open' },
+      contextSelection,
       destructive: false,
       shortcut: 'Enter',
     },
@@ -226,7 +228,10 @@ describe('Viewport', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /open file/i }));
 
-    expect(handleMenuAction).toHaveBeenCalledWith({ kind: 'builtin', action: 'open' });
+    expect(handleMenuAction).toHaveBeenCalledWith({
+      action: { kind: 'builtin', action: 'open' },
+      contextSelection: { kind: 'node', targets: ['src/app.ts'] },
+    });
     expect(screen.getByTestId('separator')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Trello: https://trello.com/c/foT17j88/163-architecture-deepen-graph-context-menu-execution

Status: draft PR opened before implementation, per Trello #163 workstream setup.

Initial scope from card:
- Deepen Graph Context Menu execution so Context Selection turns into a validated menu action.
- Keep entry building, run context, and effect context plumbing behind one behavior-shaped interface.
- Align first through grill-with-docs before production changes.

No production implementation has started yet.