### PR TITLE
Clarify indexing progress and graph stats

### DIFF
--- a/.changeset/clean-index-progress.md
+++ b/.changeset/clean-index-progress.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy-dev/core": patch
+"@codegraphy-dev/extension": patch
+---
+
+Make Indexing progress clearer by separating preparation from file analysis, replacing final cache-save progress with graph-view update progress, and hiding old graph stats until the indexed graph is published.

--- a/packages/core/src/analysis/workspaceAnalyze.ts
+++ b/packages/core/src/analysis/workspaceAnalyze.ts
@@ -121,9 +121,9 @@ export async function analyzeWorkspaceWithAnalyzer(
   });
 
   dependencies.sendProgress?.({
-    phase: 'Analyzing Files',
+    phase: 'Preparing Analysis',
     current: 0,
-    total: discoveryResult.files.length,
+    total: 1,
   });
   const analysisResult = await source._analyzeFiles(
     discoveryResult.files,

--- a/packages/core/tests/analysis/workspaceAnalyze.test.ts
+++ b/packages/core/tests/analysis/workspaceAnalyze.test.ts
@@ -180,7 +180,7 @@ describe('pipeline/analysis/analyze', () => {
       total: 1,
     });
     expect(dependencies.sendProgress).toHaveBeenNthCalledWith(3, {
-      phase: 'Analyzing Files',
+      phase: 'Preparing Analysis',
       current: 0,
       total: 1,
     });
@@ -239,6 +239,53 @@ describe('pipeline/analysis/analyze', () => {
     expect(dependencies.showWarningMessage).toHaveBeenCalledWith(
       formatWorkspacePipelineLimitReachedMessage(27, 25),
     );
+  });
+
+  it('reports preparation before file-level analysis progress starts', async () => {
+    const source = createSource();
+    const dependencies = createDependencies();
+    const files = [
+      { absolutePath: '/workspace/src/index.ts', relativePath: 'src/index.ts' },
+    ] as IDiscoveredFile[];
+
+    dependencies.discover.mockResolvedValue({
+      directories: [],
+      durationMs: 4,
+      files,
+      limitReached: false,
+      totalFound: 1,
+    });
+    source._analyzeFiles.mockImplementation(
+      async (
+        _files: IDiscoveredFile[],
+        _workspaceRoot: string,
+        onProgress?: (progress: { current: number; total: number; filePath: string }) => void,
+      ) => {
+        onProgress?.({
+          current: 1,
+          total: 1,
+          filePath: '/workspace/src/index.ts',
+        });
+
+        return {
+          fileAnalysis: new Map(),
+          fileConnections: new Map(),
+        };
+      },
+    );
+
+    await analyzeWorkspaceWithAnalyzer(source as never, dependencies as never);
+
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(3, {
+      phase: 'Preparing Analysis',
+      current: 0,
+      total: 1,
+    });
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(4, {
+      phase: 'Analyzing Files',
+      current: 1,
+      total: 1,
+    });
   });
 
   it('keeps analyzing when progress reporting and the event bus are unavailable', async () => {

--- a/packages/extension/src/extension/graphView/analysis/execution/publish.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/publish.ts
@@ -24,6 +24,12 @@ function resolveGraphIndexStatus(
   };
 }
 
+function shouldReportGraphViewUpdateProgress(
+  state: GraphViewAnalysisExecutionState,
+): boolean {
+  return state.mode === 'index' || state.mode === 'refresh' || state.mode === 'incremental';
+}
+
 export function publishEmptyGraph(
   handlers: GraphViewAnalysisExecutionHandlers,
   hasIndex: boolean = false,
@@ -45,6 +51,13 @@ export function publishAnalyzedGraph(
 ): void {
   const actualHasIndex = state.analyzer?.hasIndex() ?? hasIndex;
   const status = resolveGraphIndexStatus(state, actualHasIndex);
+  if (shouldReportGraphViewUpdateProgress(state)) {
+    handlers.sendIndexProgress?.({
+      phase: 'Updating Graph View',
+      current: 0,
+      total: 1,
+    });
+  }
   handlers.setRawGraphData(rawGraphData);
   handlers.sendGraphIndexStatusUpdated(actualHasIndex, status.freshness, status.detail);
   handlers.updateViewContext();

--- a/packages/extension/src/webview/app/shell/view.tsx
+++ b/packages/extension/src/webview/app/shell/view.tsx
@@ -182,7 +182,7 @@ export default function App(): React.ReactElement {
           onAddFilterRequested={openFilterPopoverWithPatterns}
           onAddLegendRequested={openLegendPrompt}
         />
-        <GraphStatsBadge label={graphStatsLabel} />
+        {!graphIsIndexing && <GraphStatsBadge label={graphStatsLabel} />}
         <ToolbarRail pluginHost={pluginHost} />
         <PanelStack
           activePanel={activePanel}

--- a/packages/extension/tests/extension/graphView/analysis/execution/publish.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/publish.test.ts
@@ -77,6 +77,39 @@ describe('graph view analysis execution publish', () => {
     expect(handlers.markWorkspaceReady).toHaveBeenCalledWith(getGraphData());
   });
 
+  it('reports graph view update progress before publishing an explicit index result', () => {
+    const rawGraphData: IGraphData = {
+      nodes: [{ id: 'src/index.ts', label: 'src/index.ts', color: '#ffffff' }],
+      edges: [],
+    };
+    const transformedGraphData: IGraphData = {
+      nodes: [{ id: 'src/index.ts', label: 'src/index.ts', color: '#ffffff' }],
+      edges: [],
+    };
+    const state = createExecutionState({
+      mode: 'index',
+      analyzer: createExecutionAnalyzer(),
+    });
+    const { handlers } = createExecutionHandlers({
+      applyViewTransform: vi.fn(() => {
+        handlers.setGraphData(transformedGraphData);
+      }),
+    });
+    const sendIndexProgress = vi.mocked(handlers.sendIndexProgress!);
+    const sendGraphDataUpdated = vi.mocked(handlers.sendGraphDataUpdated);
+
+    publishAnalyzedGraph(state, handlers, rawGraphData, true);
+
+    expect(sendIndexProgress).toHaveBeenCalledWith({
+      phase: 'Updating Graph View',
+      current: 0,
+      total: 1,
+    });
+    expect(sendIndexProgress.mock.invocationCallOrder[0]).toBeLessThan(
+      sendGraphDataUpdated.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it('publishes the actual missing index state when indexing does not create a Graph Cache', () => {
     const rawGraphData: IGraphData = {
       nodes: [{ id: 'src/index.ts', label: 'src/index.ts', color: '#ffffff' }],

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -210,6 +210,51 @@ describe('App', () => {
     expect(screen.getByText('Indexing Workspace')).toBeInTheDocument();
   });
 
+  it('hides final-looking graph stats while explicit indexing is active', async () => {
+    render(<App />);
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [{ id: 'test.ts', label: 'test.ts', color: '#3B82F6' }],
+          edges: [],
+        },
+      });
+      sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+    });
+
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_INDEX_PROGRESS',
+        payload: { phase: 'Preparing Analysis', current: 0, total: 1 },
+      });
+    });
+
+    expect(screen.queryByText('1 node • 0 edges')).not.toBeInTheDocument();
+    expect(screen.getByText('Preparing Analysis')).toBeInTheDocument();
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [
+            { id: 'test.ts', label: 'test.ts', color: '#3B82F6' },
+            { id: 'used.ts', label: 'used.ts', color: '#3B82F6' },
+          ],
+          edges: [
+            { id: 'test.ts->used.ts#import', from: 'test.ts', to: 'used.ts', kind: 'import', sources: [] },
+          ],
+        },
+      });
+    });
+
+    expect(screen.queryByText('Preparing Analysis')).not.toBeInTheDocument();
+    expect(screen.getByText('2 nodes • 1 edge')).toBeInTheDocument();
+  });
+
   it('should send WEBVIEW_READY only once across initial graph load', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sentMessages = (globalThis as any).__vscodeSentMessages as Array<{ type?: string }>;


### PR DESCRIPTION
## Summary
- split Core indexing progress so preparation is separate from file-level analysis progress
- report an Updating Graph View phase before publishing explicit index/refresh results
- hide stale graph stats while explicit indexing is active, then show final stats after GRAPH_DATA_UPDATED

## Trello
- https://trello.com/c/XAIXmH7D
- Related harness card: https://trello.com/c/KzKVD9t8

## Tests
- Red test: packages/core/tests/analysis/workspaceAnalyze.test.ts reports preparation before file-level analysis progress starts
- Red test: packages/extension/tests/webview/app/shell/view.test.tsx hides final-looking graph stats while explicit indexing is active
- Red test: packages/extension/tests/extension/graphView/analysis/execution/publish.test.ts reports graph view update progress before publishing an explicit index result
- pnpm --filter @codegraphy-dev/core exec vitest run --config vitest.config.ts tests/analysis/workspaceAnalyze.test.ts
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/app/shell/view.test.tsx tests/extension/graphView/analysis/execution/publish.test.ts tests/extension/graphView/analysis/execution/progress.test.ts tests/webview/graphIndexStatus/view.test.tsx
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/analysis/execution/publish.test.ts
- pnpm --filter @codegraphy-dev/extension run typecheck
- pnpm changeset status --since origin/main
- pre-commit: pnpm run typecheck, eslint --fix on staged files

## Integration risk
- Progress phase strings change from initial Analyzing Files 0/N to Preparing Analysis 0/1 before file-level progress starts.
- Stats are hidden only while graphIsIndexing is true; workstreams that depend on inspecting counts mid-index should listen for the final GRAPH_DATA_UPDATED payload instead.
- Explicit index/refresh/incremental publishes now emit Updating Graph View immediately before graph publication; harness assertions that enumerate exact phase lists may need to allow this additional phase.
