### PR TITLE
[codex] Add startup lifecycle acceptance harness

### DIFF
--- a/packages/extension/src/e2e/suite/graph.test.ts
+++ b/packages/extension/src/e2e/suite/graph.test.ts
@@ -111,6 +111,20 @@ function getGraphCachePath(): string {
   return path.join(getWorkspaceRoot(), '.codegraphy', 'graph.lbug');
 }
 
+function getRepoMetaPath(): string {
+  return path.join(getWorkspaceRoot(), '.codegraphy', 'meta.json');
+}
+
+function unlinkIfExists(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
 function getIndexTimeoutMs(): number {
   return scenario.name === 'codegraphy-root'
     ? CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS
@@ -442,6 +456,185 @@ suite('Graph: Workspace Analysis', function () {
       subscription.dispose();
     }
   });
+
+  test('CodeGraphy monorepo cold cache startup indexes explicitly and reopens warm from the Graph Cache', async function() {
+    if (scenario.name !== 'codegraphy-root') {
+      this.skip();
+      return;
+    }
+
+    this.timeout(CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS);
+
+    const graphCachePath = getGraphCachePath();
+    const repoMetaPath = getRepoMetaPath();
+    unlinkIfExists(repoMetaPath);
+    unlinkIfExists(graphCachePath);
+    assert.ok(!fs.existsSync(repoMetaPath), 'Expected repo meta to be removed before cold startup');
+    assert.ok(!fs.existsSync(graphCachePath), 'Expected the Graph Cache to be removed before cold startup');
+
+    indexedGraphPromise = undefined;
+    discoveredGraphPromise = undefined;
+
+    const api = await getAPI();
+    const progressPhases: string[] = [];
+    const graphUpdates: Array<{ nodes: number; edges: number }> = [];
+    const indexStatuses: Array<{ hasIndex: boolean; freshness: string; detail: string }> = [];
+    let sawSettingsHydrated = false;
+    let sawFiltersHydrated = false;
+    const subscription = api.onExtensionMessage(message => {
+      const type = (message as { type?: string }).type;
+      if (type === 'SETTINGS_UPDATED') {
+        sawSettingsHydrated = true;
+        return;
+      }
+
+      if (type === 'FILTER_PATTERNS_UPDATED') {
+        sawFiltersHydrated = true;
+        return;
+      }
+
+      if (type === 'GRAPH_INDEX_STATUS_UPDATED') {
+        const payload = (message as {
+          payload: { hasIndex: boolean; freshness: string; detail: string };
+        }).payload;
+        indexStatuses.push(payload);
+        return;
+      }
+
+      if (type === 'GRAPH_INDEX_PROGRESS') {
+        progressPhases.push((message as { payload: { phase: string } }).payload.phase);
+        return;
+      }
+
+      if (type !== 'GRAPH_DATA_UPDATED') {
+        return;
+      }
+
+      const graphData = (message as { payload: import('../../shared/graph/contracts').IGraphData }).payload;
+      graphUpdates.push({
+        nodes: graphData.nodes.length,
+        edges: graphData.edges.length,
+      });
+    });
+
+    try {
+      const coldGraphPromise = waitForExtensionMessageWhere<{
+        type: 'GRAPH_DATA_UPDATED';
+        payload: import('../../shared/graph/contracts').IGraphData;
+      }>(
+        api,
+        'GRAPH_DATA_UPDATED',
+        message => message.payload.nodes.length > 0,
+        180_000,
+      );
+      const coldBootstrap = waitForExtensionMessage(api, 'APP_BOOTSTRAP_COMPLETE', 180_000);
+
+      await vscode.commands.executeCommand('codegraphy.open');
+
+      const [coldGraphMessage] = await Promise.all([
+        coldGraphPromise,
+        coldBootstrap,
+      ]);
+      const coldVisibleGraph = await requestVisibleGraphState(api, 60_000);
+
+      assert.ok(sawSettingsHydrated, 'Expected cold startup to hydrate settings before leaving loading');
+      assert.ok(sawFiltersHydrated, 'Expected cold startup to hydrate filter patterns before leaving loading');
+      assert.ok(
+        indexStatuses.some(status => !status.hasIndex && status.freshness === 'missing'),
+        `Expected cold startup to report a missing Graph Cache before explicit indexing. Statuses: ${JSON.stringify(indexStatuses)}`,
+      );
+      assert.ok(
+        coldGraphMessage.payload.nodes.length > 0,
+        `Expected cold startup to discover visible file nodes. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+      assert.strictEqual(
+        coldGraphMessage.payload.edges.length,
+        0,
+        `Expected cold startup without a Graph Cache to show no edges. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+      assert.ok(
+        coldVisibleGraph.nodeCount > 0,
+        `Expected cold startup visible graph nodes. Visible graph: ${JSON.stringify(coldVisibleGraph)}`,
+      );
+      assert.ok(
+        coldVisibleGraph.nodes.every(node => (node.nodeType ?? 'file') === 'file'),
+        `Expected cold startup visible graph to contain only file nodes. Visible graph: ${JSON.stringify(coldVisibleGraph)}`,
+      );
+      assert.ok(
+        coldVisibleGraph.nodes.every(node => typeof node.color === 'string' && node.color.startsWith('#')),
+        `Expected cold startup visible file nodes to have graph colors. Visible graph: ${JSON.stringify(coldVisibleGraph)}`,
+      );
+      assert.strictEqual(
+        coldVisibleGraph.edgeCount,
+        0,
+        `Expected cold startup visible graph to have no edges. Visible graph: ${JSON.stringify(coldVisibleGraph)}`,
+      );
+
+      const rebuiltGraph = waitForExtensionMessageWhere<{
+        type: 'GRAPH_DATA_UPDATED';
+        payload: import('../../shared/graph/contracts').IGraphData;
+      }>(
+        api,
+        'GRAPH_DATA_UPDATED',
+        message => message.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS,
+      );
+      const indexReady = waitForGraphIndexStatus(api, true, CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS);
+      await api.dispatchWebviewMessage({ type: 'INDEX_GRAPH' });
+      const rebuiltGraphMessage = await rebuiltGraph;
+      await indexReady;
+
+      assert.ok(
+        fs.existsSync(repoMetaPath),
+        `Expected explicit indexing to recreate repo meta at ${repoMetaPath}`,
+      );
+      assert.ok(
+        fs.existsSync(graphCachePath),
+        `Expected explicit indexing to recreate the Graph Cache at ${graphCachePath}`,
+      );
+      assert.ok(
+        progressPhases.includes('Discovering Files'),
+        `Expected indexing to publish discovery progress. Phases: ${progressPhases.join(', ')}`,
+      );
+      assert.ok(
+        progressPhases.includes('Saving Graph Cache'),
+        `Expected indexing to publish Graph Cache persistence progress. Phases: ${progressPhases.join(', ')}`,
+      );
+      assert.ok(
+        rebuiltGraphMessage.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        `Expected explicit indexing to publish relationship edges. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+
+      const warmGraph = waitForExtensionMessageWhere<{
+        type: 'GRAPH_DATA_UPDATED';
+        payload: import('../../shared/graph/contracts').IGraphData;
+      }>(
+        api,
+        'GRAPH_DATA_UPDATED',
+        message => message.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        60_000,
+      );
+      const warmBootstrap = waitForExtensionMessage(api, 'APP_BOOTSTRAP_COMPLETE', 60_000);
+      await api.dispatchWebviewMessage({ type: 'WEBVIEW_READY', payload: null });
+      const [warmGraphMessage] = await Promise.all([warmGraph, warmBootstrap]);
+      const warmVisibleGraph = await requestVisibleGraphState(api, 60_000);
+
+      assert.ok(
+        warmGraphMessage.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        `Expected warm startup to publish edges from the Graph Cache. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+      assert.ok(
+        warmVisibleGraph.nodeCount > CODEGRAPHY_ROOT_RENDERED_NODE_THRESHOLD,
+        `Expected warm visible graph nodes from the Graph Cache. Visible graph: ${JSON.stringify(warmVisibleGraph)}`,
+      );
+      assert.ok(
+        warmVisibleGraph.edgeCount > CODEGRAPHY_ROOT_RENDERED_EDGE_THRESHOLD,
+        `Expected warm visible graph edges from the Graph Cache. Visible graph: ${JSON.stringify(warmVisibleGraph)}`,
+      );
+    } finally {
+      subscription.dispose();
+    }
+  });
 });
 
 function waitForExtensionMessage(
@@ -636,6 +829,7 @@ interface VisibleGraphStateResponse {
     edgeCount: number;
     edgeIds: string[];
     nodeCount: number;
+    nodes: Array<{ id: string; nodeType?: string; color: string }>;
   };
 }
 

--- a/packages/extension/src/shared/protocol/webviewToExtension.ts
+++ b/packages/extension/src/shared/protocol/webviewToExtension.ts
@@ -100,6 +100,7 @@ export type WebviewToExtensionMessage =
       type: 'VISIBLE_GRAPH_STATE_RESPONSE';
       payload: {
         nodeCount: number;
+        nodes: Array<{ id: string; nodeType?: string; color: string }>;
         edgeCount: number;
         edgeIds: string[];
       };

--- a/packages/extension/src/webview/app/shell/visibleGraphResponse.ts
+++ b/packages/extension/src/webview/app/shell/visibleGraphResponse.ts
@@ -5,6 +5,11 @@ import { postMessage as postWebviewMessage } from '../../vscodeApi';
 export function createVisibleGraphStatePayload(graphData: IGraphData | null | undefined) {
   return {
     nodeCount: graphData?.nodes.length ?? 0,
+    nodes: graphData?.nodes.map(node => ({
+      id: node.id,
+      nodeType: node.nodeType,
+      color: node.color,
+    })) ?? [],
     edgeCount: graphData?.edges.length ?? 0,
     edgeIds: graphData?.edges.map(edge => edge.id) ?? [],
   };

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -404,6 +404,10 @@ describe('App', () => {
       type: 'VISIBLE_GRAPH_STATE_RESPONSE',
       payload: {
         nodeCount: 2,
+        nodes: [
+          { id: 'src/app.ts', nodeType: 'file', color: '#3B82F6' },
+          { id: 'src/app.ts#run:function', nodeType: 'symbol', color: '#8B5CF6' },
+        ],
         edgeCount: 1,
         edgeIds: ['src/app.ts->src/app.ts#run:function#contains'],
       },

--- a/packages/extension/tests/webview/app/shell/visibleGraphResponse.test.ts
+++ b/packages/extension/tests/webview/app/shell/visibleGraphResponse.test.ts
@@ -35,6 +35,7 @@ describe('webview/app/shell/visibleGraphResponse', () => {
       edgeCount: 0,
       edgeIds: [],
       nodeCount: 0,
+      nodes: [],
     });
   });
 
@@ -43,6 +44,7 @@ describe('webview/app/shell/visibleGraphResponse', () => {
       edgeCount: 1,
       edgeIds: ['a->b'],
       nodeCount: 1,
+      nodes: [{ id: 'a.ts', nodeType: undefined, color: '#3B82F6' }],
     });
   });
 
@@ -65,6 +67,7 @@ describe('webview/app/shell/visibleGraphResponse', () => {
         edgeCount: 1,
         edgeIds: ['a->b'],
         nodeCount: 1,
+        nodes: [{ id: 'a.ts', nodeType: undefined, color: '#3B82F6' }],
       },
     });
 


### PR DESCRIPTION
## Summary
- Adds a CodeGraphy-root VS Code e2e acceptance scenario for the cold-cache to explicit-index to warm-cache lifecycle.
- Deletes `.codegraphy/meta.json` and `.codegraphy/graph.lbug`, verifies settings/filter hydration, missing-cache status, cold visible graph semantics, indexing progress, Graph Cache recreation, and warm webview-ready replay.
- Extends the existing `GET_VISIBLE_GRAPH_STATE` harness response so the acceptance test can assert visible file-node colors instead of only counts.
- Keeps this workstream harness/test-only; no runtime startup fixes are included.

## Self-Review Against Trello Card
Covered by the harness:
- Cold cache files deleted: explicitly removes `.codegraphy/meta.json` and `.codegraphy/graph.lbug`.
- Settings and filters hydrate: records `SETTINGS_UPDATED` and `FILTER_PATTERNS_UPDATED` before leaving loading.
- Initial visible file-node graph with no edges: requests webview visible graph state and asserts nodes exist, all visible nodes are file nodes, all have hex colors, and edge count is zero.
- Explicit indexing progress: dispatches `INDEX_GRAPH` and requires `Discovering Files` plus `Saving Graph Cache` progress phases.
- Edges update after indexing: waits for the CodeGraphy-root provider edge threshold.
- No infinite loading: waits for `APP_BOOTSTRAP_COMPLETE`; current production behavior can stall here, which is the intended red signal.

Known gap / limitation:
- The warm-cache portion is a webview-ready replay in the same VS Code extension-host process, not a full new VS Code process restart. It still verifies the webview opens from already generated Graph Cache data after explicit indexing, but a stricter process-restart harness would need runner-level support or a separate scenario phase.

## Red / Characterizing Signal
The focused e2e command currently reproduces the startup cleanup bug before the explicit index step. With both cache files deleted, CodeGraphy clears/discovers and then performs full analysis/builds edges before the user-triggered index path, and the run can stall before surfacing a clean bootstrap/assertion failure. I interrupted the hung runs rather than leaving VS Code stuck indefinitely.

Observed output from the latest focused run included:
- `[CodeGraphy] Cache cleared`
- `[CodeGraphy] Discovered 1950 files in 437ms`
- `[CodeGraphy] Analysis: 0 cache hits, 1950 misses`
- `[CodeGraphy] Graph built: 4460 nodes, 7617 edges`
- then no timely completion before manual interruption

## Validation
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/app/shell/visibleGraphResponse.test.ts` — passed.
- `pnpm --filter @codegraphy-dev/extension exec tsc -p src/e2e/tsconfig.json --noEmit` — passed.
- `pnpm --filter @codegraphy-dev/extension exec eslint src/e2e/suite/graph.test.ts src/webview/app/shell/visibleGraphResponse.ts tests/webview/app/shell/visibleGraphResponse.test.ts tests/webview/app/shell/view.test.tsx src/shared/protocol/webviewToExtension.ts` — passed.
- `CODEGRAPHY_E2E_ONLY_SCENARIO=codegraphy-root CODEGRAPHY_E2E_GREP="cold cache startup indexes explicitly" pnpm --filter @codegraphy-dev/extension run test:vscode` — red/hung; manually interrupted after observing cold startup clear/discovery/full-analysis symptoms.
- pre-commit hook during amend: `pnpm run typecheck` plus lint-staged `eslint --fix` — passed.

## Notes For Other Workstreams
- First failing boundary is before manual `INDEX_GRAPH`: cold startup should publish missing Graph Cache state plus colored visible file nodes with no edges, but current production startup proceeds into full analysis/edge building or gets stuck before bootstrap.
- A stricter true restart assertion should be added either by extending the VS Code e2e runner to support multi-phase scenario launches or by another harness that can start VS Code twice against the same workspace cache.

Trello: https://trello.com/c/KzKVD9t8