### PR TITLE
Fix Graph Cache startup responsiveness

### DIFF
--- a/.changeset/graph-cache-startup-responsiveness.md
+++ b/.changeset/graph-cache-startup-responsiveness.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy-dev/core": patch
+"@codegraphy-dev/extension": patch
+---
+
+Improve Graph Cache load and save responsiveness during startup and warm-cache graph replay.

--- a/packages/core/src/graphCache/database/io/connection.ts
+++ b/packages/core/src/graphCache/database/io/connection.ts
@@ -3,6 +3,7 @@ import type * as lb from '@ladybugdb/core';
 import type { FileAnalysisRow } from '../records/contracts';
 
 interface LadybugQueryResultLike {
+  getAll?(): Promise<FileAnalysisRow[]>;
   getAllSync?(): FileAnalysisRow[];
   close?(): void;
 }
@@ -24,12 +25,28 @@ export function runStatementSync(connection: lb.Connection, statement: string): 
   closeQueryResults(result);
 }
 
+export async function runStatementAsync(connection: lb.Connection, statement: string): Promise<void> {
+  const result = await connection.query(statement);
+  closeQueryResults(result);
+}
+
 export function readRowsSync(connection: lb.Connection, statement: string): FileAnalysisRow[] {
   const result = connection.querySync(statement);
 
   try {
     const queryResult = Array.isArray(result) ? result[0] : result;
     return (queryResult as LadybugQueryResultLike | undefined)?.getAllSync?.() ?? [];
+  } finally {
+    closeQueryResults(result);
+  }
+}
+
+export async function readRowsAsync(connection: lb.Connection, statement: string): Promise<FileAnalysisRow[]> {
+  const result = await connection.query(statement);
+
+  try {
+    const queryResult = Array.isArray(result) ? result[0] : result;
+    return await ((queryResult as LadybugQueryResultLike | undefined)?.getAll?.() ?? []);
   } finally {
     closeQueryResults(result);
   }
@@ -45,6 +62,21 @@ function ensureSchema(connection: lb.Connection): void {
     'CREATE NODE TABLE IF NOT EXISTS Symbol(symbolId STRING PRIMARY KEY, filePath STRING, name STRING, kind STRING, signature STRING, rangeJson STRING, metadataJson STRING)',
   );
   runStatementSync(
+    connection,
+    'CREATE NODE TABLE IF NOT EXISTS Relation(relationId STRING PRIMARY KEY, filePath STRING, kind STRING, pluginId STRING, sourceId STRING, fromFilePath STRING, toFilePath STRING, fromNodeId STRING, toNodeId STRING, fromSymbolId STRING, toSymbolId STRING, specifier STRING, relationType STRING, variant STRING, resolvedPath STRING, metadataJson STRING)',
+  );
+}
+
+async function ensureSchemaAsync(connection: lb.Connection): Promise<void> {
+  await runStatementAsync(
+    connection,
+    'CREATE NODE TABLE IF NOT EXISTS FileAnalysis(filePath STRING PRIMARY KEY, mtime INT64, size INT64, analysis STRING)',
+  );
+  await runStatementAsync(
+    connection,
+    'CREATE NODE TABLE IF NOT EXISTS Symbol(symbolId STRING PRIMARY KEY, filePath STRING, name STRING, kind STRING, signature STRING, rangeJson STRING, metadataJson STRING)',
+  );
+  await runStatementAsync(
     connection,
     'CREATE NODE TABLE IF NOT EXISTS Relation(relationId STRING PRIMARY KEY, filePath STRING, kind STRING, pluginId STRING, sourceId STRING, fromFilePath STRING, toFilePath STRING, fromNodeId STRING, toNodeId STRING, fromSymbolId STRING, toSymbolId STRING, specifier STRING, relationType STRING, variant STRING, resolvedPath STRING, metadataJson STRING)',
   );
@@ -75,11 +107,11 @@ export async function withConnectionAsync<T>(
   const connection = new Connection(database);
 
   try {
-    connection.initSync();
-    ensureSchema(connection);
+    await connection.init();
+    await ensureSchemaAsync(connection);
     return await callback(connection);
   } finally {
-    connection.closeSync();
-    database.closeSync();
+    await connection.close();
+    await database.close();
   }
 }

--- a/packages/core/src/graphCache/database/io/load.ts
+++ b/packages/core/src/graphCache/database/io/load.ts
@@ -4,7 +4,7 @@ import {
   WORKSPACE_ANALYSIS_CACHE_VERSION,
   type IWorkspaceAnalysisCache,
 } from '../../../analysis/cache';
-import { readRowsSync, withConnection } from './connection';
+import { readRowsAsync, readRowsSync, withConnection, withConnectionAsync } from './connection';
 import { clearDatabaseArtifacts, getWorkspaceAnalysisDatabasePath } from './paths';
 import { createSnapshotFileEntry } from '../records/file';
 import { FILE_ANALYSIS_ROWS_QUERY } from '../query/read';
@@ -20,6 +20,46 @@ export function loadWorkspaceAnalysisDatabaseCache(
   try {
     return withConnection(databasePath, (connection) => {
       const rows = readRowsSync(connection, FILE_ANALYSIS_ROWS_QUERY);
+      const cache = createEmptyWorkspaceAnalysisCache();
+
+      for (const row of rows) {
+        try {
+          const entry = createSnapshotFileEntry(row);
+          if (!entry) {
+            continue;
+          }
+
+          cache.files[entry.filePath] = {
+            mtime: entry.mtime,
+            size: entry.size,
+            analysis: entry.analysis,
+          };
+        } catch (error) {
+          console.warn('[CodeGraphy] Skipping unreadable persisted analysis row.', error);
+        }
+      }
+
+      cache.version = WORKSPACE_ANALYSIS_CACHE_VERSION;
+      return cache;
+    });
+  } catch (error) {
+    console.warn('[CodeGraphy] Failed to read persisted analysis database. Rebuilding cache.', error);
+    clearDatabaseArtifacts(databasePath);
+    return createEmptyWorkspaceAnalysisCache();
+  }
+}
+
+export async function loadWorkspaceAnalysisDatabaseCacheAsync(
+  workspaceRoot: string,
+): Promise<IWorkspaceAnalysisCache> {
+  const databasePath = getWorkspaceAnalysisDatabasePath(workspaceRoot);
+  if (!fs.existsSync(databasePath)) {
+    return createEmptyWorkspaceAnalysisCache();
+  }
+
+  try {
+    return await withConnectionAsync(databasePath, async (connection) => {
+      const rows = await readRowsAsync(connection, FILE_ANALYSIS_ROWS_QUERY);
       const cache = createEmptyWorkspaceAnalysisCache();
 
       for (const row of rows) {

--- a/packages/core/src/graphCache/database/io/save.ts
+++ b/packages/core/src/graphCache/database/io/save.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { setImmediate as waitForImmediate } from 'node:timers/promises';
 import type { IWorkspaceAnalysisCache } from '../../../analysis/cache';
-import { runStatementSync, withConnection, withConnectionAsync } from './connection';
+import { runStatementAsync, runStatementSync, withConnection, withConnectionAsync } from './connection';
 import { ensureDatabaseDirectory, getWorkspaceAnalysisDatabasePath } from './paths';
 import {
   persistAnalysisEntry,
@@ -81,9 +81,9 @@ export async function saveWorkspaceAnalysisDatabaseCacheAsync(
 
   try {
     await withConnectionAsync(tempDatabasePath, async (connection) => {
-      runStatementSync(connection, 'MATCH (entry:FileAnalysis) DELETE entry');
-      runStatementSync(connection, 'MATCH (entry:Symbol) DELETE entry');
-      runStatementSync(connection, 'MATCH (entry:Relation) DELETE entry');
+      await runStatementAsync(connection, 'MATCH (entry:FileAnalysis) DELETE entry');
+      await runStatementAsync(connection, 'MATCH (entry:Symbol) DELETE entry');
+      await runStatementAsync(connection, 'MATCH (entry:Relation) DELETE entry');
 
       let current = 0;
       let statementsSinceYield = 0;

--- a/packages/core/src/graphCache/database/query/write.ts
+++ b/packages/core/src/graphCache/database/query/write.ts
@@ -1,7 +1,7 @@
 import type * as lb from '@ladybugdb/core';
 import type { IAnalysisSymbol } from '@codegraphy-dev/plugin-api';
 import type { IWorkspaceAnalysisCache } from '../../../analysis/cache';
-import { runStatementSync } from '../io/connection';
+import { runStatementAsync, runStatementSync } from '../io/connection';
 import { createRelationStatement } from '../relation/statement';
 
 function escapeCypherString(value: string): string {
@@ -51,16 +51,16 @@ export async function persistAnalysisEntryAsync(
   entry: IWorkspaceAnalysisCache['files'][string],
   afterStatement: () => Promise<void>,
 ): Promise<void> {
-  runStatementSync(connection, createFileAnalysisStatement(filePath, entry));
+  await runStatementAsync(connection, createFileAnalysisStatement(filePath, entry));
   await afterStatement();
 
   for (const symbol of entry.analysis.symbols ?? []) {
-    runStatementSync(connection, createSymbolStatement(symbol));
+    await runStatementAsync(connection, createSymbolStatement(symbol));
     await afterStatement();
   }
 
   for (const [relationIndex, relation] of (entry.analysis.relations ?? []).entries()) {
-    runStatementSync(connection, createRelationStatement(filePath, relation, relationIndex));
+    await runStatementAsync(connection, createRelationStatement(filePath, relation, relationIndex));
     await afterStatement();
   }
 }

--- a/packages/core/src/graphCache/database/storage.ts
+++ b/packages/core/src/graphCache/database/storage.ts
@@ -1,4 +1,7 @@
-import { loadWorkspaceAnalysisDatabaseCache as loadWorkspaceAnalysisDatabaseCacheImpl } from './io/load';
+import {
+  loadWorkspaceAnalysisDatabaseCache as loadWorkspaceAnalysisDatabaseCacheImpl,
+  loadWorkspaceAnalysisDatabaseCacheAsync as loadWorkspaceAnalysisDatabaseCacheAsyncImpl,
+} from './io/load';
 import { getWorkspaceAnalysisDatabasePath as getWorkspaceAnalysisDatabasePathImpl } from './io/paths';
 import {
   readWorkspaceAnalysisDatabaseSnapshot as readWorkspaceAnalysisDatabaseSnapshotImpl,
@@ -23,6 +26,12 @@ export function loadWorkspaceAnalysisDatabaseCache(
   workspaceRoot: string,
 ) {
   return loadWorkspaceAnalysisDatabaseCacheImpl(workspaceRoot);
+}
+
+export function loadWorkspaceAnalysisDatabaseCacheAsync(
+  workspaceRoot: string,
+) {
+  return loadWorkspaceAnalysisDatabaseCacheAsyncImpl(workspaceRoot);
 }
 
 export function readWorkspaceAnalysisDatabaseSnapshot(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,6 +118,7 @@ export {
   clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCache,
   saveWorkspaceAnalysisDatabaseCacheAsync,

--- a/packages/extension/src/extension/pipeline/database/cache/storage.ts
+++ b/packages/extension/src/extension/pipeline/database/cache/storage.ts
@@ -3,6 +3,7 @@ export {
   clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCache,
   saveWorkspaceAnalysisDatabaseCacheAsync,

--- a/packages/extension/src/extension/pipeline/service/base/state.ts
+++ b/packages/extension/src/extension/pipeline/service/base/state.ts
@@ -14,6 +14,7 @@ import { Configuration } from '../../../config/reader';
 import { EventBus } from '../../../../core/plugins/events/bus';
 import type { IWorkspaceAnalysisCache } from '../../cache';
 import {
+  loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot,
   type WorkspaceAnalysisDatabaseSnapshot,
 } from '../../database/cache/storage';
@@ -26,6 +27,7 @@ export abstract class WorkspacePipelineStateBase {
   protected readonly _context: vscode.ExtensionContext;
   protected readonly _engineState: WorkspaceIndexEngineState;
   protected _eventBus?: EventBus;
+  private _cacheHydrationPromise?: Promise<void>;
 
   constructor(context: vscode.ExtensionContext) {
     this._context = context;
@@ -104,6 +106,25 @@ export abstract class WorkspacePipelineStateBase {
     }
 
     return readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot);
+  }
+
+  protected async _hydrateCacheFromGraphCache(): Promise<void> {
+    const workspaceRoot = this._getWorkspaceRoot();
+    if (!workspaceRoot || Object.keys(this._cache.files).length > 0) {
+      return;
+    }
+
+    this._cacheHydrationPromise ??= loadWorkspaceAnalysisDatabaseCacheAsync(workspaceRoot)
+      .then((cache) => {
+        if (Object.keys(this._cache.files).length === 0) {
+          this._cache = cache;
+        }
+      })
+      .finally(() => {
+        this._cacheHydrationPromise = undefined;
+      });
+
+    await this._cacheHydrationPromise;
   }
 
   protected abstract _getWorkspaceRoot(): string | undefined;

--- a/packages/extension/src/extension/pipeline/service/cache/initialState.ts
+++ b/packages/extension/src/extension/pipeline/service/cache/initialState.ts
@@ -3,16 +3,9 @@ import {
   createEmptyWorkspaceAnalysisCache,
   type IWorkspaceAnalysisCache,
 } from '../../cache';
-import { loadWorkspaceAnalysisDatabaseCache } from '../../database/cache/storage';
-import { readWorkspacePipelineRoot } from '../../serviceAdapters';
 
 export function createWorkspacePipelineInitialCache(
-  workspaceFolders: typeof vscode.workspace.workspaceFolders,
+  _workspaceFolders: typeof vscode.workspace.workspaceFolders,
 ): IWorkspaceAnalysisCache {
-  const workspaceRoot = readWorkspacePipelineRoot(workspaceFolders);
-  const repoCache = workspaceRoot
-    ? loadWorkspaceAnalysisDatabaseCache(workspaceRoot)
-    : undefined;
-
-  return repoCache ?? createEmptyWorkspaceAnalysisCache();
+  return createEmptyWorkspaceAnalysisCache();
 }

--- a/packages/extension/src/extension/pipeline/service/cache/storage.ts
+++ b/packages/extension/src/extension/pipeline/service/cache/storage.ts
@@ -1,6 +1,6 @@
 import type { IWorkspaceAnalysisCache } from '../../cache';
 import { clearWorkspacePipelineCache } from '../../analysis/state';
-import { saveWorkspaceAnalysisDatabaseCache } from '../../database/cache/storage';
+import { saveWorkspaceAnalysisDatabaseCacheAsync } from '../../database/cache/storage';
 
 export function clearWorkspacePipelineStoredCache(
   workspaceRoot: string | undefined,
@@ -18,9 +18,8 @@ export function persistWorkspacePipelineCache(
     return;
   }
 
-  try {
-    saveWorkspaceAnalysisDatabaseCache(workspaceRoot, cache);
-  } catch (error) {
-    warn('[CodeGraphy] Failed to persist repo-local analysis cache.', error);
-  }
+  void saveWorkspaceAnalysisDatabaseCacheAsync(workspaceRoot, cache)
+    .catch((error: unknown) => {
+      warn('[CodeGraphy] Failed to persist repo-local analysis cache.', error);
+    });
 }

--- a/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
@@ -205,6 +205,8 @@ export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipeline
     signal?: AbortSignal,
   ): Promise<IGraphData> {
     throwIfWorkspaceAnalysisAborted(signal);
+    await this._hydrateCacheFromGraphCache();
+    throwIfWorkspaceAnalysisAborted(signal);
 
     const workspaceRoot = this._getWorkspaceRoot();
     if (!workspaceRoot) {

--- a/packages/extension/tests/extension/pipeline/analysis.test.ts
+++ b/packages/extension/tests/extension/pipeline/analysis.test.ts
@@ -258,6 +258,39 @@ describe('WorkspacePipeline analysis', () => {
     expect(readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot).relations.length).toBeGreaterThan(0);
   });
 
+  it('replays warm Graph Cache nodes and edges after a cold index', async () => {
+    const workspaceRoot = await createWorkspace({
+      'src/utils.ts': 'export const value = 1;\n',
+      'src/index.ts': "import { value } from './utils';\nconsole.log(value);\n",
+    });
+    workspaceFoldersValue = [
+      { uri: vscode.Uri.file(workspaceRoot), name: 'workspace', index: 0 },
+    ];
+    const coldAnalyzer = new WorkspacePipeline(
+      createContext() as unknown as vscode.ExtensionContext
+    );
+
+    await coldAnalyzer.initialize();
+
+    const coldGraph = await coldAnalyzer.analyze();
+    expect(coldGraph.edges.map(edge => edge.id)).toContain('src/index.ts->src/utils.ts#import');
+
+    const warmAnalyzer = new WorkspacePipeline(
+      createContext() as unknown as vscode.ExtensionContext
+    );
+    await warmAnalyzer.initialize();
+
+    const warmGraph = await warmAnalyzer.loadCachedGraph();
+
+    expect(warmGraph.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'src/index.ts', color: expect.stringMatching(/^#[0-9a-f]{6}$/i) }),
+        expect.objectContaining({ id: 'src/utils.ts', color: expect.stringMatching(/^#[0-9a-f]{6}$/i) }),
+      ]),
+    );
+    expect(warmGraph.edges.map(edge => edge.id)).toContain('src/index.ts->src/utils.ts#import');
+  });
+
   it('returns an empty graph when no workspace folder is open', async () => {
     workspaceFoldersValue = undefined;
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/packages/extension/tests/extension/pipeline/lifecycle.test.ts
+++ b/packages/extension/tests/extension/pipeline/lifecycle.test.ts
@@ -617,7 +617,7 @@ describe('WorkspacePipeline lifecycle', { timeout: 30000 }, () => {
     });
   });
 
-  it('invalidates selected workspace files from the cache and persists the updated cache', () => {
+  it('invalidates selected workspace files from the cache and persists the updated cache', async () => {
     const workspaceRoot = createWorkspaceRoot();
     workspaceFoldersValue = [
       { uri: vscode.Uri.file(workspaceRoot), name: 'workspace', index: 0 },
@@ -677,10 +677,12 @@ describe('WorkspacePipeline lifecycle', { timeout: 30000 }, () => {
     expect(analyzerPrivate._lastFileAnalysis.has('src/remove.ts')).toBe(false);
     expect(analyzerPrivate._lastFileConnections.has('src/remove.ts')).toBe(false);
     expect(context.workspaceState.update).not.toHaveBeenCalled();
-    expect(loadWorkspaceAnalysisDatabaseCache(workspaceRoot).files['src/keep.ts']).toEqual({
-      mtime: 10,
-      size: 0,
-      analysis: { filePath: '/workspace/src/keep.ts', relations: [] },
+    await vi.waitFor(() => {
+      expect(loadWorkspaceAnalysisDatabaseCache(workspaceRoot).files['src/keep.ts']).toEqual({
+        mtime: 10,
+        size: 0,
+        analysis: { filePath: '/workspace/src/keep.ts', relations: [] },
+      });
     });
   });
 });

--- a/packages/extension/tests/extension/pipeline/lifecycle.test.ts
+++ b/packages/extension/tests/extension/pipeline/lifecycle.test.ts
@@ -266,7 +266,7 @@ describe('WorkspacePipeline lifecycle', { timeout: 30000 }, () => {
     })._getWorkspaceRoot()).toBeUndefined();
   });
 
-  it('loads the repo-local persisted cache when .codegraphy/graph.lbug already exists', () => {
+  it('defers repo-local Graph Cache hydration until cached graph replay', async () => {
     const workspaceRoot = createWorkspaceRoot();
     workspaceFoldersValue = [
       { uri: vscode.Uri.file(workspaceRoot), name: 'workspace', index: 0 },
@@ -293,6 +293,18 @@ describe('WorkspacePipeline lifecycle', { timeout: 30000 }, () => {
         update: vi.fn(() => Promise.resolve()),
       },
     } as unknown as vscode.ExtensionContext);
+
+    expect((analyzer as unknown as {
+      _cache: {
+        version: string;
+        files: Record<string, unknown>;
+      };
+    })._cache).toEqual({
+      version: WORKSPACE_ANALYSIS_CACHE_VERSION,
+      files: {},
+    });
+
+    await analyzer.loadCachedGraph();
 
     expect((analyzer as unknown as {
       _cache: {

--- a/packages/extension/tests/extension/pipeline/service/cache/storage.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/cache/storage.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearWorkspacePipelineCache } from '../../../../../src/extension/pipeline/analysis/state';
-import { saveWorkspaceAnalysisDatabaseCache } from '../../../../../src/extension/pipeline/database/cache/storage.ts';
+import { saveWorkspaceAnalysisDatabaseCacheAsync } from '../../../../../src/extension/pipeline/database/cache/storage.ts';
 import {
   clearWorkspacePipelineStoredCache,
   persistWorkspacePipelineCache,
@@ -11,7 +11,7 @@ vi.mock('../../../../../src/extension/pipeline/analysis/state', () => ({
 }));
 
 vi.mock('../../../../../src/extension/pipeline/database/cache/storage.ts', () => ({
-  saveWorkspaceAnalysisDatabaseCache: vi.fn(),
+  saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
 }));
 
 describe('pipeline/service/cache/storage', () => {
@@ -33,7 +33,7 @@ describe('pipeline/service/cache/storage', () => {
 
     persistWorkspacePipelineCache(undefined, { files: {} } as never, warn);
 
-    expect(saveWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
+    expect(saveWorkspaceAnalysisDatabaseCacheAsync).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
   });
 
@@ -43,23 +43,23 @@ describe('pipeline/service/cache/storage', () => {
 
     persistWorkspacePipelineCache('/workspace', cache as never, warn);
 
-    expect(saveWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith('/workspace', cache);
+    expect(saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalledWith('/workspace', cache);
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it('warns when saving the repo-local cache throws', () => {
+  it('warns when saving the repo-local cache rejects', async () => {
     const cache = { files: {} };
     const warn = vi.fn();
     const error = new Error('save failed');
-    vi.mocked(saveWorkspaceAnalysisDatabaseCache).mockImplementation(() => {
-      throw error;
-    });
+    vi.mocked(saveWorkspaceAnalysisDatabaseCacheAsync).mockRejectedValue(error);
 
     persistWorkspacePipelineCache('/workspace', cache as never, warn);
 
-    expect(warn).toHaveBeenCalledWith(
-      '[CodeGraphy] Failed to persist repo-local analysis cache.',
-      error,
-    );
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        '[CodeGraphy] Failed to persist repo-local analysis cache.',
+        error,
+      );
+    });
   });
 });

--- a/packages/extension/tests/extension/pipeline/service/cache/storage.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/cache/storage.test.ts
@@ -47,6 +47,24 @@ describe('pipeline/service/cache/storage', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it('returns before repo-local cache persistence settles', async () => {
+    const cache = { files: { 'src/a.ts': {} } };
+    const warn = vi.fn();
+    let resolveSave!: () => void;
+    const savePromise = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+    vi.mocked(saveWorkspaceAnalysisDatabaseCacheAsync).mockReturnValue(savePromise);
+
+    persistWorkspacePipelineCache('/workspace', cache as never, warn);
+
+    expect(saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalledWith('/workspace', cache);
+    expect(warn).not.toHaveBeenCalled();
+
+    resolveSave();
+    await savePromise;
+  });
+
   it('warns when saving the repo-local cache rejects', async () => {
     const cache = { files: {} };
     const warn = vi.fn();

--- a/packages/extension/tests/extension/pluginIntegration/installed/activation.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/installed/activation.test.ts
@@ -15,6 +15,7 @@ const mockState = vi.hoisted(() => ({
     clearWorkspaceAnalysisDatabaseCache: vi.fn(),
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
+    loadWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
     saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
   },
@@ -43,6 +44,7 @@ vi.mock('../../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   clearWorkspaceAnalysisDatabaseCache: mockState.databaseCache.clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
 }));
@@ -101,6 +103,10 @@ describe('extension/pluginIntegration/installedPluginActivation', () => {
       files: {},
       version: '2.0.0',
     });
+    mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync.mockResolvedValue({
+      files: {},
+      version: '2.0.0',
+    });
     mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot.mockReturnValue({
       files: [],
       symbols: [],
@@ -152,9 +158,7 @@ describe('extension/pluginIntegration/installedPluginActivation', () => {
     expect(pluginIds).toEqual(
       expect.arrayContaining(['codegraphy.markdown', installedPackage!.pluginId]),
     );
-    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
-      workspaceFixture!.workspacePath,
-    );
+    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
     expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 });

--- a/packages/extension/tests/extension/pluginIntegration/installed/statuses.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/installed/statuses.test.ts
@@ -15,6 +15,7 @@ const mockState = vi.hoisted(() => ({
     clearWorkspaceAnalysisDatabaseCache: vi.fn(),
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
+    loadWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
     saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
   },
@@ -43,6 +44,7 @@ vi.mock('../../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   clearWorkspaceAnalysisDatabaseCache: mockState.databaseCache.clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
 }));
@@ -209,6 +211,10 @@ describe('extension/pluginIntegration/installedPluginStatuses', () => {
       files: {},
       version: '2.0.0',
     });
+    mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync.mockResolvedValue({
+      files: {},
+      version: '2.0.0',
+    });
     mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot.mockReturnValue({
       files: [],
       symbols: [],
@@ -261,9 +267,7 @@ describe('extension/pluginIntegration/installedPluginStatuses', () => {
       ]),
     );
     await internals._analysisMethods._analyzeAndSendData();
-    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
-      workspaceFixture!.workspacePath,
-    );
+    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
     expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 

--- a/packages/extension/tests/extension/pluginIntegration/typescript.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/typescript.test.ts
@@ -17,6 +17,7 @@ const mockState = vi.hoisted(() => ({
     clearWorkspaceAnalysisDatabaseCache: vi.fn(),
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
+    loadWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
     saveWorkspaceAnalysisDatabaseCache: vi.fn(),
     saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
@@ -42,6 +43,7 @@ vi.mock('../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   clearWorkspaceAnalysisDatabaseCache: mockState.databaseCache.clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCache: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache,
   saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
@@ -92,6 +94,10 @@ describe('extension/pluginIntegration/typescript', () => {
       },
     );
     mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache.mockReturnValue({
+      files: {},
+      version: '2.0.0',
+    });
+    mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync.mockResolvedValue({
       files: {},
       version: '2.0.0',
     });
@@ -155,11 +161,9 @@ describe('extension/pluginIntegration/typescript', () => {
     ).map((pluginInfo) => pluginInfo.plugin.id);
 
     expect(pluginIds).toContain('codegraphy.typescript');
-    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
-      workspaceFixture!.workspacePath,
-    );
+    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
     expect(mockState.databaseCache.clearWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
-    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache).toHaveBeenCalled();
+    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
     expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 });


### PR DESCRIPTION
## Summary
- Defer repo-local Graph Cache hydration out of WorkspacePipeline startup state and hydrate it only when cached graph replay is requested.
- Move warm Graph Cache load plus async save/delete statements onto Ladybug async APIs so cache IO does not block extension-host refresh paths.
- Add cold-to-warm lifecycle coverage proving Graph Cache replay returns colored nodes and persisted import edges.

## Red Harness
- RED: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/lifecycle.test.ts -t "defers repo-local Graph Cache hydration"`
- Initial failure: the WorkspacePipeline constructor synchronously hydrated `.codegraphy/graph.lbug`, so the cache was already populated before cached replay.

## Validation
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/lifecycle.test.ts -t "defers repo-local Graph Cache hydration"`
- `pnpm --filter @codegraphy-dev/core exec vitest run --config vitest.config.ts tests/graphCache/database/storage.test.ts tests/graphCache/database/io/load.test.ts tests/graphCache/database/io/connection.test.ts`
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/lifecycle.test.ts tests/extension/pipeline/analysis.test.ts tests/extension/pipeline/service/discoveryFacade.test.ts tests/extension/pipeline/analysis/run.test.ts tests/extension/graphView/analysis/execution/load.test.ts`
- `pnpm --filter @codegraphy-dev/core typecheck`
- `pnpm --filter @codegraphy-dev/extension typecheck`
- `pnpm --filter @codegraphy-dev/core lint`
- `pnpm --filter @codegraphy-dev/extension lint`
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pluginIntegration/installed/activation.test.ts tests/extension/pluginIntegration/installed/statuses.test.ts tests/extension/pluginIntegration/typescript.test.ts tests/extension/pipeline/service/cache/storage.test.ts`
- `pnpm run test`

## Trello
- https://trello.com/c/m6Y5zjJ5
- Coordinates with https://trello.com/c/KzKVD9t8
