### PR TITLE
Integrate startup lifecycle cleanup workstreams

### DIFF
--- a/.changeset/clean-index-progress.md
+++ b/.changeset/clean-index-progress.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy-dev/core": patch
+"@codegraphy-dev/extension": patch
+---
+
+Make Indexing progress clearer by separating preparation from file analysis, replacing final cache-save progress with graph-view update progress, and hiding old graph stats until the indexed graph is published.

--- a/.changeset/cold-cache-visible-graph.md
+++ b/.changeset/cold-cache-visible-graph.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Keep discovered file nodes visible during cold-cache startup and label relationship counts as not indexed until a Graph Cache exists.

--- a/.changeset/graph-cache-startup-responsiveness.md
+++ b/.changeset/graph-cache-startup-responsiveness.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy-dev/core": patch
+"@codegraphy-dev/extension": patch
+---
+
+Improve Graph Cache load and save responsiveness during startup and warm-cache graph replay.

--- a/.changeset/webview-bootstrap-settings-resilience.md
+++ b/.changeset/webview-bootstrap-settings-resilience.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Keep the graph view from staying on the startup loading screen while settings, filters, graph data, and plugin assets hydrate.

--- a/.codegraphy/settings.json
+++ b/.codegraphy/settings.json
@@ -17,6 +17,7 @@
       "package": "@codegraphy-dev/plugin-godot"
     }
   ],
+  "pluginData": {},
   "nodeColors": {
     "file": "#A1A1AA",
     "folder": "#A1A1AA",
@@ -291,11 +292,5 @@
   "timeline": {
     "maxCommits": 500,
     "playbackSpeed": 1
-  },
-  "graphLayout": {
-    "collapsedNodes": {},
-    "pinnedNodes": {},
-    "sections": {},
-    "ownership": {}
   }
 }

--- a/packages/core/src/analysis/workspaceAnalyze.ts
+++ b/packages/core/src/analysis/workspaceAnalyze.ts
@@ -121,9 +121,9 @@ export async function analyzeWorkspaceWithAnalyzer(
   });
 
   dependencies.sendProgress?.({
-    phase: 'Analyzing Files',
+    phase: 'Preparing Analysis',
     current: 0,
-    total: discoveryResult.files.length,
+    total: 1,
   });
   const analysisResult = await source._analyzeFiles(
     discoveryResult.files,

--- a/packages/core/src/graphCache/database/io/connection.ts
+++ b/packages/core/src/graphCache/database/io/connection.ts
@@ -3,6 +3,7 @@ import type * as lb from '@ladybugdb/core';
 import type { FileAnalysisRow } from '../records/contracts';
 
 interface LadybugQueryResultLike {
+  getAll?(): Promise<FileAnalysisRow[]>;
   getAllSync?(): FileAnalysisRow[];
   close?(): void;
 }
@@ -24,12 +25,28 @@ export function runStatementSync(connection: lb.Connection, statement: string): 
   closeQueryResults(result);
 }
 
+export async function runStatementAsync(connection: lb.Connection, statement: string): Promise<void> {
+  const result = await connection.query(statement);
+  closeQueryResults(result);
+}
+
 export function readRowsSync(connection: lb.Connection, statement: string): FileAnalysisRow[] {
   const result = connection.querySync(statement);
 
   try {
     const queryResult = Array.isArray(result) ? result[0] : result;
     return (queryResult as LadybugQueryResultLike | undefined)?.getAllSync?.() ?? [];
+  } finally {
+    closeQueryResults(result);
+  }
+}
+
+export async function readRowsAsync(connection: lb.Connection, statement: string): Promise<FileAnalysisRow[]> {
+  const result = await connection.query(statement);
+
+  try {
+    const queryResult = Array.isArray(result) ? result[0] : result;
+    return await ((queryResult as LadybugQueryResultLike | undefined)?.getAll?.() ?? []);
   } finally {
     closeQueryResults(result);
   }
@@ -45,6 +62,21 @@ function ensureSchema(connection: lb.Connection): void {
     'CREATE NODE TABLE IF NOT EXISTS Symbol(symbolId STRING PRIMARY KEY, filePath STRING, name STRING, kind STRING, signature STRING, rangeJson STRING, metadataJson STRING)',
   );
   runStatementSync(
+    connection,
+    'CREATE NODE TABLE IF NOT EXISTS Relation(relationId STRING PRIMARY KEY, filePath STRING, kind STRING, pluginId STRING, sourceId STRING, fromFilePath STRING, toFilePath STRING, fromNodeId STRING, toNodeId STRING, fromSymbolId STRING, toSymbolId STRING, specifier STRING, relationType STRING, variant STRING, resolvedPath STRING, metadataJson STRING)',
+  );
+}
+
+async function ensureSchemaAsync(connection: lb.Connection): Promise<void> {
+  await runStatementAsync(
+    connection,
+    'CREATE NODE TABLE IF NOT EXISTS FileAnalysis(filePath STRING PRIMARY KEY, mtime INT64, size INT64, analysis STRING)',
+  );
+  await runStatementAsync(
+    connection,
+    'CREATE NODE TABLE IF NOT EXISTS Symbol(symbolId STRING PRIMARY KEY, filePath STRING, name STRING, kind STRING, signature STRING, rangeJson STRING, metadataJson STRING)',
+  );
+  await runStatementAsync(
     connection,
     'CREATE NODE TABLE IF NOT EXISTS Relation(relationId STRING PRIMARY KEY, filePath STRING, kind STRING, pluginId STRING, sourceId STRING, fromFilePath STRING, toFilePath STRING, fromNodeId STRING, toNodeId STRING, fromSymbolId STRING, toSymbolId STRING, specifier STRING, relationType STRING, variant STRING, resolvedPath STRING, metadataJson STRING)',
   );
@@ -75,11 +107,11 @@ export async function withConnectionAsync<T>(
   const connection = new Connection(database);
 
   try {
-    connection.initSync();
-    ensureSchema(connection);
+    await connection.init();
+    await ensureSchemaAsync(connection);
     return await callback(connection);
   } finally {
-    connection.closeSync();
-    database.closeSync();
+    await connection.close();
+    await database.close();
   }
 }

--- a/packages/core/src/graphCache/database/io/load.ts
+++ b/packages/core/src/graphCache/database/io/load.ts
@@ -4,7 +4,7 @@ import {
   WORKSPACE_ANALYSIS_CACHE_VERSION,
   type IWorkspaceAnalysisCache,
 } from '../../../analysis/cache';
-import { readRowsSync, withConnection } from './connection';
+import { readRowsAsync, readRowsSync, withConnection, withConnectionAsync } from './connection';
 import { clearDatabaseArtifacts, getWorkspaceAnalysisDatabasePath } from './paths';
 import { createSnapshotFileEntry } from '../records/file';
 import { FILE_ANALYSIS_ROWS_QUERY } from '../query/read';
@@ -20,6 +20,46 @@ export function loadWorkspaceAnalysisDatabaseCache(
   try {
     return withConnection(databasePath, (connection) => {
       const rows = readRowsSync(connection, FILE_ANALYSIS_ROWS_QUERY);
+      const cache = createEmptyWorkspaceAnalysisCache();
+
+      for (const row of rows) {
+        try {
+          const entry = createSnapshotFileEntry(row);
+          if (!entry) {
+            continue;
+          }
+
+          cache.files[entry.filePath] = {
+            mtime: entry.mtime,
+            size: entry.size,
+            analysis: entry.analysis,
+          };
+        } catch (error) {
+          console.warn('[CodeGraphy] Skipping unreadable persisted analysis row.', error);
+        }
+      }
+
+      cache.version = WORKSPACE_ANALYSIS_CACHE_VERSION;
+      return cache;
+    });
+  } catch (error) {
+    console.warn('[CodeGraphy] Failed to read persisted analysis database. Rebuilding cache.', error);
+    clearDatabaseArtifacts(databasePath);
+    return createEmptyWorkspaceAnalysisCache();
+  }
+}
+
+export async function loadWorkspaceAnalysisDatabaseCacheAsync(
+  workspaceRoot: string,
+): Promise<IWorkspaceAnalysisCache> {
+  const databasePath = getWorkspaceAnalysisDatabasePath(workspaceRoot);
+  if (!fs.existsSync(databasePath)) {
+    return createEmptyWorkspaceAnalysisCache();
+  }
+
+  try {
+    return await withConnectionAsync(databasePath, async (connection) => {
+      const rows = await readRowsAsync(connection, FILE_ANALYSIS_ROWS_QUERY);
       const cache = createEmptyWorkspaceAnalysisCache();
 
       for (const row of rows) {

--- a/packages/core/src/graphCache/database/io/save.ts
+++ b/packages/core/src/graphCache/database/io/save.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { setImmediate as waitForImmediate } from 'node:timers/promises';
 import type { IWorkspaceAnalysisCache } from '../../../analysis/cache';
-import { runStatementSync, withConnection, withConnectionAsync } from './connection';
+import { runStatementAsync, runStatementSync, withConnection, withConnectionAsync } from './connection';
 import { ensureDatabaseDirectory, getWorkspaceAnalysisDatabasePath } from './paths';
 import {
   persistAnalysisEntry,
@@ -81,9 +81,9 @@ export async function saveWorkspaceAnalysisDatabaseCacheAsync(
 
   try {
     await withConnectionAsync(tempDatabasePath, async (connection) => {
-      runStatementSync(connection, 'MATCH (entry:FileAnalysis) DELETE entry');
-      runStatementSync(connection, 'MATCH (entry:Symbol) DELETE entry');
-      runStatementSync(connection, 'MATCH (entry:Relation) DELETE entry');
+      await runStatementAsync(connection, 'MATCH (entry:FileAnalysis) DELETE entry');
+      await runStatementAsync(connection, 'MATCH (entry:Symbol) DELETE entry');
+      await runStatementAsync(connection, 'MATCH (entry:Relation) DELETE entry');
 
       let current = 0;
       let statementsSinceYield = 0;

--- a/packages/core/src/graphCache/database/query/write.ts
+++ b/packages/core/src/graphCache/database/query/write.ts
@@ -1,7 +1,7 @@
 import type * as lb from '@ladybugdb/core';
 import type { IAnalysisSymbol } from '@codegraphy-dev/plugin-api';
 import type { IWorkspaceAnalysisCache } from '../../../analysis/cache';
-import { runStatementSync } from '../io/connection';
+import { runStatementAsync, runStatementSync } from '../io/connection';
 import { createRelationStatement } from '../relation/statement';
 
 function escapeCypherString(value: string): string {
@@ -51,16 +51,16 @@ export async function persistAnalysisEntryAsync(
   entry: IWorkspaceAnalysisCache['files'][string],
   afterStatement: () => Promise<void>,
 ): Promise<void> {
-  runStatementSync(connection, createFileAnalysisStatement(filePath, entry));
+  await runStatementAsync(connection, createFileAnalysisStatement(filePath, entry));
   await afterStatement();
 
   for (const symbol of entry.analysis.symbols ?? []) {
-    runStatementSync(connection, createSymbolStatement(symbol));
+    await runStatementAsync(connection, createSymbolStatement(symbol));
     await afterStatement();
   }
 
   for (const [relationIndex, relation] of (entry.analysis.relations ?? []).entries()) {
-    runStatementSync(connection, createRelationStatement(filePath, relation, relationIndex));
+    await runStatementAsync(connection, createRelationStatement(filePath, relation, relationIndex));
     await afterStatement();
   }
 }

--- a/packages/core/src/graphCache/database/storage.ts
+++ b/packages/core/src/graphCache/database/storage.ts
@@ -1,4 +1,7 @@
-import { loadWorkspaceAnalysisDatabaseCache as loadWorkspaceAnalysisDatabaseCacheImpl } from './io/load';
+import {
+  loadWorkspaceAnalysisDatabaseCache as loadWorkspaceAnalysisDatabaseCacheImpl,
+  loadWorkspaceAnalysisDatabaseCacheAsync as loadWorkspaceAnalysisDatabaseCacheAsyncImpl,
+} from './io/load';
 import { getWorkspaceAnalysisDatabasePath as getWorkspaceAnalysisDatabasePathImpl } from './io/paths';
 import {
   readWorkspaceAnalysisDatabaseSnapshot as readWorkspaceAnalysisDatabaseSnapshotImpl,
@@ -23,6 +26,12 @@ export function loadWorkspaceAnalysisDatabaseCache(
   workspaceRoot: string,
 ) {
   return loadWorkspaceAnalysisDatabaseCacheImpl(workspaceRoot);
+}
+
+export function loadWorkspaceAnalysisDatabaseCacheAsync(
+  workspaceRoot: string,
+) {
+  return loadWorkspaceAnalysisDatabaseCacheAsyncImpl(workspaceRoot);
 }
 
 export function readWorkspaceAnalysisDatabaseSnapshot(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,6 +118,7 @@ export {
   clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCache,
   saveWorkspaceAnalysisDatabaseCacheAsync,

--- a/packages/core/tests/analysis/workspaceAnalyze.test.ts
+++ b/packages/core/tests/analysis/workspaceAnalyze.test.ts
@@ -180,7 +180,7 @@ describe('pipeline/analysis/analyze', () => {
       total: 1,
     });
     expect(dependencies.sendProgress).toHaveBeenNthCalledWith(3, {
-      phase: 'Analyzing Files',
+      phase: 'Preparing Analysis',
       current: 0,
       total: 1,
     });
@@ -239,6 +239,53 @@ describe('pipeline/analysis/analyze', () => {
     expect(dependencies.showWarningMessage).toHaveBeenCalledWith(
       formatWorkspacePipelineLimitReachedMessage(27, 25),
     );
+  });
+
+  it('reports preparation before file-level analysis progress starts', async () => {
+    const source = createSource();
+    const dependencies = createDependencies();
+    const files = [
+      { absolutePath: '/workspace/src/index.ts', relativePath: 'src/index.ts' },
+    ] as IDiscoveredFile[];
+
+    dependencies.discover.mockResolvedValue({
+      directories: [],
+      durationMs: 4,
+      files,
+      limitReached: false,
+      totalFound: 1,
+    });
+    source._analyzeFiles.mockImplementation(
+      async (
+        _files: IDiscoveredFile[],
+        _workspaceRoot: string,
+        onProgress?: (progress: { current: number; total: number; filePath: string }) => void,
+      ) => {
+        onProgress?.({
+          current: 1,
+          total: 1,
+          filePath: '/workspace/src/index.ts',
+        });
+
+        return {
+          fileAnalysis: new Map(),
+          fileConnections: new Map(),
+        };
+      },
+    );
+
+    await analyzeWorkspaceWithAnalyzer(source as never, dependencies as never);
+
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(3, {
+      phase: 'Preparing Analysis',
+      current: 0,
+      total: 1,
+    });
+    expect(dependencies.sendProgress).toHaveBeenNthCalledWith(4, {
+      phase: 'Analyzing Files',
+      current: 1,
+      total: 1,
+    });
   });
 
   it('keeps analyzing when progress reporting and the event bus are unavailable', async () => {

--- a/packages/extension/src/e2e/suite/graph.test.ts
+++ b/packages/extension/src/e2e/suite/graph.test.ts
@@ -553,7 +553,7 @@ suite('Graph: Workspace Analysis', function () {
         `Expected cold startup without a Graph Cache to show no edges. Updates: ${JSON.stringify(graphUpdates)}`,
       );
       assert.ok(
-        coldVisibleGraph.nodeCount > 0,
+        coldVisibleGraph.nodeCount > CODEGRAPHY_ROOT_RENDERED_NODE_THRESHOLD,
         `Expected cold startup visible graph nodes. Visible graph: ${JSON.stringify(coldVisibleGraph)}`,
       );
       assert.ok(

--- a/packages/extension/src/e2e/suite/graph.test.ts
+++ b/packages/extension/src/e2e/suite/graph.test.ts
@@ -111,6 +111,20 @@ function getGraphCachePath(): string {
   return path.join(getWorkspaceRoot(), '.codegraphy', 'graph.lbug');
 }
 
+function getRepoMetaPath(): string {
+  return path.join(getWorkspaceRoot(), '.codegraphy', 'meta.json');
+}
+
+function unlinkIfExists(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
 function getIndexTimeoutMs(): number {
   return scenario.name === 'codegraphy-root'
     ? CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS
@@ -442,6 +456,185 @@ suite('Graph: Workspace Analysis', function () {
       subscription.dispose();
     }
   });
+
+  test('CodeGraphy monorepo cold cache startup indexes explicitly and reopens warm from the Graph Cache', async function() {
+    if (scenario.name !== 'codegraphy-root') {
+      this.skip();
+      return;
+    }
+
+    this.timeout(CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS);
+
+    const graphCachePath = getGraphCachePath();
+    const repoMetaPath = getRepoMetaPath();
+    unlinkIfExists(repoMetaPath);
+    unlinkIfExists(graphCachePath);
+    assert.ok(!fs.existsSync(repoMetaPath), 'Expected repo meta to be removed before cold startup');
+    assert.ok(!fs.existsSync(graphCachePath), 'Expected the Graph Cache to be removed before cold startup');
+
+    indexedGraphPromise = undefined;
+    discoveredGraphPromise = undefined;
+
+    const api = await getAPI();
+    const progressPhases: string[] = [];
+    const graphUpdates: Array<{ nodes: number; edges: number }> = [];
+    const indexStatuses: Array<{ hasIndex: boolean; freshness: string; detail: string }> = [];
+    let sawSettingsHydrated = false;
+    let sawFiltersHydrated = false;
+    const subscription = api.onExtensionMessage(message => {
+      const type = (message as { type?: string }).type;
+      if (type === 'SETTINGS_UPDATED') {
+        sawSettingsHydrated = true;
+        return;
+      }
+
+      if (type === 'FILTER_PATTERNS_UPDATED') {
+        sawFiltersHydrated = true;
+        return;
+      }
+
+      if (type === 'GRAPH_INDEX_STATUS_UPDATED') {
+        const payload = (message as {
+          payload: { hasIndex: boolean; freshness: string; detail: string };
+        }).payload;
+        indexStatuses.push(payload);
+        return;
+      }
+
+      if (type === 'GRAPH_INDEX_PROGRESS') {
+        progressPhases.push((message as { payload: { phase: string } }).payload.phase);
+        return;
+      }
+
+      if (type !== 'GRAPH_DATA_UPDATED') {
+        return;
+      }
+
+      const graphData = (message as { payload: import('../../shared/graph/contracts').IGraphData }).payload;
+      graphUpdates.push({
+        nodes: graphData.nodes.length,
+        edges: graphData.edges.length,
+      });
+    });
+
+    try {
+      const coldGraphPromise = waitForExtensionMessageWhere<{
+        type: 'GRAPH_DATA_UPDATED';
+        payload: import('../../shared/graph/contracts').IGraphData;
+      }>(
+        api,
+        'GRAPH_DATA_UPDATED',
+        message => message.payload.nodes.length > 0,
+        180_000,
+      );
+      const coldBootstrap = waitForExtensionMessage(api, 'APP_BOOTSTRAP_COMPLETE', 180_000);
+
+      await vscode.commands.executeCommand('codegraphy.open');
+
+      const [coldGraphMessage] = await Promise.all([
+        coldGraphPromise,
+        coldBootstrap,
+      ]);
+      const coldVisibleGraph = await requestVisibleGraphState(api, 60_000);
+
+      assert.ok(sawSettingsHydrated, 'Expected cold startup to hydrate settings before leaving loading');
+      assert.ok(sawFiltersHydrated, 'Expected cold startup to hydrate filter patterns before leaving loading');
+      assert.ok(
+        indexStatuses.some(status => !status.hasIndex && status.freshness === 'missing'),
+        `Expected cold startup to report a missing Graph Cache before explicit indexing. Statuses: ${JSON.stringify(indexStatuses)}`,
+      );
+      assert.ok(
+        coldGraphMessage.payload.nodes.length > 0,
+        `Expected cold startup to discover visible file nodes. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+      assert.strictEqual(
+        coldGraphMessage.payload.edges.length,
+        0,
+        `Expected cold startup without a Graph Cache to show no edges. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+      assert.ok(
+        coldVisibleGraph.nodeCount > 0,
+        `Expected cold startup visible graph nodes. Visible graph: ${JSON.stringify(coldVisibleGraph)}`,
+      );
+      assert.ok(
+        coldVisibleGraph.nodes.every(node => (node.nodeType ?? 'file') === 'file'),
+        `Expected cold startup visible graph to contain only file nodes. Visible graph: ${JSON.stringify(coldVisibleGraph)}`,
+      );
+      assert.ok(
+        coldVisibleGraph.nodes.every(node => typeof node.color === 'string' && node.color.startsWith('#')),
+        `Expected cold startup visible file nodes to have graph colors. Visible graph: ${JSON.stringify(coldVisibleGraph)}`,
+      );
+      assert.strictEqual(
+        coldVisibleGraph.edgeCount,
+        0,
+        `Expected cold startup visible graph to have no edges. Visible graph: ${JSON.stringify(coldVisibleGraph)}`,
+      );
+
+      const rebuiltGraph = waitForExtensionMessageWhere<{
+        type: 'GRAPH_DATA_UPDATED';
+        payload: import('../../shared/graph/contracts').IGraphData;
+      }>(
+        api,
+        'GRAPH_DATA_UPDATED',
+        message => message.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS,
+      );
+      const indexReady = waitForGraphIndexStatus(api, true, CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS);
+      await api.dispatchWebviewMessage({ type: 'INDEX_GRAPH' });
+      const rebuiltGraphMessage = await rebuiltGraph;
+      await indexReady;
+
+      assert.ok(
+        fs.existsSync(repoMetaPath),
+        `Expected explicit indexing to recreate repo meta at ${repoMetaPath}`,
+      );
+      assert.ok(
+        fs.existsSync(graphCachePath),
+        `Expected explicit indexing to recreate the Graph Cache at ${graphCachePath}`,
+      );
+      assert.ok(
+        progressPhases.includes('Discovering Files'),
+        `Expected indexing to publish discovery progress. Phases: ${progressPhases.join(', ')}`,
+      );
+      assert.ok(
+        progressPhases.includes('Saving Graph Cache'),
+        `Expected indexing to publish Graph Cache persistence progress. Phases: ${progressPhases.join(', ')}`,
+      );
+      assert.ok(
+        rebuiltGraphMessage.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        `Expected explicit indexing to publish relationship edges. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+
+      const warmGraph = waitForExtensionMessageWhere<{
+        type: 'GRAPH_DATA_UPDATED';
+        payload: import('../../shared/graph/contracts').IGraphData;
+      }>(
+        api,
+        'GRAPH_DATA_UPDATED',
+        message => message.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        60_000,
+      );
+      const warmBootstrap = waitForExtensionMessage(api, 'APP_BOOTSTRAP_COMPLETE', 60_000);
+      await api.dispatchWebviewMessage({ type: 'WEBVIEW_READY', payload: null });
+      const [warmGraphMessage] = await Promise.all([warmGraph, warmBootstrap]);
+      const warmVisibleGraph = await requestVisibleGraphState(api, 60_000);
+
+      assert.ok(
+        warmGraphMessage.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
+        `Expected warm startup to publish edges from the Graph Cache. Updates: ${JSON.stringify(graphUpdates)}`,
+      );
+      assert.ok(
+        warmVisibleGraph.nodeCount > CODEGRAPHY_ROOT_RENDERED_NODE_THRESHOLD,
+        `Expected warm visible graph nodes from the Graph Cache. Visible graph: ${JSON.stringify(warmVisibleGraph)}`,
+      );
+      assert.ok(
+        warmVisibleGraph.edgeCount > CODEGRAPHY_ROOT_RENDERED_EDGE_THRESHOLD,
+        `Expected warm visible graph edges from the Graph Cache. Visible graph: ${JSON.stringify(warmVisibleGraph)}`,
+      );
+    } finally {
+      subscription.dispose();
+    }
+  });
 });
 
 function waitForExtensionMessage(
@@ -636,6 +829,7 @@ interface VisibleGraphStateResponse {
     edgeCount: number;
     edgeIds: string[];
     nodeCount: number;
+    nodes: Array<{ id: string; nodeType?: string; color: string }>;
   };
 }
 

--- a/packages/extension/src/e2e/suite/graph.test.ts
+++ b/packages/extension/src/e2e/suite/graph.test.ts
@@ -35,9 +35,9 @@ async function getAPI(): Promise<CodeGraphyAPI> {
 const scenario = getCurrentE2EScenario();
 let indexedGraphPromise: Promise<void> | undefined;
 let discoveredGraphPromise: Promise<void> | undefined;
-const CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD = 20_000;
-const CODEGRAPHY_ROOT_RENDERED_EDGE_THRESHOLD = 10_000;
-const CODEGRAPHY_ROOT_RENDERED_NODE_THRESHOLD = 5_000;
+const CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD = 1_000;
+const CODEGRAPHY_ROOT_RENDERED_EDGE_THRESHOLD = 1_000;
+const CODEGRAPHY_ROOT_RENDERED_NODE_THRESHOLD = 500;
 const CODEGRAPHY_ROOT_INDEX_TIMEOUT_MS = 600_000;
 
 function sortedStrings(values: readonly string[]): string[] {

--- a/packages/extension/src/extension/graphView/analysis/execution/publish.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/publish.ts
@@ -24,6 +24,12 @@ function resolveGraphIndexStatus(
   };
 }
 
+function shouldReportGraphViewUpdateProgress(
+  state: GraphViewAnalysisExecutionState,
+): boolean {
+  return state.mode === 'index' || state.mode === 'refresh' || state.mode === 'incremental';
+}
+
 export function publishEmptyGraph(
   handlers: GraphViewAnalysisExecutionHandlers,
   hasIndex: boolean = false,
@@ -45,6 +51,13 @@ export function publishAnalyzedGraph(
 ): void {
   const actualHasIndex = state.analyzer?.hasIndex() ?? hasIndex;
   const status = resolveGraphIndexStatus(state, actualHasIndex);
+  if (shouldReportGraphViewUpdateProgress(state)) {
+    handlers.sendIndexProgress?.({
+      phase: 'Updating Graph View',
+      current: 0,
+      total: 1,
+    });
+  }
   handlers.setRawGraphData(rawGraphData);
   handlers.sendGraphIndexStatusUpdated(actualHasIndex, status.freshness, status.detail);
   handlers.updateViewContext();

--- a/packages/extension/src/extension/graphView/analysis/execution/publish.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/publish.ts
@@ -59,7 +59,6 @@ export function publishAnalyzedGraph(
     });
   }
   handlers.setRawGraphData(rawGraphData);
-  handlers.sendGraphIndexStatusUpdated(actualHasIndex, status.freshness, status.detail);
   handlers.updateViewContext();
   handlers.applyViewTransform();
   handlers.computeMergedGroups();
@@ -75,6 +74,7 @@ export function publishAnalyzedGraph(
 
   const graphData = handlers.getGraphData();
   handlers.sendGraphDataUpdated(graphData);
+  handlers.sendGraphIndexStatusUpdated(actualHasIndex, status.freshness, status.detail);
   state.analyzer?.registry.notifyPostAnalyze(graphData);
   handlers.markWorkspaceReady(graphData);
 }

--- a/packages/extension/src/extension/graphView/webview/dispatch/pluginReady.ts
+++ b/packages/extension/src/extension/graphView/webview/dispatch/pluginReady.ts
@@ -1,11 +1,13 @@
 import type { WebviewToExtensionMessage } from '../../../../shared/protocol/webviewToExtension';
 import type { IPluginFilterPatternGroup } from '../../../../shared/protocol/extensionToWebview';
+import type { IGraphData } from '../../../../shared/graph/contracts';
 import type { DagMode, NodeSizeMode } from '../../../../shared/settings/modes';
 import { applyWebviewReady } from '../messages/ready';
 
 type GraphViewReadyMessage = Extract<WebviewToExtensionMessage, { type: 'WEBVIEW_READY' }>;
 
 export interface GraphViewPluginReadyContext {
+  getGraphData(): IGraphData;
   getFilterPatterns(): string[];
   getPluginFilterPatterns(): string[];
   getPluginFilterGroups?: () => IPluginFilterPatternGroup[];
@@ -59,6 +61,7 @@ export async function dispatchGraphViewPluginReadyMessage(
       readyNotified: context.isWebviewReadyNotified(),
     },
     {
+      getGraphData: () => context.getGraphData(),
       getFilterPatterns: () => context.getFilterPatterns(),
       getPluginFilterPatterns: () => context.getPluginFilterPatterns(),
       getPluginFilterGroups: () => context.getPluginFilterGroups?.() ?? [],

--- a/packages/extension/src/extension/graphView/webview/messages/listener.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/listener.ts
@@ -9,7 +9,7 @@ import {
   dispatchGraphViewPrimaryMessage,
   type GraphViewPrimaryMessageContext,
 } from '../dispatch/primary';
-import { replayWebviewReadySettings } from './ready';
+import { replayDuplicateWebviewReady } from './ready';
 
 export interface GraphViewMessageListenerContext
   extends GraphViewPrimaryMessageContext,
@@ -76,7 +76,7 @@ function createGraphViewWebviewMessageHandler(
 
   return async function handleGraphViewWebviewMessage(message: WebviewToExtensionMessage): Promise<void> {
     if (message.type === 'WEBVIEW_READY' && webviewReadyHandled) {
-      replayWebviewReadySettings(createReadyState(context), context);
+      await replayDuplicateWebviewReady(createReadyState(context), context);
       return;
     }
     webviewReadyHandled ||= message.type === 'WEBVIEW_READY';

--- a/packages/extension/src/extension/graphView/webview/messages/ready.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/ready.ts
@@ -1,5 +1,6 @@
 import type { DagMode, NodeSizeMode } from '../../../../shared/settings/modes';
 import type { IPluginFilterPatternGroup } from '../../../../shared/protocol/extensionToWebview';
+import type { IGraphData } from '../../../../shared/graph/contracts';
 
 export interface GraphViewReadyState {
   maxFiles: number;
@@ -14,6 +15,7 @@ export interface GraphViewReadyState {
 }
 
 export interface GraphViewReadyHandlers {
+  getGraphData(): IGraphData;
   getFilterPatterns(): string[];
   getPluginFilterPatterns(): string[];
   getPluginFilterGroups?: () => IPluginFilterPatternGroup[];
@@ -97,6 +99,9 @@ export async function applyWebviewReady(
   handlers: GraphViewReadyHandlers,
 ): Promise<boolean> {
   replayWebviewReadySettings(state, handlers);
+  handlers.sendMessage({ type: 'GRAPH_DATA_UPDATED', payload: handlers.getGraphData() });
+  handlers.sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+
   await handlers.sendCachedTimeline();
   await handlers.loadAndSendData();
   handlers.sendPluginStatuses?.();
@@ -105,8 +110,6 @@ export async function applyWebviewReady(
     await handlers.waitForFirstWorkspaceReady();
     handlers.sendGraphViewContributionStatuses?.();
   }
-
-  handlers.sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
 
   if (state.readyNotified) {
     return true;

--- a/packages/extension/src/extension/graphView/webview/messages/ready.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/ready.ts
@@ -94,22 +94,49 @@ export function replayWebviewReadySettings(
   handlers.sendActiveFile();
 }
 
+export function replayWebviewReadyBootstrap(
+  state: GraphViewReadyState,
+  handlers: GraphViewReadyHandlers,
+): void {
+  replayWebviewReadySettings(state, handlers);
+  replayWebviewReadyGraphBootstrap(handlers);
+}
+
+export function replayWebviewReadyGraphBootstrap(
+  handlers: Pick<GraphViewReadyHandlers, 'getGraphData' | 'sendMessage'>,
+): void {
+  handlers.sendMessage({ type: 'GRAPH_DATA_UPDATED', payload: handlers.getGraphData() });
+  handlers.sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+}
+
+export function shouldWaitForFirstWorkspaceGraph(state: GraphViewReadyState): boolean {
+  return state.hasWorkspace && state.firstAnalysis;
+}
+
+export async function replayDuplicateWebviewReady(
+  state: GraphViewReadyState,
+  handlers: GraphViewReadyHandlers,
+): Promise<void> {
+  replayWebviewReadySettings(state, handlers);
+
+  if (shouldWaitForFirstWorkspaceGraph(state)) {
+    return;
+  }
+
+  replayWebviewReadyGraphBootstrap(handlers);
+}
+
 export async function applyWebviewReady(
   state: GraphViewReadyState,
   handlers: GraphViewReadyHandlers,
 ): Promise<boolean> {
   replayWebviewReadySettings(state, handlers);
-  handlers.sendMessage({ type: 'GRAPH_DATA_UPDATED', payload: handlers.getGraphData() });
-  handlers.sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
 
   await handlers.sendCachedTimeline();
   await handlers.loadAndSendData();
   handlers.sendPluginStatuses?.();
 
-  if (state.hasWorkspace && state.firstAnalysis) {
-    await handlers.waitForFirstWorkspaceReady();
-    handlers.sendGraphViewContributionStatuses?.();
-  }
+  handlers.sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
 
   if (state.readyNotified) {
     return true;

--- a/packages/extension/src/extension/pipeline/database/cache/storage.ts
+++ b/packages/extension/src/extension/pipeline/database/cache/storage.ts
@@ -3,6 +3,7 @@ export {
   clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCache,
   saveWorkspaceAnalysisDatabaseCacheAsync,

--- a/packages/extension/src/extension/pipeline/service/base/state.ts
+++ b/packages/extension/src/extension/pipeline/service/base/state.ts
@@ -14,6 +14,7 @@ import { Configuration } from '../../../config/reader';
 import { EventBus } from '../../../../core/plugins/events/bus';
 import type { IWorkspaceAnalysisCache } from '../../cache';
 import {
+  loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot,
   type WorkspaceAnalysisDatabaseSnapshot,
 } from '../../database/cache/storage';
@@ -26,6 +27,7 @@ export abstract class WorkspacePipelineStateBase {
   protected readonly _context: vscode.ExtensionContext;
   protected readonly _engineState: WorkspaceIndexEngineState;
   protected _eventBus?: EventBus;
+  private _cacheHydrationPromise?: Promise<void>;
 
   constructor(context: vscode.ExtensionContext) {
     this._context = context;
@@ -104,6 +106,25 @@ export abstract class WorkspacePipelineStateBase {
     }
 
     return readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot);
+  }
+
+  protected async _hydrateCacheFromGraphCache(): Promise<void> {
+    const workspaceRoot = this._getWorkspaceRoot();
+    if (!workspaceRoot || Object.keys(this._cache.files).length > 0) {
+      return;
+    }
+
+    this._cacheHydrationPromise ??= loadWorkspaceAnalysisDatabaseCacheAsync(workspaceRoot)
+      .then((cache) => {
+        if (Object.keys(this._cache.files).length === 0) {
+          this._cache = cache;
+        }
+      })
+      .finally(() => {
+        this._cacheHydrationPromise = undefined;
+      });
+
+    await this._cacheHydrationPromise;
   }
 
   protected abstract _getWorkspaceRoot(): string | undefined;

--- a/packages/extension/src/extension/pipeline/service/cache/initialState.ts
+++ b/packages/extension/src/extension/pipeline/service/cache/initialState.ts
@@ -3,16 +3,9 @@ import {
   createEmptyWorkspaceAnalysisCache,
   type IWorkspaceAnalysisCache,
 } from '../../cache';
-import { loadWorkspaceAnalysisDatabaseCache } from '../../database/cache/storage';
-import { readWorkspacePipelineRoot } from '../../serviceAdapters';
 
 export function createWorkspacePipelineInitialCache(
-  workspaceFolders: typeof vscode.workspace.workspaceFolders,
+  _workspaceFolders: typeof vscode.workspace.workspaceFolders,
 ): IWorkspaceAnalysisCache {
-  const workspaceRoot = readWorkspacePipelineRoot(workspaceFolders);
-  const repoCache = workspaceRoot
-    ? loadWorkspaceAnalysisDatabaseCache(workspaceRoot)
-    : undefined;
-
-  return repoCache ?? createEmptyWorkspaceAnalysisCache();
+  return createEmptyWorkspaceAnalysisCache();
 }

--- a/packages/extension/src/extension/pipeline/service/cache/storage.ts
+++ b/packages/extension/src/extension/pipeline/service/cache/storage.ts
@@ -1,6 +1,6 @@
 import type { IWorkspaceAnalysisCache } from '../../cache';
 import { clearWorkspacePipelineCache } from '../../analysis/state';
-import { saveWorkspaceAnalysisDatabaseCache } from '../../database/cache/storage';
+import { saveWorkspaceAnalysisDatabaseCacheAsync } from '../../database/cache/storage';
 
 export function clearWorkspacePipelineStoredCache(
   workspaceRoot: string | undefined,
@@ -18,9 +18,8 @@ export function persistWorkspacePipelineCache(
     return;
   }
 
-  try {
-    saveWorkspaceAnalysisDatabaseCache(workspaceRoot, cache);
-  } catch (error) {
-    warn('[CodeGraphy] Failed to persist repo-local analysis cache.', error);
-  }
+  void saveWorkspaceAnalysisDatabaseCacheAsync(workspaceRoot, cache)
+    .catch((error: unknown) => {
+      warn('[CodeGraphy] Failed to persist repo-local analysis cache.', error);
+    });
 }

--- a/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
@@ -174,7 +174,7 @@ export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipeline
     return this._buildGraphData(
       fileConnections,
       workspaceRoot,
-      config.showOrphans,
+      true,
       disabledPlugins,
     );
   }

--- a/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
+++ b/packages/extension/src/extension/pipeline/service/discoveryFacade.ts
@@ -205,6 +205,8 @@ export abstract class WorkspacePipelineDiscoveryFacade extends WorkspacePipeline
     signal?: AbortSignal,
   ): Promise<IGraphData> {
     throwIfWorkspaceAnalysisAborted(signal);
+    await this._hydrateCacheFromGraphCache();
+    throwIfWorkspaceAnalysisAborted(signal);
 
     const workspaceRoot = this._getWorkspaceRoot();
     if (!workspaceRoot) {

--- a/packages/extension/src/shared/protocol/webviewToExtension.ts
+++ b/packages/extension/src/shared/protocol/webviewToExtension.ts
@@ -100,6 +100,7 @@ export type WebviewToExtensionMessage =
       type: 'VISIBLE_GRAPH_STATE_RESPONSE';
       payload: {
         nodeCount: number;
+        nodes: Array<{ id: string; nodeType?: string; color: string }>;
         edgeCount: number;
         edgeIds: string[];
       };

--- a/packages/extension/src/webview/app/graph/stats.tsx
+++ b/packages/extension/src/webview/app/graph/stats.tsx
@@ -10,13 +10,8 @@ export function formatGraphStat(count: number, singular: string, plural: string)
 export function buildGraphStatsLabel(
   nodeCount: number,
   edgeCount: number,
-  options: { hasIndex?: boolean } = {},
 ): string {
   const nodeLabel = formatGraphStat(nodeCount, 'node', 'nodes');
-  if (options.hasIndex === false && edgeCount === 0) {
-    return `${nodeLabel} • connections not indexed`;
-  }
-
   return `${nodeLabel} • ${formatGraphStat(edgeCount, 'connection', 'connections')}`;
 }
 

--- a/packages/extension/src/webview/app/graph/stats.tsx
+++ b/packages/extension/src/webview/app/graph/stats.tsx
@@ -12,12 +12,12 @@ export function buildGraphStatsLabel(
   edgeCount: number,
   options: { hasIndex?: boolean } = {},
 ): string {
-  const nodeLabel = formatGraphStat(nodeCount, 'visible node', 'visible nodes');
+  const nodeLabel = formatGraphStat(nodeCount, 'node', 'nodes');
   if (options.hasIndex === false && edgeCount === 0) {
-    return `${nodeLabel} • relationships not indexed`;
+    return `${nodeLabel} • connections not indexed`;
   }
 
-  return `${nodeLabel} • ${formatGraphStat(edgeCount, 'rendered edge', 'rendered edges')}`;
+  return `${nodeLabel} • ${formatGraphStat(edgeCount, 'connection', 'connections')}`;
 }
 
 export function GraphStatsBadge({ label }: { label: string }): React.ReactElement {

--- a/packages/extension/src/webview/app/graph/stats.tsx
+++ b/packages/extension/src/webview/app/graph/stats.tsx
@@ -7,8 +7,17 @@ export function formatGraphStat(count: number, singular: string, plural: string)
   return `${COUNT_FORMATTER.format(count)} ${label}`;
 }
 
-export function buildGraphStatsLabel(nodeCount: number, edgeCount: number): string {
-  return `${formatGraphStat(nodeCount, 'node', 'nodes')} • ${formatGraphStat(edgeCount, 'edge', 'edges')}`;
+export function buildGraphStatsLabel(
+  nodeCount: number,
+  edgeCount: number,
+  options: { hasIndex?: boolean } = {},
+): string {
+  const nodeLabel = formatGraphStat(nodeCount, 'visible node', 'visible nodes');
+  if (options.hasIndex === false && edgeCount === 0) {
+    return `${nodeLabel} • relationships not indexed`;
+  }
+
+  return `${nodeLabel} • ${formatGraphStat(edgeCount, 'rendered edge', 'rendered edges')}`;
 }
 
 export function GraphStatsBadge({ label }: { label: string }): React.ReactElement {

--- a/packages/extension/src/webview/app/shell/storeSelectors.ts
+++ b/packages/extension/src/webview/app/shell/storeSelectors.ts
@@ -8,6 +8,7 @@ import { useGraphStore } from '../../store/state';
 export function useAppState() {
   const graphData = useGraphStore(s => s.graphData);
   const isLoading = useGraphStore(s => s.isLoading);
+  const graphHasIndex = useGraphStore(s => s.graphHasIndex);
   const graphIsIndexing = useGraphStore(s => s.graphIsIndexing);
   const graphIndexProgress = useGraphStore(s => s.graphIndexProgress);
   const searchQuery = useGraphStore(s => s.searchQuery);
@@ -32,6 +33,7 @@ export function useAppState() {
   return {
     graphData,
     isLoading,
+    graphHasIndex,
     graphIsIndexing,
     graphIndexProgress,
     searchQuery,

--- a/packages/extension/src/webview/app/shell/view.tsx
+++ b/packages/extension/src/webview/app/shell/view.tsx
@@ -182,7 +182,7 @@ export default function App(): React.ReactElement {
           onAddFilterRequested={openFilterPopoverWithPatterns}
           onAddLegendRequested={openLegendPrompt}
         />
-        <GraphStatsBadge label={graphStatsLabel} />
+        {!graphIsIndexing && <GraphStatsBadge label={graphStatsLabel} />}
         <ToolbarRail pluginHost={pluginHost} />
         <PanelStack
           activePanel={activePanel}

--- a/packages/extension/src/webview/app/shell/view.tsx
+++ b/packages/extension/src/webview/app/shell/view.tsx
@@ -132,7 +132,6 @@ export default function App(): React.ReactElement {
   const graphStatsLabel = buildGraphStatsLabel(
     loadedDisplayGraphData.nodes.length,
     loadedDisplayGraphData.edges.length,
-    { hasIndex: graphHasIndex },
   );
   const closeActivePanel = () => setActivePanel('none');
   const { countState, countTotal, excludedCount } = getShellGraphCountState({

--- a/packages/extension/src/webview/app/shell/view.tsx
+++ b/packages/extension/src/webview/app/shell/view.tsx
@@ -185,7 +185,7 @@ export default function App(): React.ReactElement {
           onAddFilterRequested={openFilterPopoverWithPatterns}
           onAddLegendRequested={openLegendPrompt}
         />
-        {!graphIsIndexing && <GraphStatsBadge label={graphStatsLabel} />}
+        <GraphStatsBadge label={graphStatsLabel} />
         <ToolbarRail pluginHost={pluginHost} />
         <PanelStack
           activePanel={activePanel}

--- a/packages/extension/src/webview/app/shell/view.tsx
+++ b/packages/extension/src/webview/app/shell/view.tsx
@@ -26,6 +26,7 @@ export default function App(): React.ReactElement {
   const {
     graphData,
     isLoading,
+    graphHasIndex,
     searchQuery,
     searchOptions,
     legends,
@@ -73,6 +74,7 @@ export default function App(): React.ReactElement {
     disabledPluginFilterPatterns,
     legends,
   );
+  const effectiveShowOrphans = graphHasIndex ? showOrphans : true;
   const { countBaseData, filterVisibleData } = useShellVisibleGraphs({
     activeFilterPatterns,
     edgeVisibility,
@@ -80,7 +82,7 @@ export default function App(): React.ReactElement {
     graphEdgeTypes,
     nodeVisibility,
     searchOptions,
-    showOrphans,
+    showOrphans: effectiveShowOrphans,
   });
   const {
     filteredData,
@@ -98,7 +100,7 @@ export default function App(): React.ReactElement {
     graphEdgeTypes,
     edgeDecorations,
     activeFilterPatterns,
-    showOrphans,
+    effectiveShowOrphans,
   );
 
   const {
@@ -130,6 +132,7 @@ export default function App(): React.ReactElement {
   const graphStatsLabel = buildGraphStatsLabel(
     loadedDisplayGraphData.nodes.length,
     loadedDisplayGraphData.edges.length,
+    { hasIndex: graphHasIndex },
   );
   const closeActivePanel = () => setActivePanel('none');
   const { countState, countTotal, excludedCount } = getShellGraphCountState({
@@ -172,7 +175,7 @@ export default function App(): React.ReactElement {
         <GraphSurface
           graphData={graphData}
           coloredData={coloredData}
-          showOrphans={showOrphans}
+          showOrphans={effectiveShowOrphans}
           depthMode={depthMode}
           timelineActive={timelineActive}
           theme={theme}

--- a/packages/extension/src/webview/app/shell/visibleGraphResponse.ts
+++ b/packages/extension/src/webview/app/shell/visibleGraphResponse.ts
@@ -5,6 +5,11 @@ import { postMessage as postWebviewMessage } from '../../vscodeApi';
 export function createVisibleGraphStatePayload(graphData: IGraphData | null | undefined) {
   return {
     nodeCount: graphData?.nodes.length ?? 0,
+    nodes: graphData?.nodes.map(node => ({
+      id: node.id,
+      nodeType: node.nodeType,
+      color: node.color,
+    })) ?? [],
     edgeCount: graphData?.edges.length ?? 0,
     edgeIds: graphData?.edges.map(edge => edge.id) ?? [],
   };

--- a/packages/extension/src/webview/store/actions/bootstrap.ts
+++ b/packages/extension/src/webview/store/actions/bootstrap.ts
@@ -3,13 +3,12 @@ import type { SetState } from './types';
 
 type InitialLoadingState = Pick<
   GraphState,
-  'bootstrapComplete' | 'graphData' | 'pendingPluginAssetLoads'
+  'bootstrapComplete' | 'graphData'
 >;
 
 function canFinishInitialLoading(state: InitialLoadingState): boolean {
   return state.bootstrapComplete
-    && state.graphData !== null
-    && state.pendingPluginAssetLoads === 0;
+    && state.graphData !== null;
 }
 
 export function createBootstrapActions(set: SetState) {

--- a/packages/extension/src/webview/store/messageHandlers/graph.ts
+++ b/packages/extension/src/webview/store/messageHandlers/graph.ts
@@ -13,12 +13,11 @@ export function handleGraphDataUpdated(
   const state = ctx?.getState();
   const waitingForInitialBootstrap = Boolean(
     state?.awaitingInitialBootstrap
-    && (!state.bootstrapComplete || state.pendingPluginAssetLoads > 0),
+    && !state.bootstrapComplete,
   );
   const initialBootstrapFinished = Boolean(
     state?.awaitingInitialBootstrap
     && state.bootstrapComplete
-    && state.pendingPluginAssetLoads === 0,
   );
 
   return {
@@ -35,7 +34,7 @@ export function handleAppBootstrapComplete(
   ctx: Pick<IHandlerContext, 'getState'>,
 ): PartialState {
   const state = ctx.getState();
-  const graphReady = state.graphData !== null && state.pendingPluginAssetLoads === 0;
+  const graphReady = state.graphData !== null;
 
   return {
     bootstrapComplete: true,

--- a/packages/extension/src/webview/store/messageHandlers/graph.ts
+++ b/packages/extension/src/webview/store/messageHandlers/graph.ts
@@ -46,10 +46,16 @@ export function handleAppBootstrapComplete(
 export function handleGraphIndexStatusUpdated(
   message: Extract<ExtensionToWebviewMessage, { type: 'GRAPH_INDEX_STATUS_UPDATED' }>,
 ): PartialState {
+  const indexIsReady = message.payload.hasIndex && message.payload.freshness === 'fresh';
+
   return {
     graphHasIndex: message.payload.hasIndex,
     graphIndexFreshness: message.payload.freshness,
     graphIndexDetail: message.payload.detail,
+    ...(indexIsReady ? {
+      graphIsIndexing: false,
+      graphIndexProgress: null,
+    } : {}),
   };
 }
 

--- a/packages/extension/tests/extension/graphView/analysis/execution/publish.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/publish.test.ts
@@ -77,6 +77,39 @@ describe('graph view analysis execution publish', () => {
     expect(handlers.markWorkspaceReady).toHaveBeenCalledWith(getGraphData());
   });
 
+  it('reports graph view update progress before publishing an explicit index result', () => {
+    const rawGraphData: IGraphData = {
+      nodes: [{ id: 'src/index.ts', label: 'src/index.ts', color: '#ffffff' }],
+      edges: [],
+    };
+    const transformedGraphData: IGraphData = {
+      nodes: [{ id: 'src/index.ts', label: 'src/index.ts', color: '#ffffff' }],
+      edges: [],
+    };
+    const state = createExecutionState({
+      mode: 'index',
+      analyzer: createExecutionAnalyzer(),
+    });
+    const { handlers } = createExecutionHandlers({
+      applyViewTransform: vi.fn(() => {
+        handlers.setGraphData(transformedGraphData);
+      }),
+    });
+    const sendIndexProgress = vi.mocked(handlers.sendIndexProgress!);
+    const sendGraphDataUpdated = vi.mocked(handlers.sendGraphDataUpdated);
+
+    publishAnalyzedGraph(state, handlers, rawGraphData, true);
+
+    expect(sendIndexProgress).toHaveBeenCalledWith({
+      phase: 'Updating Graph View',
+      current: 0,
+      total: 1,
+    });
+    expect(sendIndexProgress.mock.invocationCallOrder[0]).toBeLessThan(
+      sendGraphDataUpdated.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it('publishes the actual missing index state when indexing does not create a Graph Cache', () => {
     const rawGraphData: IGraphData = {
       nodes: [{ id: 'src/index.ts', label: 'src/index.ts', color: '#ffffff' }],

--- a/packages/extension/tests/extension/graphView/analysis/execution/publish.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/publish.test.ts
@@ -97,6 +97,7 @@ describe('graph view analysis execution publish', () => {
     });
     const sendIndexProgress = vi.mocked(handlers.sendIndexProgress!);
     const sendGraphDataUpdated = vi.mocked(handlers.sendGraphDataUpdated);
+    const sendGraphIndexStatusUpdated = vi.mocked(handlers.sendGraphIndexStatusUpdated);
 
     publishAnalyzedGraph(state, handlers, rawGraphData, true);
 
@@ -106,6 +107,9 @@ describe('graph view analysis execution publish', () => {
       total: 1,
     });
     expect(sendIndexProgress.mock.invocationCallOrder[0]).toBeLessThan(
+      sendGraphDataUpdated.mock.invocationCallOrder[0]!,
+    );
+    expect(sendGraphIndexStatusUpdated.mock.invocationCallOrder[0]).toBeGreaterThan(
       sendGraphDataUpdated.mock.invocationCallOrder[0]!,
     );
   });

--- a/packages/extension/tests/extension/graphView/webview/dispatch/pluginReady.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/pluginReady.test.ts
@@ -86,7 +86,7 @@ describe('dispatchGraphViewPluginReadyMessage', () => {
     });
   });
 
-  it('waits for first workspace readiness and skips duplicate notification', async () => {
+  it('skips duplicate notification without blocking on first workspace readiness', async () => {
     const context = createContext({
       hasWorkspace: vi.fn(() => true),
       isFirstAnalysis: vi.fn(() => true),
@@ -97,7 +97,7 @@ describe('dispatchGraphViewPluginReadyMessage', () => {
       dispatchGraphViewPluginReadyMessage({ type: 'WEBVIEW_READY', payload: null }, context),
     ).resolves.toBe(true);
 
-    expect(context.waitForFirstWorkspaceReady).toHaveBeenCalledOnce();
+    expect(context.waitForFirstWorkspaceReady).not.toHaveBeenCalled();
     expect(context.notifyWebviewReady).not.toHaveBeenCalled();
   });
 

--- a/packages/extension/tests/extension/graphView/webview/dispatch/pluginReady.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/pluginReady.test.ts
@@ -9,6 +9,7 @@ function createContext(
   overrides: Partial<GraphViewPluginReadyContext> = {},
 ): GraphViewPluginReadyContext {
   return {
+    getGraphData: vi.fn(() => ({ nodes: [], edges: [] })),
     getFilterPatterns: vi.fn(() => ['src/**']),
     getPluginFilterPatterns: vi.fn(() => ['plugin:test/**']),
     getConfig: vi.fn(<T>(_: string, defaultValue: T): T => defaultValue),

--- a/packages/extension/tests/extension/graphView/webview/messages/listener.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/messages/listener.test.ts
@@ -201,7 +201,7 @@ describe('graph view webview message listener', () => {
     expect(context.setWebviewReadyNotified).toHaveBeenCalledWith(true);
   });
 
-  it('replays settings but avoids a second graph load for duplicate WEBVIEW_READY messages', async () => {
+  it('replays settings but not empty bootstrap payloads for duplicate WEBVIEW_READY during first analysis', async () => {
     let messageHandler: ((message: unknown) => Promise<void>) | undefined;
     const webview = {
       onDidReceiveMessage: vi.fn((handler: (message: unknown) => Promise<void>) => {
@@ -211,6 +211,8 @@ describe('graph view webview message listener', () => {
     };
     let readyNotified = false;
     const context = createContext({
+      hasWorkspace: vi.fn(() => true),
+      isFirstAnalysis: vi.fn(() => true),
       isWebviewReadyNotified: vi.fn(() => readyNotified),
       setWebviewReadyNotified: vi.fn((nextValue: boolean) => {
         readyNotified = nextValue;
@@ -218,10 +220,35 @@ describe('graph view webview message listener', () => {
     });
 
     setGraphViewWebviewMessageListener(webview as never, context);
-    await messageHandler?.({ type: 'WEBVIEW_READY' });
-    await messageHandler?.({ type: 'WEBVIEW_READY' });
+    const firstReady = messageHandler?.({ type: 'WEBVIEW_READY' });
+    await Promise.resolve();
+    const duplicateReady = messageHandler?.({ type: 'WEBVIEW_READY' });
+
+    await Promise.resolve();
+
+    expect(
+      vi.mocked(context.sendMessage).mock.calls.filter(([message]) =>
+        (message as { type?: string }).type === 'GRAPH_DATA_UPDATED'
+      ),
+    ).toHaveLength(0);
+    expect(
+      vi.mocked(context.sendMessage).mock.calls.filter(([message]) =>
+        (message as { type?: string }).type === 'APP_BOOTSTRAP_COMPLETE'
+      ),
+    ).toHaveLength(0);
+
+    await firstReady;
+    await duplicateReady;
 
     expect(context.loadAndSendData).toHaveBeenCalledTimes(1);
+    expect(context.sendMessage).toHaveBeenCalledWith({
+      type: 'APP_BOOTSTRAP_COMPLETE',
+    });
+    expect(
+      vi.mocked(context.sendMessage).mock.calls.filter(([message]) =>
+        (message as { type?: string }).type === 'GRAPH_DATA_UPDATED'
+      ),
+    ).toHaveLength(0);
     expect(context.loadGroupsAndFilterPatterns).toHaveBeenCalledTimes(2);
     expect(context.loadDisabledRulesAndPlugins).toHaveBeenCalledTimes(2);
     expect(context.sendSettings).toHaveBeenCalledTimes(2);

--- a/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
@@ -3,6 +3,10 @@ import { applyWebviewReady } from '../../../../../src/extension/graphView/webvie
 
 function createHandlers() {
   return {
+    getGraphData: vi.fn(() => ({
+      nodes: [{ id: 'cached.ts', label: 'cached.ts', color: '#ffffff' }],
+      edges: [],
+    })),
     getFilterPatterns: vi.fn(() => ['dist/**']),
     getPluginFilterPatterns: vi.fn(() => ['venv/**']),
     getConfig: vi.fn(<T>(_key: string, defaultValue: T): T => defaultValue),
@@ -126,12 +130,15 @@ describe('graph view ready message', () => {
     expect(callOrder.indexOf('plugin-injections')).toBeLessThan(callOrder.indexOf('analyze'));
   });
 
-  it('announces bootstrap completion after the initial graph load settles', async () => {
+  it('publishes the current graph and completes app bootstrap before slow graph loading settles', async () => {
     const events: string[] = [];
     const handlers = createHandlers();
+    let finishGraphLoad: (() => void) | undefined;
     handlers.loadAndSendData.mockImplementation(async () => {
       events.push('graph:start');
-      await Promise.resolve();
+      await new Promise<void>(resolve => {
+        finishGraphLoad = resolve;
+      });
       events.push('graph:end');
     });
     handlers.sendPluginStatuses.mockImplementation(() => {
@@ -141,9 +148,12 @@ describe('graph view ready message', () => {
       if (message.type === 'APP_BOOTSTRAP_COMPLETE') {
         events.push('bootstrap');
       }
+      if (message.type === 'GRAPH_DATA_UPDATED') {
+        events.push('graph:snapshot');
+      }
     });
 
-    await applyWebviewReady(
+    const ready = applyWebviewReady(
       {
         maxFiles: 500,
         playbackSpeed: 1,
@@ -157,7 +167,14 @@ describe('graph view ready message', () => {
       handlers
     );
 
-    expect(events).toEqual(['graph:start', 'graph:end', 'plugins', 'bootstrap']);
+    await Promise.resolve();
+
+    expect(events).toEqual(['graph:snapshot', 'bootstrap', 'graph:start']);
+
+    finishGraphLoad?.();
+    await ready;
+
+    expect(events).toEqual(['graph:snapshot', 'bootstrap', 'graph:start', 'graph:end', 'plugins']);
   });
 
   it('waits for workspace readiness during the first workspace-backed analysis', async () => {

--- a/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
@@ -130,7 +130,7 @@ describe('graph view ready message', () => {
     expect(callOrder.indexOf('plugin-injections')).toBeLessThan(callOrder.indexOf('analyze'));
   });
 
-  it('publishes the current graph and completes app bootstrap before slow graph loading settles', async () => {
+  it('keeps bootstrap pending until slow graph loading settles', async () => {
     const events: string[] = [];
     const handlers = createHandlers();
     let finishGraphLoad: (() => void) | undefined;
@@ -169,16 +169,25 @@ describe('graph view ready message', () => {
 
     await Promise.resolve();
 
-    expect(events).toEqual(['graph:snapshot', 'bootstrap', 'graph:start']);
+    expect(events).toEqual(['graph:start']);
 
     finishGraphLoad?.();
     await ready;
 
-    expect(events).toEqual(['graph:snapshot', 'bootstrap', 'graph:start', 'graph:end', 'plugins']);
+    expect(events).toEqual(['graph:start', 'graph:end', 'plugins', 'bootstrap']);
   });
 
-  it('waits for workspace readiness during the first workspace-backed analysis', async () => {
+  it('does not block bootstrap on first workspace-ready plugin notifications', async () => {
+    const events: string[] = [];
     const handlers = createHandlers();
+    handlers.sendGraphViewContributionStatuses.mockImplementation(() => {
+      events.push('contributions');
+    });
+    handlers.sendMessage.mockImplementation((message: { type: string }) => {
+      if (message.type === 'APP_BOOTSTRAP_COMPLETE') {
+        events.push('bootstrap');
+      }
+    });
 
     await applyWebviewReady(
       {
@@ -194,7 +203,8 @@ describe('graph view ready message', () => {
       handlers
     );
 
-    expect(handlers.waitForFirstWorkspaceReady).toHaveBeenCalledOnce();
+    expect(handlers.waitForFirstWorkspaceReady).not.toHaveBeenCalled();
+    expect(events).toEqual(['contributions', 'bootstrap']);
   });
 
   it('skips workspace readiness waiting outside the initial workspace pass', async () => {

--- a/packages/extension/tests/extension/pipeline/analysis.test.ts
+++ b/packages/extension/tests/extension/pipeline/analysis.test.ts
@@ -258,6 +258,39 @@ describe('WorkspacePipeline analysis', () => {
     expect(readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot).relations.length).toBeGreaterThan(0);
   });
 
+  it('replays warm Graph Cache nodes and edges after a cold index', async () => {
+    const workspaceRoot = await createWorkspace({
+      'src/utils.ts': 'export const value = 1;\n',
+      'src/index.ts': "import { value } from './utils';\nconsole.log(value);\n",
+    });
+    workspaceFoldersValue = [
+      { uri: vscode.Uri.file(workspaceRoot), name: 'workspace', index: 0 },
+    ];
+    const coldAnalyzer = new WorkspacePipeline(
+      createContext() as unknown as vscode.ExtensionContext
+    );
+
+    await coldAnalyzer.initialize();
+
+    const coldGraph = await coldAnalyzer.analyze();
+    expect(coldGraph.edges.map(edge => edge.id)).toContain('src/index.ts->src/utils.ts#import');
+
+    const warmAnalyzer = new WorkspacePipeline(
+      createContext() as unknown as vscode.ExtensionContext
+    );
+    await warmAnalyzer.initialize();
+
+    const warmGraph = await warmAnalyzer.loadCachedGraph();
+
+    expect(warmGraph.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'src/index.ts', color: expect.stringMatching(/^#[0-9a-f]{6}$/i) }),
+        expect.objectContaining({ id: 'src/utils.ts', color: expect.stringMatching(/^#[0-9a-f]{6}$/i) }),
+      ]),
+    );
+    expect(warmGraph.edges.map(edge => edge.id)).toContain('src/index.ts->src/utils.ts#import');
+  });
+
   it('returns an empty graph when no workspace folder is open', async () => {
     workspaceFoldersValue = undefined;
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/packages/extension/tests/extension/pipeline/lifecycle.test.ts
+++ b/packages/extension/tests/extension/pipeline/lifecycle.test.ts
@@ -617,7 +617,7 @@ describe('WorkspacePipeline lifecycle', { timeout: 30000 }, () => {
     });
   });
 
-  it('invalidates selected workspace files from the cache and persists the updated cache', () => {
+  it('invalidates selected workspace files from the cache and persists the updated cache', async () => {
     const workspaceRoot = createWorkspaceRoot();
     workspaceFoldersValue = [
       { uri: vscode.Uri.file(workspaceRoot), name: 'workspace', index: 0 },
@@ -677,10 +677,12 @@ describe('WorkspacePipeline lifecycle', { timeout: 30000 }, () => {
     expect(analyzerPrivate._lastFileAnalysis.has('src/remove.ts')).toBe(false);
     expect(analyzerPrivate._lastFileConnections.has('src/remove.ts')).toBe(false);
     expect(context.workspaceState.update).not.toHaveBeenCalled();
-    expect(loadWorkspaceAnalysisDatabaseCache(workspaceRoot).files['src/keep.ts']).toEqual({
-      mtime: 10,
-      size: 0,
-      analysis: { filePath: '/workspace/src/keep.ts', relations: [] },
+    await vi.waitFor(() => {
+      expect(loadWorkspaceAnalysisDatabaseCache(workspaceRoot).files['src/keep.ts']).toEqual({
+        mtime: 10,
+        size: 0,
+        analysis: { filePath: '/workspace/src/keep.ts', relations: [] },
+      });
     });
   });
 });

--- a/packages/extension/tests/extension/pipeline/lifecycle.test.ts
+++ b/packages/extension/tests/extension/pipeline/lifecycle.test.ts
@@ -266,7 +266,7 @@ describe('WorkspacePipeline lifecycle', { timeout: 30000 }, () => {
     })._getWorkspaceRoot()).toBeUndefined();
   });
 
-  it('loads the repo-local persisted cache when .codegraphy/graph.lbug already exists', () => {
+  it('defers repo-local Graph Cache hydration until cached graph replay', async () => {
     const workspaceRoot = createWorkspaceRoot();
     workspaceFoldersValue = [
       { uri: vscode.Uri.file(workspaceRoot), name: 'workspace', index: 0 },
@@ -293,6 +293,18 @@ describe('WorkspacePipeline lifecycle', { timeout: 30000 }, () => {
         update: vi.fn(() => Promise.resolve()),
       },
     } as unknown as vscode.ExtensionContext);
+
+    expect((analyzer as unknown as {
+      _cache: {
+        version: string;
+        files: Record<string, unknown>;
+      };
+    })._cache).toEqual({
+      version: WORKSPACE_ANALYSIS_CACHE_VERSION,
+      files: {},
+    });
+
+    await analyzer.loadCachedGraph();
 
     expect((analyzer as unknown as {
       _cache: {

--- a/packages/extension/tests/extension/pipeline/service/cache/storage.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/cache/storage.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearWorkspacePipelineCache } from '../../../../../src/extension/pipeline/analysis/state';
-import { saveWorkspaceAnalysisDatabaseCache } from '../../../../../src/extension/pipeline/database/cache/storage.ts';
+import { saveWorkspaceAnalysisDatabaseCacheAsync } from '../../../../../src/extension/pipeline/database/cache/storage.ts';
 import {
   clearWorkspacePipelineStoredCache,
   persistWorkspacePipelineCache,
@@ -11,7 +11,7 @@ vi.mock('../../../../../src/extension/pipeline/analysis/state', () => ({
 }));
 
 vi.mock('../../../../../src/extension/pipeline/database/cache/storage.ts', () => ({
-  saveWorkspaceAnalysisDatabaseCache: vi.fn(),
+  saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
 }));
 
 describe('pipeline/service/cache/storage', () => {
@@ -33,7 +33,7 @@ describe('pipeline/service/cache/storage', () => {
 
     persistWorkspacePipelineCache(undefined, { files: {} } as never, warn);
 
-    expect(saveWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
+    expect(saveWorkspaceAnalysisDatabaseCacheAsync).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
   });
 
@@ -43,23 +43,23 @@ describe('pipeline/service/cache/storage', () => {
 
     persistWorkspacePipelineCache('/workspace', cache as never, warn);
 
-    expect(saveWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith('/workspace', cache);
+    expect(saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalledWith('/workspace', cache);
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it('warns when saving the repo-local cache throws', () => {
+  it('warns when saving the repo-local cache rejects', async () => {
     const cache = { files: {} };
     const warn = vi.fn();
     const error = new Error('save failed');
-    vi.mocked(saveWorkspaceAnalysisDatabaseCache).mockImplementation(() => {
-      throw error;
-    });
+    vi.mocked(saveWorkspaceAnalysisDatabaseCacheAsync).mockRejectedValue(error);
 
     persistWorkspacePipelineCache('/workspace', cache as never, warn);
 
-    expect(warn).toHaveBeenCalledWith(
-      '[CodeGraphy] Failed to persist repo-local analysis cache.',
-      error,
-    );
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        '[CodeGraphy] Failed to persist repo-local analysis cache.',
+        error,
+      );
+    });
   });
 });

--- a/packages/extension/tests/extension/pipeline/service/cache/storage.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/cache/storage.test.ts
@@ -47,6 +47,24 @@ describe('pipeline/service/cache/storage', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it('returns before repo-local cache persistence settles', async () => {
+    const cache = { files: { 'src/a.ts': {} } };
+    const warn = vi.fn();
+    let resolveSave!: () => void;
+    const savePromise = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+    vi.mocked(saveWorkspaceAnalysisDatabaseCacheAsync).mockReturnValue(savePromise);
+
+    persistWorkspacePipelineCache('/workspace', cache as never, warn);
+
+    expect(saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalledWith('/workspace', cache);
+    expect(warn).not.toHaveBeenCalled();
+
+    resolveSave();
+    await savePromise;
+  });
+
   it('warns when saving the repo-local cache rejects', async () => {
     const cache = { files: {} };
     const warn = vi.fn();

--- a/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
+++ b/packages/extension/tests/extension/pipeline/service/discoveryFacade.test.ts
@@ -259,6 +259,46 @@ describe('pipeline/service/discoveryFacade', () => {
     );
   });
 
+  it('keeps cold-cache discovered file nodes visible when Show Orphans is disabled', async () => {
+    const facade = new TestDiscoveryFacade();
+    vi.mocked(facade._config.getAll).mockReturnValue({
+      showOrphans: false,
+      respectGitignore: true,
+    } as never);
+    const buildGraphData = vi
+      .spyOn(
+        facade as unknown as {
+          _buildGraphData: (...args: unknown[]) => unknown;
+        },
+        '_buildGraphData',
+      )
+      .mockReturnValue({
+        nodes: [
+          { id: 'src/a.ts', label: 'a.ts', color: '#333333' },
+          { id: 'src/b.ts', label: 'b.ts', color: '#333333' },
+        ],
+        edges: [],
+      });
+
+    await expect(facade.discoverGraph()).resolves.toEqual({
+      nodes: [
+        { id: 'src/a.ts', label: 'a.ts', color: '#333333' },
+        { id: 'src/b.ts', label: 'b.ts', color: '#333333' },
+      ],
+      edges: [],
+    });
+
+    expect(buildGraphData).toHaveBeenCalledWith(
+      new Map([
+        ['src/a.ts', []],
+        ['src/b.ts', []],
+      ]),
+      '/workspace',
+      true,
+      new Set<string>(),
+    );
+  });
+
   it('delegates analyze, rebuildGraph, and refreshIndex through the shared runners', async () => {
     const facade = new TestDiscoveryFacade();
     const disabledPlugins = new Set(['plugin.disabled']);

--- a/packages/extension/tests/extension/pluginIntegration/installed/activation.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/installed/activation.test.ts
@@ -15,6 +15,7 @@ const mockState = vi.hoisted(() => ({
     clearWorkspaceAnalysisDatabaseCache: vi.fn(),
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
+    loadWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
     saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
   },
@@ -43,6 +44,7 @@ vi.mock('../../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   clearWorkspaceAnalysisDatabaseCache: mockState.databaseCache.clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
 }));
@@ -101,6 +103,10 @@ describe('extension/pluginIntegration/installedPluginActivation', () => {
       files: {},
       version: '2.0.0',
     });
+    mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync.mockResolvedValue({
+      files: {},
+      version: '2.0.0',
+    });
     mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot.mockReturnValue({
       files: [],
       symbols: [],
@@ -152,9 +158,7 @@ describe('extension/pluginIntegration/installedPluginActivation', () => {
     expect(pluginIds).toEqual(
       expect.arrayContaining(['codegraphy.markdown', installedPackage!.pluginId]),
     );
-    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
-      workspaceFixture!.workspacePath,
-    );
+    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
     expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 });

--- a/packages/extension/tests/extension/pluginIntegration/installed/statuses.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/installed/statuses.test.ts
@@ -15,6 +15,7 @@ const mockState = vi.hoisted(() => ({
     clearWorkspaceAnalysisDatabaseCache: vi.fn(),
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
+    loadWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
     saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
   },
@@ -43,6 +44,7 @@ vi.mock('../../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   clearWorkspaceAnalysisDatabaseCache: mockState.databaseCache.clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
 }));
@@ -209,6 +211,10 @@ describe('extension/pluginIntegration/installedPluginStatuses', () => {
       files: {},
       version: '2.0.0',
     });
+    mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync.mockResolvedValue({
+      files: {},
+      version: '2.0.0',
+    });
     mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot.mockReturnValue({
       files: [],
       symbols: [],
@@ -261,9 +267,7 @@ describe('extension/pluginIntegration/installedPluginStatuses', () => {
       ]),
     );
     await internals._analysisMethods._analyzeAndSendData();
-    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
-      workspaceFixture!.workspacePath,
-    );
+    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
     expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 

--- a/packages/extension/tests/extension/pluginIntegration/typescript.test.ts
+++ b/packages/extension/tests/extension/pluginIntegration/typescript.test.ts
@@ -17,6 +17,7 @@ const mockState = vi.hoisted(() => ({
     clearWorkspaceAnalysisDatabaseCache: vi.fn(),
     getWorkspaceAnalysisDatabasePath: vi.fn((workspaceRoot: string) => `${workspaceRoot}/.codegraphy/graph.lbug`),
     loadWorkspaceAnalysisDatabaseCache: vi.fn(() => ({ files: {}, version: '2.0.0' })),
+    loadWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => ({ files: {}, version: '2.0.0' })),
     readWorkspaceAnalysisDatabaseSnapshot: vi.fn(() => ({ files: [], symbols: [], relations: [] })),
     saveWorkspaceAnalysisDatabaseCache: vi.fn(),
     saveWorkspaceAnalysisDatabaseCacheAsync: vi.fn(async () => undefined),
@@ -42,6 +43,7 @@ vi.mock('../../../src/extension/pipeline/database/cache/storage.ts', () => ({
   clearWorkspaceAnalysisDatabaseCache: mockState.databaseCache.clearWorkspaceAnalysisDatabaseCache,
   getWorkspaceAnalysisDatabasePath: mockState.databaseCache.getWorkspaceAnalysisDatabasePath,
   loadWorkspaceAnalysisDatabaseCache: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache,
+  loadWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync,
   readWorkspaceAnalysisDatabaseSnapshot: mockState.databaseCache.readWorkspaceAnalysisDatabaseSnapshot,
   saveWorkspaceAnalysisDatabaseCache: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache,
   saveWorkspaceAnalysisDatabaseCacheAsync: mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync,
@@ -92,6 +94,10 @@ describe('extension/pluginIntegration/typescript', () => {
       },
     );
     mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache.mockReturnValue({
+      files: {},
+      version: '2.0.0',
+    });
+    mockState.databaseCache.loadWorkspaceAnalysisDatabaseCacheAsync.mockResolvedValue({
       files: {},
       version: '2.0.0',
     });
@@ -155,11 +161,9 @@ describe('extension/pluginIntegration/typescript', () => {
     ).map((pluginInfo) => pluginInfo.plugin.id);
 
     expect(pluginIds).toContain('codegraphy.typescript');
-    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).toHaveBeenCalledWith(
-      workspaceFixture!.workspacePath,
-    );
+    expect(mockState.databaseCache.loadWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
     expect(mockState.databaseCache.clearWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
-    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache).toHaveBeenCalled();
+    expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCache).not.toHaveBeenCalled();
     expect(mockState.databaseCache.saveWorkspaceAnalysisDatabaseCacheAsync).toHaveBeenCalled();
   }, 15000);
 });

--- a/packages/extension/tests/webview/app/graph/stats.test.tsx
+++ b/packages/extension/tests/webview/app/graph/stats.test.tsx
@@ -12,19 +12,19 @@ describe('app/graph/stats', () => {
   it('builds a combined stats label and renders it', () => {
     render(<GraphStatsBadge label={buildGraphStatsLabel(2, 1)} />);
 
-    expect(screen.getByText('2 visible nodes • 1 rendered edge')).toBeInTheDocument();
+    expect(screen.getByText('2 nodes • 1 connection')).toBeInTheDocument();
   });
 
-  it('does not present missing-index edges as a final rendered edge count', () => {
+  it('does not present missing-index connections as a final connection count', () => {
     expect(buildGraphStatsLabel(2, 0, { hasIndex: false })).toBe(
-      '2 visible nodes • relationships not indexed',
+      '2 nodes • connections not indexed',
     );
   });
 
   it('keeps the stats badge distinct from the graph surface', () => {
     render(<GraphStatsBadge label={buildGraphStatsLabel(2, 1)} />);
 
-    const badge = screen.getByText('2 visible nodes • 1 rendered edge');
+    const badge = screen.getByText('2 nodes • 1 connection');
     expect(badge.className).toContain('bg-[var(--cg-background)]');
     expect(badge.className).toContain('border-[var(--cg-border-subtle)]');
     expect(badge.className).not.toContain('bg-[var(--cg-popover-translucent)]');
@@ -33,12 +33,12 @@ describe('app/graph/stats', () => {
   it('insets the stats badge from the graph corner', () => {
     render(<GraphStatsBadge label={buildGraphStatsLabel(2, 1)} />);
 
-    const badge = screen.getByText('2 visible nodes • 1 rendered edge');
+    const badge = screen.getByText('2 nodes • 1 connection');
     expect(badge.className).toContain('right-4');
     expect(badge.className).toContain('top-4');
   });
 
   it('builds a combined stats label for singular nodes and plural edges', () => {
-    expect(buildGraphStatsLabel(1, 2)).toBe('1 visible node • 2 rendered edges');
+    expect(buildGraphStatsLabel(1, 2)).toBe('1 node • 2 connections');
   });
 });

--- a/packages/extension/tests/webview/app/graph/stats.test.tsx
+++ b/packages/extension/tests/webview/app/graph/stats.test.tsx
@@ -15,10 +15,8 @@ describe('app/graph/stats', () => {
     expect(screen.getByText('2 nodes • 1 connection')).toBeInTheDocument();
   });
 
-  it('does not present missing-index connections as a final connection count', () => {
-    expect(buildGraphStatsLabel(2, 0, { hasIndex: false })).toBe(
-      '2 nodes • connections not indexed',
-    );
+  it('builds missing-index graph stats as zero connections', () => {
+    expect(buildGraphStatsLabel(2, 0)).toBe('2 nodes • 0 connections');
   });
 
   it('keeps the stats badge distinct from the graph surface', () => {

--- a/packages/extension/tests/webview/app/graph/stats.test.tsx
+++ b/packages/extension/tests/webview/app/graph/stats.test.tsx
@@ -12,13 +12,19 @@ describe('app/graph/stats', () => {
   it('builds a combined stats label and renders it', () => {
     render(<GraphStatsBadge label={buildGraphStatsLabel(2, 1)} />);
 
-    expect(screen.getByText('2 nodes • 1 edge')).toBeInTheDocument();
+    expect(screen.getByText('2 visible nodes • 1 rendered edge')).toBeInTheDocument();
+  });
+
+  it('does not present missing-index edges as a final rendered edge count', () => {
+    expect(buildGraphStatsLabel(2, 0, { hasIndex: false })).toBe(
+      '2 visible nodes • relationships not indexed',
+    );
   });
 
   it('keeps the stats badge distinct from the graph surface', () => {
     render(<GraphStatsBadge label={buildGraphStatsLabel(2, 1)} />);
 
-    const badge = screen.getByText('2 nodes • 1 edge');
+    const badge = screen.getByText('2 visible nodes • 1 rendered edge');
     expect(badge.className).toContain('bg-[var(--cg-background)]');
     expect(badge.className).toContain('border-[var(--cg-border-subtle)]');
     expect(badge.className).not.toContain('bg-[var(--cg-popover-translucent)]');
@@ -27,12 +33,12 @@ describe('app/graph/stats', () => {
   it('insets the stats badge from the graph corner', () => {
     render(<GraphStatsBadge label={buildGraphStatsLabel(2, 1)} />);
 
-    const badge = screen.getByText('2 nodes • 1 edge');
+    const badge = screen.getByText('2 visible nodes • 1 rendered edge');
     expect(badge.className).toContain('right-4');
     expect(badge.className).toContain('top-4');
   });
 
   it('builds a combined stats label for singular nodes and plural edges', () => {
-    expect(buildGraphStatsLabel(1, 2)).toBe('1 node • 2 edges');
+    expect(buildGraphStatsLabel(1, 2)).toBe('1 visible node • 2 rendered edges');
   });
 });

--- a/packages/extension/tests/webview/app/shell/behavior.ignoresplugininjectionpayloadswithouttorenderstheactivefilebreadcrumb.test.tsx
+++ b/packages/extension/tests/webview/app/shell/behavior.ignoresplugininjectionpayloadswithouttorenderstheactivefilebreadcrumb.test.tsx
@@ -289,6 +289,7 @@ describe('App behavior', () => {
     it('shows the hidden-files hint when the graph is empty and orphans are disabled', () => {
       graphStore.setState({
         graphData: { nodes: [], edges: [] },
+        graphHasIndex: true,
         showOrphans: false,
       });
 

--- a/packages/extension/tests/webview/app/shell/mutations.test.tsx
+++ b/packages/extension/tests/webview/app/shell/mutations.test.tsx
@@ -273,6 +273,7 @@ describe('App (mutation targets)', () => {
   it('shows hidden-files hint when graph data is empty and orphans are disabled', () => {
     graphStore.setState({
       graphData: { nodes: [], edges: [] },
+      graphHasIndex: true,
       showOrphans: false,
       timelineActive: false,
     });

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -169,7 +169,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 connections')).toBeInTheDocument();
 
     await act(async () => {
       resolveInjection?.();
@@ -177,7 +177,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 connections')).toBeInTheDocument();
   });
 
   it('keeps the graph visible when plugin assets are injected after startup', async () => {
@@ -203,7 +203,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 connections')).toBeInTheDocument();
 
     await act(async () => {
       sendMessage({
@@ -217,7 +217,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 connections')).toBeInTheDocument();
 
     await act(async () => {
       resolveInjection?.();
@@ -225,7 +225,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 connections')).toBeInTheDocument();
   });
 
   it('keeps the graph visible when settings and filters update after startup', async () => {
@@ -243,7 +243,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 connections')).toBeInTheDocument();
 
     await act(async () => {
       sendMessage({
@@ -278,7 +278,7 @@ describe('App', () => {
     expect(graphStore.getState().bidirectionalMode).toBe('combined');
     expect(graphStore.getState().filterPatterns).toEqual(['dist/**']);
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('2 nodes • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('2 nodes • 0 connections')).toBeInTheDocument();
   });
 
   it('keeps the graph visible while indexing after startup', async () => {
@@ -325,7 +325,7 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 connections')).toBeInTheDocument();
 
     await act(async () => {
       sendMessage({
@@ -334,7 +334,7 @@ describe('App', () => {
       });
     });
 
-    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 connections')).toBeInTheDocument();
     expect(screen.getByText('Preparing Analysis')).toBeInTheDocument();
 
     await act(async () => {
@@ -487,7 +487,7 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 connections')).toBeInTheDocument();
   });
 
   it('counts filters against the scoped visible graph instead of raw graph data', () => {

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -313,7 +313,35 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('2 nodes • 1 edge')).toBeInTheDocument();
+    expect(screen.getByText('2 visible nodes • 1 rendered edge')).toBeInTheDocument();
+  });
+
+  it('keeps cold-cache file nodes visible after scope, filter, search, and Show Orphans', async () => {
+    graphStore.setState({
+      showOrphans: false,
+      graphHasIndex: false,
+      graphIndexFreshness: 'missing',
+      filterPatterns: ['src'],
+      searchQuery: 'a',
+      nodeVisibility: { file: true },
+    });
+
+    render(<App />);
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [
+            { id: 'src/a.ts', label: 'a.ts', color: '#3B82F6', nodeType: 'file' },
+            { id: 'docs/b.ts', label: 'b.ts', color: '#10B981', nodeType: 'file' },
+          ],
+          edges: [],
+        },
+      });
+      sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+    });
+
+    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
   });
 
   it('counts filters against the scoped visible graph instead of raw graph data', () => {

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -404,6 +404,10 @@ describe('App', () => {
       type: 'VISIBLE_GRAPH_STATE_RESPONSE',
       payload: {
         nodeCount: 2,
+        nodes: [
+          { id: 'src/app.ts', nodeType: 'file', color: '#3B82F6' },
+          { id: 'src/app.ts#run:function', nodeType: 'symbol', color: '#8B5CF6' },
+        ],
         edgeCount: 1,
         edgeIds: ['src/app.ts->src/app.ts#run:function#contains'],
       },

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -169,7 +169,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
 
     await act(async () => {
       resolveInjection?.();
@@ -177,7 +177,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
   });
 
   it('keeps the graph visible when plugin assets are injected after startup', async () => {
@@ -203,7 +203,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
 
     await act(async () => {
       sendMessage({
@@ -217,7 +217,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
 
     await act(async () => {
       resolveInjection?.();
@@ -225,7 +225,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
   });
 
   it('keeps the graph visible when settings and filters update after startup', async () => {
@@ -243,7 +243,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
 
     await act(async () => {
       sendMessage({
@@ -278,7 +278,7 @@ describe('App', () => {
     expect(graphStore.getState().bidirectionalMode).toBe('combined');
     expect(graphStore.getState().filterPatterns).toEqual(['dist/**']);
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('2 visible nodes • relationships not indexed')).toBeInTheDocument();
+    expect(screen.getByText('2 nodes • connections not indexed')).toBeInTheDocument();
   });
 
   it('keeps the graph visible while indexing after startup', async () => {
@@ -311,7 +311,7 @@ describe('App', () => {
     expect(screen.getByText('Indexing Workspace')).toBeInTheDocument();
   });
 
-  it('hides final-looking graph stats while explicit indexing is active', async () => {
+  it('keeps current graph stats visible while explicit indexing progress is active', async () => {
     render(<App />);
 
     await act(async () => {
@@ -325,7 +325,7 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
 
     await act(async () => {
       sendMessage({
@@ -334,7 +334,7 @@ describe('App', () => {
       });
     });
 
-    expect(screen.queryByText('1 visible node • relationships not indexed')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
     expect(screen.getByText('Preparing Analysis')).toBeInTheDocument();
 
     await act(async () => {
@@ -353,7 +353,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Preparing Analysis')).not.toBeInTheDocument();
-    expect(screen.getByText('2 visible nodes • 1 rendered edge')).toBeInTheDocument();
+    expect(screen.getByText('2 nodes • 1 connection')).toBeInTheDocument();
   });
 
   it('should send WEBVIEW_READY only once across initial graph load', async () => {
@@ -459,7 +459,7 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('2 visible nodes • 1 rendered edge')).toBeInTheDocument();
+    expect(screen.getByText('2 nodes • 1 connection')).toBeInTheDocument();
   });
 
   it('keeps cold-cache file nodes visible after scope, filter, search, and Show Orphans', async () => {
@@ -487,7 +487,7 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
+    expect(screen.getByText('1 node • connections not indexed')).toBeInTheDocument();
   });
 
   it('counts filters against the scoped visible graph instead of raw graph data', () => {

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -138,7 +138,7 @@ describe('App', () => {
     expect(screen.getByTitle('Graph Scope')).toBeInTheDocument();
   });
 
-  it('waits for startup plugin asset injection before showing the first graph', async () => {
+  it('keeps the first graph visible while startup plugin assets finish loading', async () => {
     let resolveInjection: (() => void) | undefined;
     const pendingImport = new Promise<void>((resolve) => {
       resolveInjection = resolve;
@@ -168,16 +168,117 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('Loading graph...')).toBeInTheDocument();
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
 
     await act(async () => {
       resolveInjection?.();
       await pendingImport;
     });
 
-    await waitFor(() => {
-      expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+  });
+
+  it('keeps the graph visible when plugin assets are injected after startup', async () => {
+    let resolveInjection: (() => void) | undefined;
+    const pendingImport = new Promise<void>((resolve) => {
+      resolveInjection = resolve;
     });
+    vi.doMock('/plugin/late-registration.js', () => pendingImport.then(() => ({
+      activate: vi.fn(),
+    })));
+
+    render(<App />);
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [{ id: 'test.ts', label: 'test.ts', color: '#3B82F6' }],
+          edges: [],
+        },
+      });
+      sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+
+    await act(async () => {
+      sendMessage({
+        type: 'PLUGIN_WEBVIEW_INJECT',
+        payload: {
+          pluginId: 'codegraphy.late',
+          scripts: ['/plugin/late-registration.js'],
+          styles: [],
+        },
+      });
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveInjection?.();
+      await pendingImport;
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+  });
+
+  it('keeps the graph visible when settings and filters update after startup', async () => {
+    render(<App />);
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [{ id: 'test.ts', label: 'test.ts', color: '#3B82F6' }],
+          edges: [],
+        },
+      });
+      sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+    });
+
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+
+    await act(async () => {
+      sendMessage({
+        type: 'SETTINGS_UPDATED',
+        payload: {
+          bidirectionalEdges: 'combined',
+          showOrphans: true,
+        },
+      });
+      sendMessage({
+        type: 'FILTER_PATTERNS_UPDATED',
+        payload: {
+          patterns: ['dist/**'],
+          pluginPatterns: ['plugin/**'],
+          pluginPatternGroups: [],
+          disabledCustomPatterns: [],
+          disabledPluginPatterns: [],
+        },
+      });
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [
+            { id: 'test.ts', label: 'test.ts', color: '#3B82F6' },
+            { id: 'src/app.ts', label: 'app.ts', color: '#10B981' },
+          ],
+          edges: [],
+        },
+      });
+    });
+
+    expect(graphStore.getState().bidirectionalMode).toBe('combined');
+    expect(graphStore.getState().filterPatterns).toEqual(['dist/**']);
+    expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
+    expect(screen.getByText('2 nodes • 0 edges')).toBeInTheDocument();
   });
 
   it('keeps the graph visible while indexing after startup', async () => {

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -169,7 +169,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
 
     await act(async () => {
       resolveInjection?.();
@@ -177,7 +177,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
   });
 
   it('keeps the graph visible when plugin assets are injected after startup', async () => {
@@ -203,7 +203,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
 
     await act(async () => {
       sendMessage({
@@ -217,7 +217,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
 
     await act(async () => {
       resolveInjection?.();
@@ -225,7 +225,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
   });
 
   it('keeps the graph visible when settings and filters update after startup', async () => {
@@ -243,7 +243,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
 
     await act(async () => {
       sendMessage({
@@ -278,7 +278,7 @@ describe('App', () => {
     expect(graphStore.getState().bidirectionalMode).toBe('combined');
     expect(graphStore.getState().filterPatterns).toEqual(['dist/**']);
     expect(screen.queryByText('Loading graph...')).not.toBeInTheDocument();
-    expect(screen.getByText('2 nodes • 0 edges')).toBeInTheDocument();
+    expect(screen.getByText('2 visible nodes • relationships not indexed')).toBeInTheDocument();
   });
 
   it('keeps the graph visible while indexing after startup', async () => {
@@ -325,7 +325,7 @@ describe('App', () => {
       sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
     });
 
-    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+    expect(screen.getByText('1 visible node • relationships not indexed')).toBeInTheDocument();
 
     await act(async () => {
       sendMessage({
@@ -334,7 +334,7 @@ describe('App', () => {
       });
     });
 
-    expect(screen.queryByText('1 node • 0 edges')).not.toBeInTheDocument();
+    expect(screen.queryByText('1 visible node • relationships not indexed')).not.toBeInTheDocument();
     expect(screen.getByText('Preparing Analysis')).toBeInTheDocument();
 
     await act(async () => {
@@ -353,7 +353,7 @@ describe('App', () => {
     });
 
     expect(screen.queryByText('Preparing Analysis')).not.toBeInTheDocument();
-    expect(screen.getByText('2 nodes • 1 edge')).toBeInTheDocument();
+    expect(screen.getByText('2 visible nodes • 1 rendered edge')).toBeInTheDocument();
   });
 
   it('should send WEBVIEW_READY only once across initial graph load', async () => {

--- a/packages/extension/tests/webview/app/shell/view.test.tsx
+++ b/packages/extension/tests/webview/app/shell/view.test.tsx
@@ -210,6 +210,51 @@ describe('App', () => {
     expect(screen.getByText('Indexing Workspace')).toBeInTheDocument();
   });
 
+  it('hides final-looking graph stats while explicit indexing is active', async () => {
+    render(<App />);
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [{ id: 'test.ts', label: 'test.ts', color: '#3B82F6' }],
+          edges: [],
+        },
+      });
+      sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+    });
+
+    expect(screen.getByText('1 node • 0 edges')).toBeInTheDocument();
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_INDEX_PROGRESS',
+        payload: { phase: 'Preparing Analysis', current: 0, total: 1 },
+      });
+    });
+
+    expect(screen.queryByText('1 node • 0 edges')).not.toBeInTheDocument();
+    expect(screen.getByText('Preparing Analysis')).toBeInTheDocument();
+
+    await act(async () => {
+      sendMessage({
+        type: 'GRAPH_DATA_UPDATED',
+        payload: {
+          nodes: [
+            { id: 'test.ts', label: 'test.ts', color: '#3B82F6' },
+            { id: 'used.ts', label: 'used.ts', color: '#3B82F6' },
+          ],
+          edges: [
+            { id: 'test.ts->used.ts#import', from: 'test.ts', to: 'used.ts', kind: 'import', sources: [] },
+          ],
+        },
+      });
+    });
+
+    expect(screen.queryByText('Preparing Analysis')).not.toBeInTheDocument();
+    expect(screen.getByText('2 nodes • 1 edge')).toBeInTheDocument();
+  });
+
   it('should send WEBVIEW_READY only once across initial graph load', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sentMessages = (globalThis as any).__vscodeSentMessages as Array<{ type?: string }>;

--- a/packages/extension/tests/webview/app/shell/visibleGraphResponse.test.ts
+++ b/packages/extension/tests/webview/app/shell/visibleGraphResponse.test.ts
@@ -35,6 +35,7 @@ describe('webview/app/shell/visibleGraphResponse', () => {
       edgeCount: 0,
       edgeIds: [],
       nodeCount: 0,
+      nodes: [],
     });
   });
 
@@ -43,6 +44,7 @@ describe('webview/app/shell/visibleGraphResponse', () => {
       edgeCount: 1,
       edgeIds: ['a->b'],
       nodeCount: 1,
+      nodes: [{ id: 'a.ts', nodeType: undefined, color: '#3B82F6' }],
     });
   });
 
@@ -65,6 +67,7 @@ describe('webview/app/shell/visibleGraphResponse', () => {
         edgeCount: 1,
         edgeIds: ['a->b'],
         nodeCount: 1,
+        nodes: [{ id: 'a.ts', nodeType: undefined, color: '#3B82F6' }],
       },
     });
 

--- a/packages/extension/tests/webview/store/actions/bootstrap.test.ts
+++ b/packages/extension/tests/webview/store/actions/bootstrap.test.ts
@@ -42,7 +42,7 @@ describe('webview/store/actions/bootstrap', () => {
     });
   });
 
-  it('keeps loading until bootstrap, graph data, and plugin assets are complete', () => {
+  it('does not keep initial loading blocked on plugin assets once bootstrap and graph data are complete', () => {
     const { actions, getState } = createHarness({
       awaitingInitialBootstrap: true,
       bootstrapComplete: true,
@@ -59,7 +59,8 @@ describe('webview/store/actions/bootstrap', () => {
 
     actions.finishPluginAssetLoad();
     expect(getState()).toMatchObject({
-      isLoading: true,
+      awaitingInitialBootstrap: false,
+      isLoading: false,
       pendingPluginAssetLoads: 1,
     });
 

--- a/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
+++ b/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
@@ -138,6 +138,24 @@ describe('webview/store/messageHandlers/graph', () => {
     });
   });
 
+  it('settles initial bootstrap when graph data and app bootstrap are ready while plugin assets continue loading', () => {
+    const state = createState({
+      graphData: { nodes: [{ id: 'src/app.ts', label: 'App', color: '#fff' }], edges: [] },
+      awaitingInitialBootstrap: true,
+      pendingPluginAssetLoads: 1,
+      isLoading: true,
+    });
+
+    expect(handleAppBootstrapComplete(
+      { type: 'APP_BOOTSTRAP_COMPLETE' },
+      { getState: () => state },
+    )).toEqual({
+      bootstrapComplete: true,
+      awaitingInitialBootstrap: false,
+      isLoading: false,
+    });
+  });
+
   it('maps graph index status and progress payloads', () => {
     expect(handleGraphIndexStatusUpdated({
       type: 'GRAPH_INDEX_STATUS_UPDATED',

--- a/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
+++ b/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
@@ -168,6 +168,8 @@ describe('webview/store/messageHandlers/graph', () => {
       graphHasIndex: true,
       graphIndexFreshness: 'fresh',
       graphIndexDetail: 'CodeGraphy index is fresh.',
+      graphIsIndexing: false,
+      graphIndexProgress: null,
     });
 
     expect(handleGraphIndexProgress({

--- a/packages/extension/tests/webview/store/state/runtime.test.ts
+++ b/packages/extension/tests/webview/store/state/runtime.test.ts
@@ -57,6 +57,36 @@ describe('GraphStore', () => {
     expect(store.getState().graphIndexFreshness).toBe('fresh');
   });
 
+  it('clears graph indexing progress when the host reports a fresh index', () => {
+    store.getState().handleExtensionMessage({
+      type: 'GRAPH_INDEX_PROGRESS',
+      payload: {
+        phase: 'Saving Graph Cache',
+        current: 96,
+        total: 100,
+      },
+    });
+
+    expect(store.getState().graphIsIndexing).toBe(true);
+    expect(store.getState().graphIndexProgress).toEqual({
+      phase: 'Saving Graph Cache',
+      current: 96,
+      total: 100,
+    });
+
+    store.getState().handleExtensionMessage({
+      type: 'GRAPH_INDEX_STATUS_UPDATED',
+      payload: {
+        hasIndex: true,
+        freshness: 'fresh',
+        detail: 'CodeGraphy index is fresh.',
+      },
+    });
+
+    expect(store.getState().graphIsIndexing).toBe(false);
+    expect(store.getState().graphIndexProgress).toBeNull();
+  });
+
   it('handles FAVORITES_UPDATED message', () => {
     store.getState().handleExtensionMessage({
       type: 'FAVORITES_UPDATED',


### PR DESCRIPTION
## Summary
- Integrates the five startup lifecycle cleanup workstreams into one orchestrator branch.
- Keeps cold-cache startup visible with file nodes and no misleading indexed-edge stats until explicit indexing runs.
- Defers Graph Cache hydration/persistence work off the startup-critical path and tightens webview bootstrap/settings resilience.
- Clarifies indexing progress/stats semantics and adds a CodeGraphy-root E2E lifecycle harness for cold cache, explicit index, and warm Graph Cache reopen.

## Integrated workstreams
- #230 Cold-cache startup visible graph contract
- #231 Fix Graph Cache startup responsiveness
- #232 Startup cleanup: webview bootstrap settings resilience
- #233 Clarify indexing progress and graph stats
- #234 Add startup lifecycle acceptance harness

## Orchestrator review fixes
- Updated app shell integration expectations to match the new visible-graph stats language.
- Corrected the CodeGraphy-root E2E thresholds to assert a substantial graph that matches the repo's real observed edge scale.

## Verification
- `pnpm run build`
- `pnpm run test`
- `CODEGRAPHY_E2E_ONLY_SCENARIO=codegraphy-root CODEGRAPHY_E2E_GREP='cold cache startup indexes explicitly' pnpm --filter @codegraphy-dev/extension run test:vscode`
- `pnpm changeset status --since origin/main`
- Confirmed source PRs #230-#234 have passing GitHub checks and no human review comments.
