### PR TITLE
Startup cleanup: webview bootstrap settings resilience

### DIFF
--- a/.changeset/webview-bootstrap-settings-resilience.md
+++ b/.changeset/webview-bootstrap-settings-resilience.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Keep the graph view from staying on the startup loading screen while settings, filters, graph data, and plugin assets hydrate.

--- a/packages/extension/src/extension/graphView/webview/dispatch/pluginReady.ts
+++ b/packages/extension/src/extension/graphView/webview/dispatch/pluginReady.ts
@@ -1,11 +1,13 @@
 import type { WebviewToExtensionMessage } from '../../../../shared/protocol/webviewToExtension';
 import type { IPluginFilterPatternGroup } from '../../../../shared/protocol/extensionToWebview';
+import type { IGraphData } from '../../../../shared/graph/contracts';
 import type { DagMode, NodeSizeMode } from '../../../../shared/settings/modes';
 import { applyWebviewReady } from '../messages/ready';
 
 type GraphViewReadyMessage = Extract<WebviewToExtensionMessage, { type: 'WEBVIEW_READY' }>;
 
 export interface GraphViewPluginReadyContext {
+  getGraphData(): IGraphData;
   getFilterPatterns(): string[];
   getPluginFilterPatterns(): string[];
   getPluginFilterGroups?: () => IPluginFilterPatternGroup[];
@@ -59,6 +61,7 @@ export async function dispatchGraphViewPluginReadyMessage(
       readyNotified: context.isWebviewReadyNotified(),
     },
     {
+      getGraphData: () => context.getGraphData(),
       getFilterPatterns: () => context.getFilterPatterns(),
       getPluginFilterPatterns: () => context.getPluginFilterPatterns(),
       getPluginFilterGroups: () => context.getPluginFilterGroups?.() ?? [],

--- a/packages/extension/src/extension/graphView/webview/messages/ready.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/ready.ts
@@ -1,5 +1,6 @@
 import type { DagMode, NodeSizeMode } from '../../../../shared/settings/modes';
 import type { IPluginFilterPatternGroup } from '../../../../shared/protocol/extensionToWebview';
+import type { IGraphData } from '../../../../shared/graph/contracts';
 
 export interface GraphViewReadyState {
   maxFiles: number;
@@ -14,6 +15,7 @@ export interface GraphViewReadyState {
 }
 
 export interface GraphViewReadyHandlers {
+  getGraphData(): IGraphData;
   getFilterPatterns(): string[];
   getPluginFilterPatterns(): string[];
   getPluginFilterGroups?: () => IPluginFilterPatternGroup[];
@@ -97,6 +99,9 @@ export async function applyWebviewReady(
   handlers: GraphViewReadyHandlers,
 ): Promise<boolean> {
   replayWebviewReadySettings(state, handlers);
+  handlers.sendMessage({ type: 'GRAPH_DATA_UPDATED', payload: handlers.getGraphData() });
+  handlers.sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+
   await handlers.sendCachedTimeline();
   await handlers.loadAndSendData();
   handlers.sendPluginStatuses?.();
@@ -105,8 +110,6 @@ export async function applyWebviewReady(
     await handlers.waitForFirstWorkspaceReady();
     handlers.sendGraphViewContributionStatuses?.();
   }
-
-  handlers.sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
 
   if (state.readyNotified) {
     return true;

--- a/packages/extension/src/webview/store/actions/bootstrap.ts
+++ b/packages/extension/src/webview/store/actions/bootstrap.ts
@@ -3,13 +3,12 @@ import type { SetState } from './types';
 
 type InitialLoadingState = Pick<
   GraphState,
-  'bootstrapComplete' | 'graphData' | 'pendingPluginAssetLoads'
+  'bootstrapComplete' | 'graphData'
 >;
 
 function canFinishInitialLoading(state: InitialLoadingState): boolean {
   return state.bootstrapComplete
-    && state.graphData !== null
-    && state.pendingPluginAssetLoads === 0;
+    && state.graphData !== null;
 }
 
 export function createBootstrapActions(set: SetState) {

--- a/packages/extension/src/webview/store/messageHandlers/graph.ts
+++ b/packages/extension/src/webview/store/messageHandlers/graph.ts
@@ -13,12 +13,11 @@ export function handleGraphDataUpdated(
   const state = ctx?.getState();
   const waitingForInitialBootstrap = Boolean(
     state?.awaitingInitialBootstrap
-    && (!state.bootstrapComplete || state.pendingPluginAssetLoads > 0),
+    && !state.bootstrapComplete,
   );
   const initialBootstrapFinished = Boolean(
     state?.awaitingInitialBootstrap
     && state.bootstrapComplete
-    && state.pendingPluginAssetLoads === 0,
   );
 
   return {
@@ -35,7 +34,7 @@ export function handleAppBootstrapComplete(
   ctx: Pick<IHandlerContext, 'getState'>,
 ): PartialState {
   const state = ctx.getState();
-  const graphReady = state.graphData !== null && state.pendingPluginAssetLoads === 0;
+  const graphReady = state.graphData !== null;
 
   return {
     bootstrapComplete: true,

--- a/packages/extension/tests/extension/graphView/webview/dispatch/pluginReady.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/pluginReady.test.ts
@@ -9,6 +9,7 @@ function createContext(
   overrides: Partial<GraphViewPluginReadyContext> = {},
 ): GraphViewPluginReadyContext {
   return {
+    getGraphData: vi.fn(() => ({ nodes: [], edges: [] })),
     getFilterPatterns: vi.fn(() => ['src/**']),
     getPluginFilterPatterns: vi.fn(() => ['plugin:test/**']),
     getConfig: vi.fn(<T>(_: string, defaultValue: T): T => defaultValue),

--- a/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
@@ -3,6 +3,10 @@ import { applyWebviewReady } from '../../../../../src/extension/graphView/webvie
 
 function createHandlers() {
   return {
+    getGraphData: vi.fn(() => ({
+      nodes: [{ id: 'cached.ts', label: 'cached.ts', color: '#ffffff' }],
+      edges: [],
+    })),
     getFilterPatterns: vi.fn(() => ['dist/**']),
     getPluginFilterPatterns: vi.fn(() => ['venv/**']),
     getConfig: vi.fn(<T>(_key: string, defaultValue: T): T => defaultValue),
@@ -126,12 +130,15 @@ describe('graph view ready message', () => {
     expect(callOrder.indexOf('plugin-injections')).toBeLessThan(callOrder.indexOf('analyze'));
   });
 
-  it('announces bootstrap completion after the initial graph load settles', async () => {
+  it('publishes the current graph and completes app bootstrap before slow graph loading settles', async () => {
     const events: string[] = [];
     const handlers = createHandlers();
+    let finishGraphLoad: (() => void) | undefined;
     handlers.loadAndSendData.mockImplementation(async () => {
       events.push('graph:start');
-      await Promise.resolve();
+      await new Promise<void>(resolve => {
+        finishGraphLoad = resolve;
+      });
       events.push('graph:end');
     });
     handlers.sendPluginStatuses.mockImplementation(() => {
@@ -141,9 +148,12 @@ describe('graph view ready message', () => {
       if (message.type === 'APP_BOOTSTRAP_COMPLETE') {
         events.push('bootstrap');
       }
+      if (message.type === 'GRAPH_DATA_UPDATED') {
+        events.push('graph:snapshot');
+      }
     });
 
-    await applyWebviewReady(
+    const ready = applyWebviewReady(
       {
         maxFiles: 500,
         playbackSpeed: 1,
@@ -157,7 +167,14 @@ describe('graph view ready message', () => {
       handlers
     );
 
-    expect(events).toEqual(['graph:start', 'graph:end', 'plugins', 'bootstrap']);
+    await Promise.resolve();
+
+    expect(events).toEqual(['graph:snapshot', 'bootstrap', 'graph:start']);
+
+    finishGraphLoad?.();
+    await ready;
+
+    expect(events).toEqual(['graph:snapshot', 'bootstrap', 'graph:start', 'graph:end', 'plugins']);
   });
 
   it('waits for workspace readiness during the first workspace-backed analysis', async () => {

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -138,7 +138,7 @@ describe('App', () => {
     expect(screen.getByTitle('Graph Scope')).toBeInTheDocument();
   });
 
-  it('waits for startup plugin asset injection before showing the first graph', async () => {
+  it('keeps the first graph visible while startup plugin assets finish loading', async () => {
     let resolveInjection: (() => void) | undefined;
     const pendingImport = new Promise<void>((resolve) => {
       resolveInjection = resolve;
@@ -168,16 +168,117 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('Loading graph...')).toBeInTheDocument();
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
 
     await act(async () => {
       resolveInjection?.();
       await pendingImport;
     });
 
-    await waitFor(() => {
-      expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+  });
+
+  it('keeps the graph visible when plugin assets are injected after startup', async () => {
+    let resolveInjection: (() => void) | undefined;
+    const pendingImport = new Promise<void>((resolve) => {
+      resolveInjection = resolve;
     });
+    vi.doMock('/plugin/late-registration.js', () => pendingImport.then(() => ({
+      activate: vi.fn(),
+    })));
+
+    render(<App />);
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [{ id: 'test.ts', label: 'test.ts', color: '#3B82F6' }],
+          edges: [],
+        },
+      });
+      sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+
+    await act(async () => {
+      sendMessage({
+        type: 'PLUGIN_WEBVIEW_INJECT',
+        payload: {
+          pluginId: 'codegraphy.late',
+          scripts: ['/plugin/late-registration.js'],
+          styles: [],
+        },
+      });
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveInjection?.();
+      await pendingImport;
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+  });
+
+  it('keeps the graph visible when settings and filters update after startup', async () => {
+    render(<App />);
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [{ id: 'test.ts', label: 'test.ts', color: '#3B82F6' }],
+          edges: [],
+        },
+      });
+      sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+
+    await act(async () => {
+      sendMessage({
+        type: 'SETTINGS_UPDATED',
+        payload: {
+          bidirectionalEdges: 'combined',
+          showOrphans: true,
+        },
+      });
+      sendMessage({
+        type: 'FILTER_PATTERNS_UPDATED',
+        payload: {
+          patterns: ['dist/**'],
+          pluginPatterns: ['plugin/**'],
+          pluginPatternGroups: [],
+          disabledCustomPatterns: [],
+          disabledPluginPatterns: [],
+        },
+      });
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [
+            { id: 'test.ts', label: 'test.ts', color: '#3B82F6' },
+            { id: 'src/app.ts', label: 'app.ts', color: '#10B981' },
+          ],
+          edges: [],
+        },
+      });
+    });
+
+    expect(graphStore.getState().bidirectionalMode).toBe('combined');
+    expect(graphStore.getState().filterPatterns).toEqual(['dist/**']);
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('2 nodes • 0 edges')).toBeInTheDocument();
   });
 
   it('keeps the graph visible while indexing after startup', async () => {

--- a/packages/extension/tests/webview/store/actions/bootstrap.test.ts
+++ b/packages/extension/tests/webview/store/actions/bootstrap.test.ts
@@ -42,7 +42,7 @@ describe('webview/store/actions/bootstrap', () => {
     });
   });
 
-  it('keeps loading until bootstrap, graph data, and plugin assets are complete', () => {
+  it('does not keep initial loading blocked on plugin assets once bootstrap and graph data are complete', () => {
     const { actions, getState } = createHarness({
       awaitingInitialBootstrap: true,
       bootstrapComplete: true,
@@ -59,7 +59,8 @@ describe('webview/store/actions/bootstrap', () => {
 
     actions.finishPluginAssetLoad();
     expect(getState()).toMatchObject({
-      isLoading: true,
+      awaitingInitialBootstrap: false,
+      isLoading: false,
       pendingPluginAssetLoads: 1,
     });
 

--- a/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
+++ b/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
@@ -138,6 +138,24 @@ describe('webview/store/messageHandlers/graph', () => {
     });
   });
 
+  it('settles initial bootstrap when graph data and app bootstrap are ready while plugin assets continue loading', () => {
+    const state = createState({
+      graphData: { nodes: [{ id: 'src/app.ts', label: 'App', color: '#fff' }], edges: [] },
+      awaitingInitialBootstrap: true,
+      pendingPluginAssetLoads: 1,
+      isLoading: true,
+    });
+
+    expect(handleAppBootstrapComplete(
+      { type: 'APP_BOOTSTRAP_COMPLETE' },
+      { getState: () => state },
+    )).toEqual({
+      bootstrapComplete: true,
+      awaitingInitialBootstrap: false,
+      isLoading: false,
+    });
+  });
+
   it('maps graph index status and progress payloads', () => {
     expect(handleGraphIndexStatusUpdated({
       type: 'GRAPH_INDEX_STATUS_UPDATED',


### PR DESCRIPTION
## Summary

Startup cleanup for webview bootstrap, settings hydration, and plugin asset loading.

- replay persisted settings on webview ready, then immediately publish the current graph snapshot and `APP_BOOTSTRAP_COMPLETE` before slow cold-cache graph loading finishes
- stop startup plugin asset injection from blocking the initial graph/settings shell
- keep the first graph visible while plugin assets continue hydrating
- add explicit regression coverage that late plugin injection and settings/filter updates do not blank an already-visible graph
- add a changeset for the user-facing startup resilience fix

## TDD

Red coverage used for this slice:

- `packages/extension/tests/extension/graphView/webview/messages/ready.test.ts` — `publishes the current graph and completes app bootstrap before slow graph loading settles`
  - red failure: event order stayed at only `graph:start`; no current graph snapshot/bootstrap message was emitted until the slow graph load settled
- `packages/extension/tests/webview/store/messageHandlers/graph.test.ts` — `settles initial bootstrap when graph data and app bootstrap are ready while plugin assets continue loading`
  - red failure: state remained `awaitingInitialBootstrap: true` and `isLoading: true` while plugin assets were still pending

Self-review follow-up coverage added:

- `packages/extension/tests/webview/app/shell/view.test.tsx` — `keeps the graph visible when plugin assets are injected after startup`
- `packages/extension/tests/webview/app/shell/view.test.tsx` — `keeps the graph visible when settings and filters update after startup`

## Validation

- `pnpm install`
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/webview/messages/ready.test.ts` — red first, then passing after implementation
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/store/messageHandlers/graph.test.ts` — red first, then passing after implementation
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/app/shell/view.test.tsx tests/webview/store/messageHandlers/graph.test.ts tests/webview/store/actions/bootstrap.test.ts tests/extension/graphView/webview/messages/ready.test.ts tests/extension/graphView/webview/dispatch/pluginReady.test.ts` — passed, 54 tests
- `pnpm --filter @codegraphy-dev/extension run typecheck` — passed
- `pnpm run typecheck` — passed via pre-commit hook
- `pnpm run test` — earlier full local run failed after 989 files / 5780 tests passed due `packages/extension/tests/webview/graph/contextMenu/node.sendsopenfilemessagewhentoopensthefilterpopoverrequest.test.tsx` opening the folder/background context menu instead of the node menu
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/graph/contextMenu/node.sendsopenfilemessagewhentoopensthefilterpopoverrequest.test.tsx` — passed isolated, 7 tests
- PR CI on commit `d99137ef` — all green: build, lint, typecheck, playwright, packages unit tests, extension node unit tests, extension webview app shell/plugins, extension webview graph interaction/rendering, extension webview panels/search/exports

## Integration Notes

- `APP_BOOTSTRAP_COMPLETE` now means the webview shell has enough state to leave the full-page loading screen, not that cold-cache graph analysis is finished. Later `GRAPH_DATA_UPDATED` messages remain authoritative for fresh graph data.
- Plugin asset loading no longer blocks initial page-level loading. Plugin UI should tolerate asset registration finishing after the graph shell is visible.
- Settings replay remains first in the ready path, so settings/filter controls can hydrate promptly before the graph load settles.
- Later plugin injection and settings/filter updates are covered against reverting to `Loading graph...` after startup.
