### PR TITLE
Cold-cache startup visible graph contract

### DIFF
--- a/.changeset/cold-cache-visible-graph.md
+++ b/.changeset/cold-cache-visible-graph.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Keep discovered file nodes visible during cold-cache startup and label relationship counts as not indexed until a Graph Cache exists.

--- a/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
@@ -174,7 +174,7 @@ export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipeline
     return this._buildGraphData(
       fileConnections,
       workspaceRoot,
-      config.showOrphans,
+      true,
       disabledPlugins,
     );
   }

--- a/packages/extension/src/webview/app/graph/stats.tsx
+++ b/packages/extension/src/webview/app/graph/stats.tsx
@@ -7,8 +7,17 @@ export function formatGraphStat(count: number, singular: string, plural: string)
   return `${COUNT_FORMATTER.format(count)} ${label}`;
 }
 
-export function buildGraphStatsLabel(nodeCount: number, edgeCount: number): string {
-  return `${formatGraphStat(nodeCount, 'node', 'nodes')} • ${formatGraphStat(edgeCount, 'edge', 'edges')}`;
+export function buildGraphStatsLabel(
+  nodeCount: number,
+  edgeCount: number,
+  options: { hasIndex?: boolean } = {},
+): string {
+  const nodeLabel = formatGraphStat(nodeCount, 'visible node', 'visible nodes');
+  if (options.hasIndex === false && edgeCount === 0) {
+    return `${nodeLabel} • relationships not indexed`;
+  }
+
+  return `${nodeLabel} • ${formatGraphStat(edgeCount, 'rendered edge', 'rendered edges')}`;
 }
 
 export function GraphStatsBadge({ label }: { label: string }): React.ReactElement {

--- a/packages/extension/src/webview/app/shell/storeSelectors.ts
+++ b/packages/extension/src/webview/app/shell/storeSelectors.ts
@@ -8,6 +8,7 @@ import { useGraphStore } from '../../store/state';
 export function useAppState() {
   const graphData = useGraphStore(s => s.graphData);
   const isLoading = useGraphStore(s => s.isLoading);
+  const graphHasIndex = useGraphStore(s => s.graphHasIndex);
   const graphIsIndexing = useGraphStore(s => s.graphIsIndexing);
   const graphIndexProgress = useGraphStore(s => s.graphIndexProgress);
   const searchQuery = useGraphStore(s => s.searchQuery);
@@ -32,6 +33,7 @@ export function useAppState() {
   return {
     graphData,
     isLoading,
+    graphHasIndex,
     graphIsIndexing,
     graphIndexProgress,
     searchQuery,

--- a/packages/extension/src/webview/app/shell/view.tsx
+++ b/packages/extension/src/webview/app/shell/view.tsx
@@ -26,6 +26,7 @@ export default function App(): React.ReactElement {
   const {
     graphData,
     isLoading,
+    graphHasIndex,
     searchQuery,
     searchOptions,
     legends,
@@ -73,6 +74,7 @@ export default function App(): React.ReactElement {
     disabledPluginFilterPatterns,
     legends,
   );
+  const effectiveShowOrphans = graphHasIndex ? showOrphans : true;
   const { countBaseData, filterVisibleData } = useShellVisibleGraphs({
     activeFilterPatterns,
     edgeVisibility,
@@ -80,7 +82,7 @@ export default function App(): React.ReactElement {
     graphEdgeTypes,
     nodeVisibility,
     searchOptions,
-    showOrphans,
+    showOrphans: effectiveShowOrphans,
   });
   const {
     filteredData,
@@ -98,7 +100,7 @@ export default function App(): React.ReactElement {
     graphEdgeTypes,
     edgeDecorations,
     activeFilterPatterns,
-    showOrphans,
+    effectiveShowOrphans,
   );
 
   const {
@@ -130,6 +132,7 @@ export default function App(): React.ReactElement {
   const graphStatsLabel = buildGraphStatsLabel(
     loadedDisplayGraphData.nodes.length,
     loadedDisplayGraphData.edges.length,
+    { hasIndex: graphHasIndex },
   );
   const closeActivePanel = () => setActivePanel('none');
   const { countState, countTotal, excludedCount } = getShellGraphCountState({
@@ -172,7 +175,7 @@ export default function App(): React.ReactElement {
         <GraphSurface
           graphData={graphData}
           coloredData={coloredData}
-          showOrphans={showOrphans}
+          showOrphans={effectiveShowOrphans}
           depthMode={depthMode}
           timelineActive={timelineActive}
           theme={theme}

--- a/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
@@ -259,6 +259,46 @@ describe('pipeline/service/discoveryFacade', () => {
     );
   });
 
+  it('keeps cold-cache discovered file nodes visible when Show Orphans is disabled', async () => {
+    const facade = new TestDiscoveryFacade();
+    vi.mocked(facade._config.getAll).mockReturnValue({
+      showOrphans: false,
+      respectGitignore: true,
+    } as never);
+    const buildGraphData = vi
+      .spyOn(
+        facade as unknown as {
+          _buildGraphData: (...args: unknown[]) => unknown;
+        },
+        '_buildGraphData',
+      )
+      .mockReturnValue({
+        nodes: [
+          { id: 'src/a.ts', label: 'a.ts', color: '#333333' },
+          { id: 'src/b.ts', label: 'b.ts', color: '#333333' },
+        ],
+        edges: [],
+      });
+
+    await expect(facade.discoverGraph()).resolves.toEqual({
+      nodes: [
+        { id: 'src/a.ts', label: 'a.ts', color: '#333333' },
+        { id: 'src/b.ts', label: 'b.ts', color: '#333333' },
+      ],
+      edges: [],
+    });
+
+    expect(buildGraphData).toHaveBeenCalledWith(
+      new Map([
+        ['src/a.ts', []],
+        ['src/b.ts', []],
+      ]),
+      '/workspace',
+      true,
+      new Set<string>(),
+    );
+  });
+
   it('delegates analyze, rebuildGraph, and refreshIndex through the shared runners', async () => {
     const facade = new TestDiscoveryFacade();
     const disabledPlugins = new Set(['plugin.disabled']);

--- a/packages/extension/tests/webview/app/graph/stats.test.tsx
+++ b/packages/extension/tests/webview/app/graph/stats.test.tsx
@@ -12,13 +12,19 @@ describe('app/graph/stats', () => {
   it('builds a combined stats label and renders it', () => {
     render(<GraphStatsBadge label={buildGraphStatsLabel(2, 1)} />);
 
-    expect(screen.getByText('2 nodes • 1 edge')).toBeInTheDocument();
+    expect(screen.getByText('2 visible nodes • 1 rendered edge')).toBeInTheDocument();
+  });
+
+  it('does not present missing-index edges as a final rendered edge count', () => {
+    expect(buildGraphStatsLabel(2, 0, { hasIndex: false })).toBe(
+      '2 visible nodes • relationships not indexed',
+    );
   });
 
   it('keeps the stats badge distinct from the graph surface', () => {
     render(<GraphStatsBadge label={buildGraphStatsLabel(2, 1)} />);
 
-    const badge = screen.getByText('2 nodes • 1 edge');
+    const badge = screen.getByText('2 visible nodes • 1 rendered edge');
     expect(badge.className).toContain('bg-[var(--cg-background)]');
     expect(badge.className).toContain('border-[var(--cg-border-subtle)]');
     expect(badge.className).not.toContain('bg-[var(--cg-popover-translucent)]');
@@ -27,12 +33,12 @@ describe('app/graph/stats', () => {
   it('insets the stats badge from the graph corner', () => {
     render(<GraphStatsBadge label={buildGraphStatsLabel(2, 1)} />);
 
-    const badge = screen.getByText('2 nodes • 1 edge');
+    const badge = screen.getByText('2 visible nodes • 1 rendered edge');
     expect(badge.className).toContain('right-4');
     expect(badge.className).toContain('top-4');
   });
 
   it('builds a combined stats label for singular nodes and plural edges', () => {
-    expect(buildGraphStatsLabel(1, 2)).toBe('1 node • 2 edges');
+    expect(buildGraphStatsLabel(1, 2)).toBe('1 visible node • 2 rendered edges');
   });
 });

--- a/packages/extension/tests/webview/app/shell/behavior.ignoresplugininjectionpayloadswithouttorenderstheactivefilebreadcrumb.test.tsx
+++ b/packages/extension/tests/webview/app/shell/behavior.ignoresplugininjectionpayloadswithouttorenderstheactivefilebreadcrumb.test.tsx
@@ -289,6 +289,7 @@ describe('App behavior', () => {
     it('shows the hidden-files hint when the graph is empty and orphans are disabled', () => {
       graphStore.setState({
         graphData: { nodes: [], edges: [] },
+        graphHasIndex: true,
         showOrphans: false,
       });
 

--- a/packages/extension/tests/webview/app/shell/mutations.test.tsx
+++ b/packages/extension/tests/webview/app/shell/mutations.test.tsx
@@ -273,6 +273,7 @@ describe('App (mutation targets)', () => {
   it('shows hidden-files hint when graph data is empty and orphans are disabled', () => {
     graphStore.setState({
       graphData: { nodes: [], edges: [] },
+      graphHasIndex: true,
       showOrphans: false,
       timelineActive: false,
     });

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -313,7 +313,35 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('2 nodes • 1 edge')).toBeInTheDocument();
+    expect(screen.getByText('2 visible nodes • 1 rendered edge')).toBeInTheDocument();
+  });
+
+  it('keeps cold-cache file nodes visible after scope, filter, search, and Show Orphans', async () => {
+    graphStore.setState({
+      showOrphans: false,
+      graphHasIndex: false,
+      graphIndexFreshness: 'missing',
+      filterPatterns: ['src'],
+      searchQuery: 'a',
+      nodeVisibility: { file: true },
+    });
+
+    render(<App />);
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [
+            { id: 'src/a.ts', label: 'a.ts', color: '#3B82F6', nodeType: 'file' },
+            { id: 'docs/b.ts', label: 'b.ts', color: '#10B981', nodeType: 'file' },
+          ],
+          edges: [],
+        },
+      });
+      sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+    });
+
+    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
   });
 
   it('counts filters against the scoped visible graph instead of raw graph data', () => {


### PR DESCRIPTION
## Summary
- Keep discovered cold-cache file nodes visible even when the persisted Show Orphans setting is disabled.
- Treat missing Graph Cache startup as a file-node graph with no indexed relationships, not a final `0 edges` relationship count.
- Clarify the webview stats label as visible nodes + rendered edges, or `relationships not indexed` while no index exists.

## TDD / Red Tests
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/service/discoveryFacade.test.ts`
  - Red: `keeps cold-cache discovered file nodes visible when Show Orphans is disabled` expected `_buildGraphData(..., true, ...)`, received `false`.
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/app/graph/stats.test.tsx tests/webview/app/shell/view.test.tsx`
  - Red: stats still presented `0 edges` as final, and the App hid cold-cache file nodes when Show Orphans was disabled.

## Validation
- `pnpm install` - installed missing workspace dependencies for this worktree.
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/service/discoveryFacade.test.ts` - passed 8 tests.
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/app/graph/stats.test.tsx tests/webview/app/shell/view.test.tsx` - passed 31 tests.
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/analysis/execution/load.test.ts tests/extension/graphView/analysis/execution/publish.test.ts tests/webview/store/messageHandlers/graph.test.ts tests/webview/store/state/runtime.test.ts` - passed 61 tests.
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/app/shell/behavior.ignoresplugininjectionpayloadswithouttorenderstheactivefilebreadcrumb.test.tsx tests/webview/app/shell/mutations.test.tsx` - passed 27 tests.
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/app/graph/stats.test.tsx tests/webview/app/shell/view.test.tsx tests/extension/pipeline/service/discoveryFacade.test.ts` - passed 39 tests.
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/provider/runtime.trackstheinstalledpluginactivationtokeepsqueuedworkspacechangespending.test.ts` - passed 6 tests after full-suite timeout.
- `pnpm run typecheck` - passed 10/10 tasks.
- `pnpm run lint` - passed 10/10 tasks.
- `pnpm changeset status --since origin/main` - patch bump detected for `@codegraphy-dev/extension`.
- `pnpm run test` - 5782/5783 passed; one existing provider runtime test timed out at 10s under full-suite pressure, then passed in isolation.

## Integration Risk
- This deliberately makes missing-index startup ignore the persisted Show Orphans toggle for file nodes only at the webview/display contract level; indexed warm-cache behavior still honors the toggle.
- Harness workstream should assert `hasIndex: false` with `edges: []` and look for `relationships not indexed`, not a final `0 rendered edges` count.
- Stats wording changed globally from raw `nodes/edges` to `visible nodes/rendered edges`; tests that assert exact badge copy may need updates.