### PR TITLE
Extension: add verbose Dev Mode diagnostics

### DIFF
--- a/.changeset/verbose-diagnostics.md
+++ b/.changeset/verbose-diagnostics.md
@@ -6,7 +6,7 @@
 
 Add Verbose Diagnostics for support and agent debugging.
 
-In the VS Code extension, Settings > Performance now includes a **Verbose Diagnostics** toggle. It is off by default and persists to `.codegraphy/settings.json` as `verboseDiagnostics`. When enabled, CodeGraphy writes factual `[CodeGraphy][Diagnostics]` lines to the VS Code Developer Tools console for extension activation, webview bootstrap, analysis requests, and Graph Cache load decisions.
+In the VS Code extension, Settings > Performance now includes a **Verbose Diagnostics** toggle. It is off by default and persists to `.codegraphy/settings.json` as `verboseDiagnostics`. When enabled, CodeGraphy writes factual `[CodeGraphy]` event lines to the VS Code Developer Tools console for extension activation, webview bootstrap, analysis requests, and Graph Cache load decisions.
 
 The Core CLI now accepts a global `--verbose` flag on every command. Verbose command diagnostics are written outside JSON stdout so status and query-style output remains parseable.
 

--- a/.changeset/verbose-diagnostics.md
+++ b/.changeset/verbose-diagnostics.md
@@ -1,0 +1,13 @@
+---
+"@codegraphy-dev/core": minor
+"@codegraphy-dev/extension": minor
+"@codegraphy-dev/mcp": minor
+---
+
+Add Verbose Diagnostics for support and agent debugging.
+
+In the VS Code extension, Settings > Performance now includes a **Verbose Diagnostics** toggle. It is off by default and persists to `.codegraphy/settings.json` as `verboseDiagnostics`. When enabled, CodeGraphy writes factual `[CodeGraphy][Diagnostics]` lines to the VS Code Developer Tools console for extension activation, webview bootstrap, analysis requests, and Graph Cache load decisions.
+
+The Core CLI now accepts a global `--verbose` flag on every command. Verbose command diagnostics are written outside JSON stdout so status and query-style output remains parseable.
+
+Every MCP tool now accepts `verboseDiagnostics?: boolean`. When enabled, tool results include a `diagnostics` array with factual Core Package events such as workspace status reads, indexing phases, Graph Cache state, Graph Query execution, counts, and durations. Default MCP responses stay unchanged when diagnostics are disabled.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -325,7 +325,7 @@ The `@codegraphy-dev/core` npm package that owns the central CodeGraphy engine: 
 _Avoid_: VS Code extension when referring to headless engine behavior
 
 **CodeGraphy Interface**:
-A user, agent, or programmer-facing way to interact with the **Core Package** without owning the engine. The **VS Code Extension** is the user interface, **CodeGraphy MCP** is the agent interface, and **Plugin API** is the programmer interface for plugin authors.
+A user, agent, terminal, or programmer-facing way to interact with the **Core Package** without owning the engine. The **VS Code Extension** is the graphical user interface, **CodeGraphy CLI** is the terminal interface, **CodeGraphy MCP** is the agent interface, and **Plugin API** is the programmer interface for plugin authors.
 _Avoid_: Engine, core owner, implementation package
 
 **Plugin**:
@@ -361,6 +361,10 @@ _Avoid_: Setting when referring only to the UI element
 **Display Setting**:
 A Setting that changes how graph information is presented without changing which graph items exist in the **Relationship Graph**. Display Settings include visual preferences and lower-frequency view behavior such as labels, orphans, renderer mode, direction indicators, bidirectional edge display, and depth controls.
 _Avoid_: Graph Scope, Search, Filter Setting
+
+**Verbose Diagnostics**:
+A Setting that enables verbose CodeGraphy diagnostic logging for Core Package and VS Code Extension lifecycle support workflows while a user reproduces an issue. It stays off by default so ordinary CodeGraphy use remains quiet.
+_Avoid_: Dev Mode when the behavior only refers to diagnostic logging
 
 **Filter Setting**:
 A persisted Setting that defines include or exclude criteria for path/glob patterns first. Exclude criteria remove recurring noise; include criteria narrow graph consideration to a durable working subset. Graph-aware filter criteria may be added later only when they have clear semantics separate from **Graph Scope**.
@@ -612,7 +616,26 @@ _Avoid_: Graph export
 - The **Markdown Plugin** is installed with `@codegraphy-dev/core` and enabled by default for new CodeGraphy Workspaces, but users can still toggle it off.
 - A **Settings Control** changes a **Setting**; it is not a separate persisted concept.
 - **Settings** are saved workspace-locally under `.codegraphy/settings.json` so graph preferences survive between sessions.
-- **Graph Scope**, **Filter Setting**, **Display Setting**, **Favorite**, and **Legend Entry Toggle** are settings because they are saved between sessions.
+- **Graph Scope**, **Filter Setting**, **Display Setting**, **Verbose Diagnostics**, **Favorite**, and **Legend Entry Toggle** are settings because they are saved between sessions.
+- The **Verbose Diagnostics** persisted settings key is `verboseDiagnostics`.
+- **Verbose Diagnostics** takes effect immediately for newly occurring diagnostics after the Setting changes. Restarting VS Code is only required when a support workflow needs startup lifecycle diagnostics.
+- **Verbose Diagnostics** should expose Core Package diagnostics through the active **CodeGraphy Interface**: VS Code Developer Tools for the **VS Code Extension**, terminal diagnostic output for **CodeGraphy CLI**, and tool-result or MCP-safe diagnostic output for **CodeGraphy MCP**.
+- The persisted **Verbose Diagnostics** Setting controls only the **VS Code Extension** interface. **CodeGraphy CLI** and **CodeGraphy MCP** should opt into verbose diagnostics per invocation so scripts and agent tool calls stay quiet by default.
+- **CodeGraphy CLI** should accept `--verbose` consistently across commands, even if some commands have fewer diagnostic events than others.
+- **CodeGraphy MCP** should accept `verboseDiagnostics` consistently across tools, even if some tools only report Graph Cache read or Graph Query diagnostics.
+- **Verbose Diagnostics** should report factual Core Package state, VS Code Extension lifecycle state, decisions, counts, and execution context. They should not include suggested next actions or prescriptive guidance, though each interface may format the same facts for its output sink.
+- **Verbose Diagnostics** events should carry stable area and event identifiers so humans can grep logs and agents can reason over diagnostics without parsing prose.
+- **Verbose Diagnostics** context should be JSON-serializable plain data so the same event can render consistently through the VS Code Extension, CodeGraphy CLI, and CodeGraphy MCP.
+- **Verbose Diagnostics** should prefer workspace-relative paths when a CodeGraphy Workspace root is known. Absolute paths should be limited to explicit workspace roots, external package locations, or existing error surfaces where the absolute path is already part of the reported failure.
+- **Verbose Diagnostics** should include timing and duration facts for phase boundaries when they are cheap and reliable to measure.
+- **Verbose Diagnostics** should include operation or request identifiers for multi-event indexing, query, cache sync, and lifecycle operations so interleaved diagnostics can be correlated.
+- **Verbose Diagnostics** may include compact snapshots of behavior-shaping inputs, such as enabled plugin ids/packages, disabled plugin ids, Graph Scope counts, and filter counts. They should not dump complete settings objects.
+- **Verbose Diagnostics** should wrap important existing errors and warnings with structured diagnostic context while preserving the existing error or warning behavior.
+- **Verbose Diagnostics** should stay high-signal even when verbose: prefer operation boundaries, decisions, state transitions, summaries, timings, and structured error context over repeated hot-loop or per-item logs.
+- **Verbose Diagnostics** has one curated verbose mode, not multiple verbosity levels.
+- Obvious non-error lifecycle logs may move behind **Verbose Diagnostics** when they are noisy in normal use, but this should be selective rather than a blanket migration of all existing logs.
+- User-facing troubleshooting docs and changesets should use the name **Verbose Diagnostics** consistently.
+- **Verbose Diagnostics** may log event names, lifecycle phases, counts, plugin or package ids, cache freshness decisions, and workspace-relative paths when they help support diagnose ordering and state. It should avoid logging file contents and avoid absolute paths unless an existing error path already reports one.
 - **Filter Settings** are made of **Filter Rules** whose enabled state and user customizations must be understandable when rules come from defaults, plugins, or custom user entries.
 - Custom user **Filter Rules** and **Filter Rule Overrides** can be edited or removed; source-owned built-in and plugin-contributed **Filter Rules** can be toggled but not removed from their source.
 - **Display Settings** change presentation and view behavior; they do not change graph eligibility like **Graph Scope** or **Filter Setting**.

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -5,13 +5,13 @@ Verbose Diagnostics adds factual, CodeGraphy-prefixed logs for support and agent
 Diagnostic lines use this shape:
 
 ```text
-[CodeGraphy][Diagnostics] <area> <event> <json context>
+[CodeGraphy] <event message>: <compact facts>
 ```
 
 Example:
 
 ```text
-[CodeGraphy][Diagnostics] extension.analysis request-started {"requestId":4,"mode":"load","filterPatternCount":2,"disabledPluginCount":0}
+[CodeGraphy] Starting analysis: request=4, mode=load, filters=2, disabledPlugins=0
 ```
 
 ## VS Code Extension
@@ -32,7 +32,7 @@ For support:
 2. Reload VS Code if startup logs are needed.
 3. Open VS Code Developer Tools.
 4. Reproduce the issue.
-5. Copy `[CodeGraphy][Diagnostics]` console lines into the bug report.
+5. Copy the relevant `[CodeGraphy]` console lines into the bug report.
 
 The extension emits lifecycle, webview bootstrap, analysis request, and Graph Cache load-decision facts. Normal logging stays quiet when Verbose Diagnostics is off.
 
@@ -50,7 +50,7 @@ Verbose CLI diagnostics are written outside normal JSON stdout so command output
 Example diagnostic line:
 
 ```text
-[CodeGraphy][Diagnostics] cli command-started {"command":"status","workspacePath":"/absolute/path/to/workspace"}
+[CodeGraphy] Starting command: status, workspace=/absolute/path/to/workspace
 ```
 
 ## MCP

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -1,0 +1,69 @@
+# Verbose Diagnostics
+
+Verbose Diagnostics adds factual, CodeGraphy-prefixed logs for support and agent debugging. It is off by default.
+
+Diagnostic lines use this shape:
+
+```text
+[CodeGraphy][Diagnostics] <area> <event> <json context>
+```
+
+Example:
+
+```text
+[CodeGraphy][Diagnostics] extension.analysis request-started {"requestId":4,"mode":"load","filterPatternCount":2,"disabledPluginCount":0}
+```
+
+## VS Code Extension
+
+Open Settings, expand **Performance**, and turn on **Verbose Diagnostics**.
+
+The setting is saved in the current CodeGraphy Workspace:
+
+```json
+{
+  "verboseDiagnostics": true
+}
+```
+
+For support:
+
+1. Enable **Verbose Diagnostics**.
+2. Reload VS Code if startup logs are needed.
+3. Open VS Code Developer Tools.
+4. Reproduce the issue.
+5. Copy `[CodeGraphy][Diagnostics]` console lines into the bug report.
+
+The extension emits lifecycle, webview bootstrap, analysis request, and Graph Cache load-decision facts. Normal logging stays quiet when Verbose Diagnostics is off.
+
+## CLI
+
+Pass `--verbose` to any `codegraphy` command:
+
+```bash
+codegraphy --verbose status
+codegraphy --verbose index /absolute/path/to/workspace
+```
+
+Verbose CLI diagnostics are written outside normal JSON stdout so command output remains parseable.
+
+Example diagnostic line:
+
+```text
+[CodeGraphy][Diagnostics] cli command-started {"command":"status","workspacePath":"/absolute/path/to/workspace"}
+```
+
+## MCP
+
+Every CodeGraphy MCP tool accepts `verboseDiagnostics`.
+
+Example:
+
+```json
+{
+  "path": "/absolute/path/to/workspace",
+  "verboseDiagnostics": true
+}
+```
+
+When enabled, the tool result includes a `diagnostics` array with factual Core Package events such as workspace status reads, indexing phases, Graph Cache state, Graph Query execution, counts, and durations. Default MCP responses are unchanged when `verboseDiagnostics` is omitted or false.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -104,6 +104,8 @@ For commands with `[workspace]`, the workspace is an optional trailing positiona
 
 MCP tools should mirror the core CLI command semantics. They call Core APIs directly instead of shelling out to `codegraphy`.
 
+Every MCP tool accepts optional `verboseDiagnostics: true`. When enabled, the tool result includes factual CodeGraphy diagnostic events in a `diagnostics` array. Default tool responses are unchanged when it is omitted. See [Verbose Diagnostics](./DIAGNOSTICS.md).
+
 | Tool | What It Does | Typical Use |
 |---|---|---|
 | `codegraphy_status` | Reports CodeGraphy Workspace status for the MCP server working directory or an explicit `path` | decide whether to index before querying |

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -157,7 +157,7 @@ Adjusts the physics simulation in real time.
 ### Performance
 
 - **Max Files** limits how many files are discovered and analyzed.
-- **Verbose Diagnostics** writes factual `[CodeGraphy][Diagnostics]` lines to VS Code Developer Tools for support workflows. It persists as `verboseDiagnostics` in `.codegraphy/settings.json`.
+- **Verbose Diagnostics** writes factual `[CodeGraphy]` event lines to VS Code Developer Tools for support workflows. It persists as `verboseDiagnostics` in `.codegraphy/settings.json`.
 
 See [Verbose Diagnostics](./DIAGNOSTICS.md) for the VS Code, CLI, and MCP support workflow.
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -68,6 +68,7 @@ Example:
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `maxFiles` | number | `1000` | Maximum files to discover/analyze |
+| `verboseDiagnostics` | boolean | `false` | Enables CodeGraphy-prefixed support diagnostics in the VS Code Developer Tools console |
 | `include` | string[] | `["**/*"]` | Glob patterns for files to include |
 | `filterPatterns` | string[] | `[]` | Filter Settings for files to exclude |
 | `respectGitignore` | boolean | `true` | Honor `.gitignore` patterns |
@@ -152,6 +153,13 @@ Adjusts the physics simulation in real time.
 | Center Force | 0-1 | Pull toward the viewport center. |
 | Link Distance | 30-500 | Preferred distance between connected nodes in pixels. |
 | Link Force | 0-1 | How strongly edges pull connected nodes together. |
+
+### Performance
+
+- **Max Files** limits how many files are discovered and analyzed.
+- **Verbose Diagnostics** writes factual `[CodeGraphy][Diagnostics]` lines to VS Code Developer Tools for support workflows. It persists as `verboseDiagnostics` in `.codegraphy/settings.json`.
+
+See [Verbose Diagnostics](./DIAGNOSTICS.md) for the VS Code, CLI, and MCP support workflow.
 
 ### Legends
 

--- a/docs/agents/trello-165-dev-mode-diagnostics-plan.md
+++ b/docs/agents/trello-165-dev-mode-diagnostics-plan.md
@@ -30,13 +30,13 @@ As part of this work, selectively move obvious non-error lifecycle logs behind V
 When **Verbose Diagnostics** is on for a CodeGraphy interface, CodeGraphy should emit copy/paste-friendly diagnostics with a recognizable prefix:
 
 ```text
-[CodeGraphy][Diagnostics] <area> <event> <structured context>
+[CodeGraphy] <event message>: <compact facts>
 ```
 
-Recommended context style is a stable object argument after a short message, for example:
+Recommended context style is a concise event message followed by only the facts needed to orient debugging, for example:
 
 ```text
-[CodeGraphy][Diagnostics] graph-cache freshness decision { freshness: "stale", reason: "plugin-signature-changed" }
+[CodeGraphy] Graph Cache stale: reason=plugin-signature-changed
 ```
 
 Core Package diagnostics should be modeled as structured diagnostic events first, then rendered by each adapter. The Core Package should not know about VS Code Developer Tools, terminal streams, or MCP transport details.
@@ -115,7 +115,7 @@ Avoid diagnostics for:
    - Add adapter-side renderers for Extension, CLI, and MCP.
    - Adapter renderers should accept an enabled predicate so toggling or flags take effect immediately where the interface supports it.
    - Keep diagnostics inert when disabled.
-   - Use `[CodeGraphy][Diagnostics]` as the fixed prefix.
+   - Use `[CodeGraphy]` as the fixed prefix for extension console and CLI output.
    - Prefer typed helper functions for consistent area/event/context fields instead of open-ended console calls.
 
 4. Core Package diagnostic hooks
@@ -187,7 +187,7 @@ Avoid diagnostics for:
      - reload VS Code if startup logs are needed
      - open Developer Tools
      - reproduce the issue
-     - copy `[CodeGraphy][Diagnostics]` logs into the bug report
+     - copy relevant `[CodeGraphy]` logs into the bug report
    - Add CLI troubleshooting copy for `codegraphy ... --verbose` or the final chosen CLI flag.
    - Add MCP troubleshooting copy showing how an agent should request verbose diagnostics and where to find returned diagnostic entries.
    - Use the name **Verbose Diagnostics** consistently in docs.

--- a/docs/agents/trello-165-dev-mode-diagnostics-plan.md
+++ b/docs/agents/trello-165-dev-mode-diagnostics-plan.md
@@ -1,0 +1,252 @@
+# Trello 165 Dev Mode Diagnostics Plan
+
+Trello card: https://trello.com/c/s2S4WRcB/165-extension-add-verbose-dev-mode-diagnostics
+Draft PR: https://github.com/joesobo/CodeGraphyV4/pull/236
+
+## Alignment
+
+- Add a single **Verbose Diagnostics** toggle under the Settings panel Performance section.
+- Persist the toggle in workspace-local `.codegraphy/settings.json`.
+- Default the setting to `false`.
+- The toggle takes effect immediately for newly occurring diagnostics.
+- Restart or reload VS Code is only needed when support needs startup lifecycle logs.
+- The VS Code UI toggle controls diagnostics for the VS Code Extension interface.
+- CodeGraphy CLI and CodeGraphy MCP opt into verbose diagnostics per invocation; they do not become verbose merely because the VS Code UI toggle is persisted in workspace settings.
+- Diagnostics cover Core Package activity across its three direct interfaces: VS Code Extension, CodeGraphy CLI, and CodeGraphy MCP.
+- Diagnostics also cover VS Code Extension lifecycle activity, which exists only in the UI interface.
+- Diagnostic output is interface-specific:
+  - VS Code Extension: VS Code Developer Tools console.
+  - CodeGraphy CLI: terminal diagnostic output that does not corrupt normal JSON stdout.
+  - CodeGraphy MCP: MCP-safe diagnostic output, preferably included in tool results or exposed through explicit diagnostic metadata instead of writing arbitrary stdio logs.
+- Logs should include event names, lifecycle phases, counts, plugin or package ids, cache decisions, and workspace-relative paths when useful.
+- Logs should avoid file contents and avoid absolute paths unless an existing error path already reports one.
+
+## Product Behavior
+
+When **Verbose Diagnostics** is off, CodeGraphy should keep normal console logging quiet except for existing errors and warnings.
+
+As part of this work, selectively move obvious non-error lifecycle logs behind Verbose Diagnostics when they are noisy in normal use. Do not migrate all existing logs indiscriminately.
+
+When **Verbose Diagnostics** is on for a CodeGraphy interface, CodeGraphy should emit copy/paste-friendly diagnostics with a recognizable prefix:
+
+```text
+[CodeGraphy][Diagnostics] <area> <event> <structured context>
+```
+
+Recommended context style is a stable object argument after a short message, for example:
+
+```text
+[CodeGraphy][Diagnostics] graph-cache freshness decision { freshness: "stale", reason: "plugin-signature-changed" }
+```
+
+Core Package diagnostics should be modeled as structured diagnostic events first, then rendered by each adapter. The Core Package should not know about VS Code Developer Tools, terminal streams, or MCP transport details.
+
+Diagnostics are factual only across interfaces. They should report state, phases, decisions, counts, plugin ids/packages, cache reasons, and execution context. They should not include suggested next actions, advice, or prescriptive guidance.
+
+There is one curated verbose mode. Do not add multiple verbosity levels such as `verbose`, `trace`, or `-vvv`.
+
+Each diagnostic event should carry stable `area` and `event` identifiers, for example `graph-cache` + `load`, `indexing` + `discovery-completed`, or `plugin` + `initialize-started`.
+
+Diagnostic `context` should be JSON-serializable plain data only: strings, booleans, numbers, null, arrays, and plain objects. Normalize `Error` objects, `Map`, `Set`, VS Code objects, class instances, and paths before emitting.
+
+Paths in diagnostic context should be workspace-relative whenever a CodeGraphy Workspace root is known. Absolute paths are reserved for explicit workspace roots, external package locations, and existing error surfaces where the absolute path is already part of the failure.
+
+Diagnostics should include timing facts for phase boundaries when cheap and reliable, such as discovery duration, analysis duration, cache load/save duration, Graph Query duration, and plugin hook duration.
+
+Multi-event operations should include a stable `operationId` or `requestId` so interleaved diagnostics can be correlated across indexing, Graph Cache Sync, Graph Query, CLI commands, MCP tool calls, and extension analysis requests.
+
+Operation-start diagnostics may include compact behavior-shaping snapshots, such as enabled plugin ids/packages, disabled plugin ids, Graph Scope counts, and filter counts. Diagnostics should not dump complete settings objects.
+
+Important existing errors and warnings should be wrapped with structured diagnostic context when diagnostics are enabled, while preserving the existing error or warning behavior.
+
+Verbose diagnostics should remain high-signal. Prefer operation boundaries, state transitions, decisions, summaries, timings, and structured error context. Avoid repeated hot-loop logs, per-node/per-edge/per-file chatter, and raw dumps that bury the actual failure signal.
+
+## External Patterns Reviewed
+
+- `debug` uses scoped namespaces and sends debug output to stderr by default, which supports targeted verbosity without corrupting normal stdout.
+- npm separates command output from debug logs and treats verbose/timing information as diagnostic support material, not the primary command result.
+- curl writes verbose transfer diagnostics to stderr and has separate mechanisms for structured transfer facts.
+- Git distinguishes human output from stable porcelain output, which reinforces that CodeGraphy CLI diagnostics must not destabilize parseable stdout.
+- OpenTelemetry semantic conventions reinforce stable attribute names and event identity instead of prose-only logs.
+
+## Signal Budget
+
+Verbose diagnostics should answer "what happened, in what order, with what inputs and counts" without trying to narrate every internal step.
+
+Emit diagnostics for:
+
+- operation start/end/failure
+- cache status, load, freshness, invalidation, save, and sync decisions
+- workspace path resolution
+- discovery, analysis, graph projection, Graph Query, and graph publication boundaries
+- plugin selection, initialization, lifecycle hooks, skipped plugins, and plugin failures
+- settings or scope facts that materially affect an operation
+- existing important errors/warnings with added operation and context facts
+
+Avoid diagnostics for:
+
+- every file analyzed unless a bounded sample is explicitly needed for a failure
+- every node, edge, relationship, symbol, render tick, pointer event, or progress increment
+- complete settings objects, file contents, AST data, Graph Cache row data, or raw graph payloads
+- speculative explanations or suggested next actions
+
+## Implementation Plan
+
+1. Settings contract and persistence
+   - Add `verboseDiagnostics: boolean` to `ICodeGraphyRepoSettings`.
+   - Add default `verboseDiagnostics: false` in `createDefaultCodeGraphyRepoSettings`.
+   - Add the key to persisted-shape allowlisting.
+   - Add the key to settings snapshots/reset behavior.
+   - Add webview-to-extension and extension-to-webview messages for setting updates.
+   - Add store state and setters so the webview can render and immediately reflect the persisted value.
+
+2. Performance toggle UI
+   - Add a compact row to `PerformanceSection`.
+   - Use the existing `Switch` and `Label` pattern.
+   - Label the toggle `Verbose Diagnostics`.
+   - Post an update message immediately when the switch changes.
+
+3. Diagnostic logger
+   - Add a small Core Package diagnostic event contract, for example `{ area, event, context }`.
+   - Use stable `area` and `event` values; do not make prose messages the only event identity.
+   - Enforce or normalize JSON-serializable context.
+   - Normalize workspace paths to workspace-relative paths where possible.
+   - Include operation/request ids for multi-event operations.
+   - Add adapter-side renderers for Extension, CLI, and MCP.
+   - Adapter renderers should accept an enabled predicate so toggling or flags take effect immediately where the interface supports it.
+   - Keep diagnostics inert when disabled.
+   - Use `[CodeGraphy][Diagnostics]` as the fixed prefix.
+   - Prefer typed helper functions for consistent area/event/context fields instead of open-ended console calls.
+
+4. Core Package diagnostic hooks
+   - Extend Core Package indexing/logging options with an optional diagnostic callback or logger.
+   - Keep the Core Package independent of VS Code APIs.
+   - Emit diagnostics at Core Package lifecycle boundaries:
+     - workspace index start/end
+     - changed-file refresh start/end
+     - plugin registry creation and plugin initialization summary
+     - file discovery start/end and limit reached
+     - file analysis start/end with cache hit/miss summary
+     - pre/post analysis hooks and files-changed hook summaries
+     - Graph Cache status/load/save decisions
+     - cheap/reliable duration facts for discovery, analysis, cache, query, and plugin hook phases
+     - compact behavior-shaping snapshots at operation start
+   - Have each Core Package adapter pass its own gated diagnostic sink into Core Package calls.
+
+5. CodeGraphy CLI diagnostics
+   - Add a global CLI activation path for Core Package diagnostics: `--verbose`, accepted consistently by every command.
+   - Keep this as a single on/off verbose mode; do not add multiple CLI verbosity levels.
+   - Do not read the persisted `verboseDiagnostics` setting as an implicit CLI verbose trigger.
+   - Keep ordinary command output stable. For commands that currently write JSON to stdout, diagnostic text should not be written to stdout.
+   - Prefer stderr for human-readable diagnostic lines or an explicit structured diagnostic field only when the command already returns structured output and callers can tolerate the schema.
+   - Cover command parsing, workspace path resolution, status/cache/plugin-management boundaries, and `codegraphy index` lifecycle decisions.
+   - Keep CLI verbose diagnostics factual only.
+
+6. CodeGraphy MCP diagnostics
+   - Add an MCP activation path for Core Package diagnostics that does not rely on process stderr being visible to clients.
+   - Add `verboseDiagnostics?: boolean` consistently to every MCP tool.
+   - Keep this as a single boolean verbose mode.
+   - Do not read the persisted `verboseDiagnostics` setting as an implicit MCP verbose trigger.
+   - Keep default tool results unchanged when diagnostics are disabled.
+   - Ensure `codegraphy_index` can return diagnostics for Core indexing/cache/plugin decisions when requested.
+   - Query tools should expose Graph Cache read and Graph Query diagnostics when requested, even if their trace is shorter than indexing diagnostics.
+   - Optimize MCP diagnostics for factual agent context:
+     - workspace path actually used
+     - Graph Cache state and stale reasons
+     - Core Package phases that ran
+     - counts for discovered/analyzed/returned items
+     - plugin ids/packages considered, loaded, skipped, or errored
+     - Graph Scope, Filter, Search, pagination, and query decisions that affected result size
+   - Do not include suggested next actions or prescriptive guidance in MCP diagnostics.
+
+7. VS Code Extension diagnostics
+   - Emit diagnostics for extension activation and provider construction.
+   - Emit diagnostics for Graph View resolve, webview ready, first workspace ready, and message routing for lifecycle-level messages.
+   - Emit diagnostics for analysis requests:
+     - requested mode: load/analyze/index/refresh/incremental
+     - stale/aborted request decisions
+     - background Graph Cache Sync start/end/failure
+     - Graph Cache freshness/missing/stale decisions
+     - compact settings, Graph Scope, plugin, and filter counts that affect the request
+     - graph publication counts before sending `GRAPH_DATA_UPDATED`
+   - Emit diagnostics for plugin toggles, reload/sync, contribution refreshes, and plugin status summaries.
+   - Pass the same enabled diagnostic sink into Core Package calls made by the extension.
+
+8. Webview diagnostics
+   - Keep the primary target as VS Code Developer Tools.
+   - Log webview-side lifecycle and signal events that are visible only in the webview runtime:
+     - received bootstrap/settings/graph-data messages
+     - graph runtime state transitions
+     - graph render readiness and graph mode changes
+   - Gate webview logs from the same persisted setting delivered in the normal settings/bootstrap flow.
+
+9. User-facing troubleshooting docs
+   - Add or update troubleshooting copy describing the support workflow:
+     - open Settings > Performance
+     - enable Verbose Diagnostics
+     - reload VS Code if startup logs are needed
+     - open Developer Tools
+     - reproduce the issue
+     - copy `[CodeGraphy][Diagnostics]` logs into the bug report
+   - Add CLI troubleshooting copy for `codegraphy ... --verbose` or the final chosen CLI flag.
+   - Add MCP troubleshooting copy showing how an agent should request verbose diagnostics and where to find returned diagnostic entries.
+   - Use the name **Verbose Diagnostics** consistently in docs.
+
+10. Tests
+   - Settings persistence:
+     - default value is false
+     - update message persists `verboseDiagnostics` to `.codegraphy/settings.json`
+     - manual settings reload or reset broadcasts the value back to the webview
+   - UI:
+     - Performance toggle renders from store state
+     - toggling posts the correct update message
+   - Logger:
+     - disabled logger emits nothing
+     - enabled logger emits the fixed prefix and context
+     - enabled logger keeps context JSON-serializable
+     - important errors/warnings are wrapped with structured context without suppressing existing behavior
+     - hot-loop/per-item diagnostics are aggregated or omitted
+   - Core Package:
+     - diagnostic callbacks fire for index/discovery/plugin/cache boundaries without importing VS Code
+   - CLI:
+     - verbose mode emits diagnostics to the intended non-stdout sink
+     - JSON stdout remains parseable when verbose diagnostics are enabled
+     - default mode remains quiet
+   - MCP:
+     - default tool responses remain unchanged
+     - verbose diagnostic requests include Core Package diagnostics in the intended response shape
+     - MCP stdio transport is not polluted by ad hoc console output
+   - Extension lifecycle:
+     - representative analysis/cache/plugin lifecycle diagnostics are gated by the setting
+   - Webview:
+     - representative message/runtime diagnostics are gated by the setting
+
+11. Validation
+   - Run targeted tests while iterating.
+   - Run relevant extension and Core Package test filters.
+   - Run lint and typecheck before finishing.
+   - Add a detailed changeset for the user-facing behavior change.
+   - The changeset should describe what was added and how to use Verbose Diagnostics through the UI, CLI `--verbose`, and MCP `verboseDiagnostics`.
+
+## Files Likely To Change
+
+- `CONTEXT.md`
+- `docs/agents/trello-165-dev-mode-diagnostics-plan.md`
+- `packages/core/src/indexing/*`
+- `packages/core/src/cli/*`
+- `packages/core/src/analysis/*`
+- `packages/core/src/plugins/*`
+- `packages/core/src/graphCache/*`
+- `packages/mcp/src/mcp/*`
+- `packages/extension/src/extension/repoSettings/*`
+- `packages/extension/src/extension/graphView/*`
+- `packages/extension/src/extension/pipeline/*`
+- `packages/extension/src/shared/protocol/*`
+- `packages/extension/src/shared/settings/*`
+- `packages/extension/src/webview/store/*`
+- `packages/extension/src/webview/components/settingsPanel/performance/*`
+- `packages/extension/src/webview/*`
+- `packages/extension/tests/**`
+- `packages/core/tests/**`
+- troubleshooting docs or README
+- `.changeset/*`

--- a/packages/core/src/cli/command.ts
+++ b/packages/core/src/cli/command.ts
@@ -3,10 +3,15 @@ import { runPluginsCommand } from './plugins/command';
 import { runSetupCommand } from './setup/command';
 import { runStatusCommand } from './status/command';
 import type { CliCommand } from './parse';
+import { createDiagnosticEvent, formatDiagnosticEventLine } from '../diagnostics/events';
 
 export interface CommandExecutionResult {
   exitCode: number;
   output: string;
+}
+
+export interface CliCommandDependencies {
+  writeDiagnostic?(line: string): void;
 }
 
 function createHelpResult(): CommandExecutionResult {
@@ -24,18 +29,65 @@ function createHelpResult(): CommandExecutionResult {
   };
 }
 
-export async function runCliCommand(command: CliCommand): Promise<CommandExecutionResult> {
+function emitCliDiagnostic(
+  command: CliCommand,
+  dependencies: CliCommandDependencies,
+  event: string,
+  context: Record<string, unknown>,
+): void {
+  if (!command.verbose) {
+    return;
+  }
+
+  const writeDiagnostic = dependencies.writeDiagnostic ?? ((line: string) => {
+    process.stderr.write(`${line}\n`);
+  });
+  writeDiagnostic(formatDiagnosticEventLine(createDiagnosticEvent({
+    area: 'cli',
+    event,
+    context,
+  })));
+}
+
+function createCommandContext(command: CliCommand): Record<string, unknown> {
+  return {
+    command: command.name,
+    ...(command.action ? { action: command.action } : {}),
+    ...(command.packageName ? { packageName: command.packageName } : {}),
+    ...(command.packageRoot ? { packageRoot: command.packageRoot } : {}),
+    ...(command.workspacePath ? { workspacePath: command.workspacePath } : {}),
+  };
+}
+
+export async function runCliCommand(
+  command: CliCommand,
+  dependencies: CliCommandDependencies = {},
+): Promise<CommandExecutionResult> {
+  emitCliDiagnostic(command, dependencies, 'command-started', createCommandContext(command));
+  let result: CommandExecutionResult;
+
   switch (command.name) {
     case 'setup':
-      return runSetupCommand();
+      result = runSetupCommand();
+      break;
     case 'status':
-      return runStatusCommand(command.workspacePath);
+      result = runStatusCommand(command.workspacePath);
+      break;
     case 'index':
-      return runIndexCommand(command.workspacePath);
+      result = await runIndexCommand(command.workspacePath);
+      break;
     case 'plugins':
-      return runPluginsCommand(command);
+      result = await runPluginsCommand(command);
+      break;
     case 'help':
     default:
-      return createHelpResult();
+      result = createHelpResult();
   }
+
+  emitCliDiagnostic(command, dependencies, 'command-completed', {
+    command: command.name,
+    exitCode: result.exitCode,
+  });
+
+  return result;
 }

--- a/packages/core/src/cli/command.ts
+++ b/packages/core/src/cli/command.ts
@@ -39,9 +39,13 @@ function emitCliDiagnostic(
     return;
   }
 
-  const writeDiagnostic = dependencies.writeDiagnostic ?? ((line: string) => {
+  const writeDiagnostic = (line: string): void => {
+    if (dependencies.writeDiagnostic) {
+      dependencies.writeDiagnostic(line);
+      return;
+    }
     process.stderr.write(`${line}\n`);
-  });
+  };
   writeDiagnostic(formatDiagnosticEventLine(createDiagnosticEvent({
     area: 'cli',
     event,
@@ -73,13 +77,13 @@ export async function runCliCommand(
     case 'status':
       result = runStatusCommand(command.workspacePath, undefined, {
         verbose: command.verbose,
-        writeDiagnostic: dependencies.writeDiagnostic,
+        ...(dependencies.writeDiagnostic ? { writeDiagnostic: line => dependencies.writeDiagnostic?.(line) } : {}),
       });
       break;
     case 'index':
       result = await runIndexCommand(command.workspacePath, undefined, {
         verbose: command.verbose,
-        writeDiagnostic: dependencies.writeDiagnostic,
+        ...(dependencies.writeDiagnostic ? { writeDiagnostic: line => dependencies.writeDiagnostic?.(line) } : {}),
       });
       break;
     case 'plugins':

--- a/packages/core/src/cli/command.ts
+++ b/packages/core/src/cli/command.ts
@@ -74,7 +74,10 @@ export async function runCliCommand(
       result = runStatusCommand(command.workspacePath);
       break;
     case 'index':
-      result = await runIndexCommand(command.workspacePath);
+      result = await runIndexCommand(command.workspacePath, undefined, {
+        verbose: command.verbose,
+        writeDiagnostic: dependencies.writeDiagnostic,
+      });
       break;
     case 'plugins':
       result = await runPluginsCommand(command);

--- a/packages/core/src/cli/command.ts
+++ b/packages/core/src/cli/command.ts
@@ -71,7 +71,10 @@ export async function runCliCommand(
       result = runSetupCommand();
       break;
     case 'status':
-      result = runStatusCommand(command.workspacePath);
+      result = runStatusCommand(command.workspacePath, undefined, {
+        verbose: command.verbose,
+        writeDiagnostic: dependencies.writeDiagnostic,
+      });
       break;
     case 'index':
       result = await runIndexCommand(command.workspacePath, undefined, {

--- a/packages/core/src/cli/index/command.ts
+++ b/packages/core/src/cli/index/command.ts
@@ -39,9 +39,17 @@ export async function runIndexCommand(
   const diagnostics: DiagnosticEventSink | undefined = options.verbose
     ? {
         emit(event: DiagnosticEvent): void {
-          const writeDiagnostic = options.writeDiagnostic ?? dependencies.writeDiagnostic ?? ((line: string) => {
+          const writeDiagnostic = (line: string): void => {
+            if (options.writeDiagnostic) {
+              options.writeDiagnostic(line);
+              return;
+            }
+            if (dependencies.writeDiagnostic) {
+              dependencies.writeDiagnostic(line);
+              return;
+            }
             process.stderr.write(`${line}\n`);
-          });
+          };
           writeDiagnostic(formatDiagnosticEventLine(event));
         },
       }

--- a/packages/core/src/cli/index/command.ts
+++ b/packages/core/src/cli/index/command.ts
@@ -1,12 +1,20 @@
 import { requestCodeGraphyIndexWorkspace } from '../../workspace/requestIndexing';
 import { resolveCodeGraphyWorkspacePath } from '../../workspace/requestPaths';
 import type { IndexWorkspaceResult, WorkspacePathInput } from '../../workspace/requestTypes';
+import type { DiagnosticEvent, DiagnosticEventSink } from '../../diagnostics/events';
+import { formatDiagnosticEventLine } from '../../diagnostics/events';
 import type { CommandExecutionResult } from '../command';
 
 interface IndexCommandDependencies {
   cwd(): string;
   indexWorkspace(input: WorkspacePathInput): Promise<IndexWorkspaceResult>;
+  writeDiagnostic?(line: string): void;
   writeStatus(message: string): void;
+}
+
+interface IndexCommandOptions {
+  verbose?: boolean;
+  writeDiagnostic?(line: string): void;
 }
 
 const DEFAULT_DEPENDENCIES: IndexCommandDependencies = {
@@ -24,10 +32,24 @@ function renderCommandResult(result: Record<string, unknown>): string {
 export async function runIndexCommand(
   workspacePath?: string,
   dependencies: IndexCommandDependencies = DEFAULT_DEPENDENCIES,
+  options: IndexCommandOptions = {},
 ): Promise<CommandExecutionResult> {
   const resolvedWorkspaceRoot = resolveCodeGraphyWorkspacePath(workspacePath, dependencies.cwd());
   dependencies.writeStatus(`CodeGraphy indexing started for ${resolvedWorkspaceRoot}...`);
-  const result = await dependencies.indexWorkspace({ workspacePath: resolvedWorkspaceRoot });
+  const diagnostics: DiagnosticEventSink | undefined = options.verbose
+    ? {
+        emit(event: DiagnosticEvent): void {
+          const writeDiagnostic = options.writeDiagnostic ?? dependencies.writeDiagnostic ?? ((line: string) => {
+            process.stderr.write(`${line}\n`);
+          });
+          writeDiagnostic(formatDiagnosticEventLine(event));
+        },
+      }
+    : undefined;
+  const result = await dependencies.indexWorkspace({
+    workspacePath: resolvedWorkspaceRoot,
+    ...(diagnostics ? { diagnostics } : {}),
+  });
 
   return {
     exitCode: 0,

--- a/packages/core/src/cli/parse.ts
+++ b/packages/core/src/cli/parse.ts
@@ -9,22 +9,49 @@ export type {
   PluginsCommandAction,
 } from './parseTypes';
 
+function readGlobalFlags(argv: string[]): { positional: string[]; verbose: boolean } {
+  const positional: string[] = [];
+  let verbose = false;
+
+  for (const arg of argv) {
+    if (arg === '--verbose') {
+      verbose = true;
+      continue;
+    }
+
+    positional.push(arg);
+  }
+
+  return { positional, verbose };
+}
+
+function withGlobalFlags(command: CliCommand, verbose: boolean): CliCommand {
+  return verbose ? { ...command, verbose } : command;
+}
+
 export function parseCliCommand(argv: string[]): CliCommand {
-  const [name, ...rest] = argv;
+  const { positional, verbose } = readGlobalFlags(argv);
+  const [name, ...rest] = positional;
 
   if (isHelpCommandName(name)) {
-    return { name: 'help' };
+    return withGlobalFlags({ name: 'help' }, verbose);
   }
 
+  let command: CliCommand;
   switch (name) {
     case 'setup':
-      return { name: 'setup' };
+      command = { name: 'setup' };
+      break;
     case 'index':
     case 'status':
-      return parseWorkspaceCommand(name, rest);
+      command = parseWorkspaceCommand(name, rest);
+      break;
     case 'plugins':
-      return parsePluginsCommand(rest);
+      command = parsePluginsCommand(rest);
+      break;
     default:
-      return { name: 'help' };
+      command = { name: 'help' };
   }
+
+  return withGlobalFlags(command, verbose);
 }

--- a/packages/core/src/cli/parseTypes.ts
+++ b/packages/core/src/cli/parseTypes.ts
@@ -6,5 +6,6 @@ export interface CliCommand {
   action?: PluginsCommandAction;
   packageName?: string;
   packageRoot?: string;
+  verbose?: boolean;
   workspacePath?: string;
 }

--- a/packages/core/src/cli/status/command.ts
+++ b/packages/core/src/cli/status/command.ts
@@ -30,9 +30,17 @@ export function runStatusCommand(
   const diagnostics: DiagnosticEventSink | undefined = options.verbose
     ? {
         emit(event: DiagnosticEvent): void {
-          const writeDiagnostic = options.writeDiagnostic ?? dependencies.writeDiagnostic ?? ((line: string) => {
+          const writeDiagnostic = (line: string): void => {
+            if (options.writeDiagnostic) {
+              options.writeDiagnostic(line);
+              return;
+            }
+            if (dependencies.writeDiagnostic) {
+              dependencies.writeDiagnostic(line);
+              return;
+            }
             process.stderr.write(`${line}\n`);
-          });
+          };
           writeDiagnostic(formatDiagnosticEventLine(event));
         },
       }

--- a/packages/core/src/cli/status/command.ts
+++ b/packages/core/src/cli/status/command.ts
@@ -1,4 +1,6 @@
 import type { CommandExecutionResult } from '../command';
+import type { DiagnosticEvent, DiagnosticEventSink } from '../../diagnostics/events';
+import { formatDiagnosticEventLine } from '../../diagnostics/events';
 import { resolveCodeGraphyWorkspacePath } from '../../workspace/requestPaths';
 import { readCodeGraphyWorkspaceStatusForCli } from '../../workspace/requestStatus';
 import type { WorkspacePathInput, WorkspaceStatusResult } from '../../workspace/requestTypes';
@@ -6,6 +8,12 @@ import type { WorkspacePathInput, WorkspaceStatusResult } from '../../workspace/
 interface StatusCommandDependencies {
   cwd(): string;
   readStatus(input: WorkspacePathInput): WorkspaceStatusResult;
+  writeDiagnostic?(line: string): void;
+}
+
+interface StatusCommandOptions {
+  verbose?: boolean;
+  writeDiagnostic?(line: string): void;
 }
 
 const DEFAULT_DEPENDENCIES: StatusCommandDependencies = {
@@ -16,10 +24,24 @@ const DEFAULT_DEPENDENCIES: StatusCommandDependencies = {
 export function runStatusCommand(
   workspacePath?: string,
   dependencies: StatusCommandDependencies = DEFAULT_DEPENDENCIES,
+  options: StatusCommandOptions = {},
 ): CommandExecutionResult {
   const workspaceRoot = resolveCodeGraphyWorkspacePath(workspacePath, dependencies.cwd());
+  const diagnostics: DiagnosticEventSink | undefined = options.verbose
+    ? {
+        emit(event: DiagnosticEvent): void {
+          const writeDiagnostic = options.writeDiagnostic ?? dependencies.writeDiagnostic ?? ((line: string) => {
+            process.stderr.write(`${line}\n`);
+          });
+          writeDiagnostic(formatDiagnosticEventLine(event));
+        },
+      }
+    : undefined;
   return {
     exitCode: 0,
-    output: JSON.stringify(dependencies.readStatus({ workspacePath: workspaceRoot }), null, 2),
+    output: JSON.stringify(dependencies.readStatus({
+      workspacePath: workspaceRoot,
+      ...(diagnostics ? { diagnostics } : {}),
+    }), null, 2),
   };
 }

--- a/packages/core/src/diagnostics/events.ts
+++ b/packages/core/src/diagnostics/events.ts
@@ -1,0 +1,104 @@
+export type DiagnosticContextValue =
+  | null
+  | string
+  | number
+  | boolean
+  | DiagnosticContextValue[]
+  | { [key: string]: DiagnosticContextValue };
+
+export interface DiagnosticEvent {
+  area: string;
+  event: string;
+  context?: Record<string, DiagnosticContextValue>;
+}
+
+export interface DiagnosticEventInput {
+  area: string;
+  event: string;
+  context?: Record<string, unknown>;
+}
+
+export interface DiagnosticEventSink {
+  emit(event: DiagnosticEvent): void;
+}
+
+function normalizeError(error: Error): Record<string, DiagnosticContextValue> {
+  return {
+    name: error.name,
+    message: error.message,
+  };
+}
+
+function normalizeContextValue(value: unknown): DiagnosticContextValue {
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return normalizeError(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeContextValue);
+  }
+
+  if (value instanceof Set) {
+    return [...value].map(normalizeContextValue);
+  }
+
+  if (value instanceof Map) {
+    return [...value.entries()].map(([key, entryValue]) => ({
+      key: normalizeContextValue(key),
+      value: normalizeContextValue(entryValue),
+    }));
+  }
+
+  if (typeof value === 'object') {
+    const normalized: Record<string, DiagnosticContextValue> = {};
+    for (const [key, entryValue] of Object.entries(value)) {
+      normalized[key] = normalizeContextValue(entryValue);
+    }
+    return normalized;
+  }
+
+  return String(value);
+}
+
+function normalizeContext(context: Record<string, unknown> | undefined): Record<string, DiagnosticContextValue> | undefined {
+  if (!context) {
+    return undefined;
+  }
+
+  const normalized: Record<string, DiagnosticContextValue> = {};
+  for (const [key, value] of Object.entries(context)) {
+    normalized[key] = normalizeContextValue(value);
+  }
+  return normalized;
+}
+
+export function createDiagnosticEvent(input: DiagnosticEventInput): DiagnosticEvent {
+  return {
+    area: input.area,
+    event: input.event,
+    ...(input.context ? { context: normalizeContext(input.context) } : {}),
+  };
+}
+
+export function collectDiagnosticEvents(enabled: boolean): DiagnosticEventSink & { readonly events: DiagnosticEvent[] } {
+  const events: DiagnosticEvent[] = [];
+  return {
+    get events(): DiagnosticEvent[] {
+      return events;
+    },
+    emit(event: DiagnosticEvent): void {
+      if (enabled) {
+        events.push(event);
+      }
+    },
+  };
+}
+
+export function formatDiagnosticEventLine(event: DiagnosticEvent): string {
+  const context = event.context ? ` ${JSON.stringify(event.context)}` : '';
+  return `[CodeGraphy][Diagnostics] ${event.area} ${event.event}${context}`;
+}

--- a/packages/core/src/diagnostics/events.ts
+++ b/packages/core/src/diagnostics/events.ts
@@ -61,7 +61,23 @@ function normalizeContextValue(value: unknown): DiagnosticContextValue {
     return normalized;
   }
 
-  return String(value);
+  if (typeof value === 'undefined') {
+    return 'undefined';
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'symbol') {
+    return value.description ? `Symbol(${value.description})` : 'Symbol()';
+  }
+
+  if (typeof value === 'function') {
+    return value.name ? `[Function: ${value.name}]` : '[Function]';
+  }
+
+  return 'unknown';
 }
 
 function normalizeContext(context: Record<string, unknown> | undefined): Record<string, DiagnosticContextValue> | undefined {

--- a/packages/core/src/diagnostics/events.ts
+++ b/packages/core/src/diagnostics/events.ts
@@ -114,7 +114,238 @@ export function collectDiagnosticEvents(enabled: boolean): DiagnosticEventSink &
   };
 }
 
+function formatCount(value: DiagnosticContextValue | undefined, noun: string): string | undefined {
+  if (typeof value !== 'number') {
+    return undefined;
+  }
+  return `${value} ${noun}${value === 1 ? '' : 's'}`;
+}
+
+function formatScalar(value: DiagnosticContextValue | undefined): string | undefined {
+  if (value === null || typeof value === 'undefined') {
+    return undefined;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}
+
+function formatContextDetail(
+  context: Record<string, DiagnosticContextValue> | undefined,
+  key: string,
+  label: string = key,
+): string | undefined {
+  const value = formatScalar(context?.[key]);
+  return value ? `${label}=${value}` : undefined;
+}
+
+function joinDetails(details: Array<string | undefined>): string {
+  return details.filter((detail): detail is string => Boolean(detail)).join(', ');
+}
+
+function formatStatusRead(context: Record<string, DiagnosticContextValue> | undefined): string {
+  const state = formatScalar(context?.state);
+  const cacheDescription = state ? `${state} Graph Cache` : 'Graph Cache';
+  const details = joinDetails([
+    formatContextDetail(context, 'workspaceRoot', 'workspace'),
+    formatContextDetail(context, 'graphCache', 'cache'),
+    formatContextDetail(context, 'enabledPluginCount', 'plugins'),
+  ]);
+  return details
+    ? `Workspace status read: ${cacheDescription}, ${details}`
+    : `Workspace status read: ${cacheDescription}`;
+}
+
+function formatIndexingComplete(context: Record<string, DiagnosticContextValue> | undefined): string {
+  const counts = joinDetails([
+    formatCount(context?.files, 'file'),
+    formatCount(context?.nodes, 'node'),
+    formatCount(context?.edges, 'edge'),
+  ]);
+  const details = joinDetails([
+    counts,
+    formatContextDetail(context, 'durationMs', 'durationMs'),
+    formatContextDetail(context, 'operationId', 'operation'),
+    formatContextDetail(context, 'graphCache', 'cache'),
+  ]);
+  return details ? `Indexing complete: ${details}` : 'Indexing complete';
+}
+
+function formatCommandEvent(
+  event: string,
+  context: Record<string, DiagnosticContextValue> | undefined,
+): string | undefined {
+  const command = formatScalar(context?.command);
+  if (event === 'command-started') {
+    const details = joinDetails([
+      command,
+      formatContextDetail(context, 'action'),
+      formatContextDetail(context, 'workspacePath', 'workspace'),
+    ]);
+    return details ? `Starting command: ${details}` : 'Starting command';
+  }
+
+  if (event === 'command-completed') {
+    const details = joinDetails([
+      command,
+      formatContextDetail(context, 'exitCode'),
+    ]);
+    return details ? `Command complete: ${details}` : 'Command complete';
+  }
+
+  return undefined;
+}
+
+function formatAnalysisEvent(
+  event: string,
+  context: Record<string, DiagnosticContextValue> | undefined,
+): string | undefined {
+  if (event === 'request-started') {
+    return `Starting analysis: ${joinDetails([
+      formatContextDetail(context, 'requestId', 'request'),
+      formatContextDetail(context, 'mode'),
+      formatContextDetail(context, 'filterPatternCount', 'filters'),
+      formatContextDetail(context, 'disabledPluginCount', 'disabledPlugins'),
+    ])}`;
+  }
+
+  if (event === 'request-completed') {
+    return `Analysis complete: ${joinDetails([
+      formatContextDetail(context, 'requestId', 'request'),
+      formatContextDetail(context, 'mode'),
+      formatContextDetail(context, 'durationMs', 'durationMs'),
+    ])}`;
+  }
+
+  if (event === 'request-failed') {
+    return `Analysis failed: ${joinDetails([
+      formatContextDetail(context, 'requestId', 'request'),
+      formatContextDetail(context, 'mode'),
+      formatContextDetail(context, 'durationMs', 'durationMs'),
+      formatContextDetail(context, 'error'),
+    ])}`;
+  }
+
+  if (event === 'load-decision') {
+    return `Analysis load decision: ${joinDetails([
+      formatContextDetail(context, 'route'),
+      formatContextDetail(context, 'mode'),
+      formatContextDetail(context, 'shouldDiscover'),
+      formatContextDetail(context, 'canReplayCache'),
+      formatContextDetail(context, 'indexFreshness', 'freshness'),
+    ])}`;
+  }
+
+  return undefined;
+}
+
+function formatKnownEvent(event: DiagnosticEvent): string | undefined {
+  const context = event.context;
+
+  if (event.area === 'cli') {
+    return formatCommandEvent(event.event, context);
+  }
+
+  if (event.area === 'workspace' && event.event === 'index-started') {
+    return `Starting indexing: ${joinDetails([
+      formatContextDetail(context, 'workspaceRoot', 'workspace'),
+      formatContextDetail(context, 'operationId', 'operation'),
+    ])}`;
+  }
+
+  if (event.area === 'workspace' && event.event === 'status-read') {
+    return formatStatusRead(context);
+  }
+
+  if (event.area === 'indexing' && event.event === 'completed') {
+    return formatIndexingComplete(context);
+  }
+
+  if (event.area === 'graph-query' && event.event === 'started') {
+    return `Starting Graph Query: ${joinDetails([
+      formatContextDetail(context, 'report'),
+      formatContextDetail(context, 'operationId', 'operation'),
+      formatContextDetail(context, 'workspaceRoot', 'workspace'),
+    ])}`;
+  }
+
+  if (event.area === 'graph-query' && event.event === 'cache-missing') {
+    return `Graph Cache missing: ${joinDetails([
+      formatContextDetail(context, 'report'),
+      formatContextDetail(context, 'cacheState'),
+      formatContextDetail(context, 'operationId', 'operation'),
+      formatContextDetail(context, 'workspaceRoot', 'workspace'),
+    ])}`;
+  }
+
+  if (event.area === 'graph-query' && event.event === 'completed') {
+    return `Graph Query complete: ${joinDetails([
+      formatContextDetail(context, 'report'),
+      formatCount(context?.nodeCount, 'node'),
+      formatCount(context?.edgeCount, 'edge'),
+      formatContextDetail(context, 'durationMs', 'durationMs'),
+      formatContextDetail(context, 'operationId', 'operation'),
+    ])}`;
+  }
+
+  if (event.area === 'extension.lifecycle' && event.event === 'activation-started') {
+    return `Extension activation started: ${joinDetails([
+      formatContextDetail(context, 'workspaceFolders'),
+    ])}`;
+  }
+
+  if (event.area === 'extension.lifecycle' && event.event === 'activation-completed') {
+    return `Extension activation complete: ${joinDetails([
+      formatContextDetail(context, 'registeredWebviewProviders'),
+    ])}`;
+  }
+
+  if (event.area === 'extension.webview' && event.event === 'ready-replayed') {
+    return `Webview ready replayed: ${joinDetails([
+      formatContextDetail(context, 'hasWorkspace'),
+      formatContextDetail(context, 'firstAnalysis'),
+      formatContextDetail(context, 'readyNotified'),
+      formatContextDetail(context, 'maxFiles'),
+    ])}`;
+  }
+
+  if (event.area === 'extension.webview' && event.event === 'bootstrap-completed') {
+    return `Webview bootstrap complete: ${joinDetails([
+      formatContextDetail(context, 'hasWorkspace'),
+      formatContextDetail(context, 'firstAnalysis'),
+      formatContextDetail(context, 'readyNotified'),
+    ])}`;
+  }
+
+  if (event.area === 'extension.analysis') {
+    return formatAnalysisEvent(event.event, context);
+  }
+
+  return undefined;
+}
+
+function humanizeEventName(event: string): string {
+  return event
+    .split('-')
+    .filter(Boolean)
+    .map((part, index) => index === 0
+      ? `${part.charAt(0).toUpperCase()}${part.slice(1)}`
+      : part)
+    .join(' ');
+}
+
+function formatFallbackEvent(event: DiagnosticEvent): string {
+  const details = joinDetails([
+    formatContextDetail({ area: event.area }, 'area'),
+    ...Object.keys(event.context ?? {}).map(key => formatContextDetail(event.context, key)),
+  ]);
+  const message = humanizeEventName(event.event);
+  return details ? `${message}: ${details}` : message;
+}
+
 export function formatDiagnosticEventLine(event: DiagnosticEvent): string {
-  const context = event.context ? ` ${JSON.stringify(event.context)}` : '';
-  return `[CodeGraphy][Diagnostics] ${event.area} ${event.event}${context}`;
+  return `[CodeGraphy] ${formatKnownEvent(event) ?? formatFallbackEvent(event)}`;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,17 @@ export type { CommandExecutionResult } from './cli/command';
 export { runCliCommand } from './cli/command';
 export type { CliCommand, CliCommandName, PluginsCommandAction } from './cli/parse';
 export { parseCliCommand } from './cli/parse';
+export type {
+  DiagnosticContextValue,
+  DiagnosticEvent,
+  DiagnosticEventInput,
+  DiagnosticEventSink,
+} from './diagnostics/events';
+export {
+  collectDiagnosticEvents,
+  createDiagnosticEvent,
+  formatDiagnosticEventLine,
+} from './diagnostics/events';
 export { runIndexCommand } from './cli/index/command';
 export { runPluginsCommand } from './cli/plugins/command';
 export { runSetupCommand } from './cli/setup/command';

--- a/packages/core/src/workspace/requestIndexing.ts
+++ b/packages/core/src/workspace/requestIndexing.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { createDiagnosticEvent } from '../diagnostics/events';
 import { indexCodeGraphyWorkspace } from '../indexing/workspace';
 import { resolveCodeGraphyWorkspacePath } from './requestPaths';
 import type { IndexWorkspaceResult, WorkspacePathInput } from './requestTypes';
@@ -11,16 +12,45 @@ const DEFAULT_DEPENDENCIES: WorkspaceIndexDependencies = {
   cwd: () => process.cwd(),
 };
 
+let indexOperationCounter = 0;
+
+function createIndexOperationId(): string {
+  indexOperationCounter += 1;
+  return `index-${indexOperationCounter}`;
+}
+
 export async function requestCodeGraphyIndexWorkspace(
   input: WorkspacePathInput,
   dependencies: WorkspaceIndexDependencies = DEFAULT_DEPENDENCIES,
 ): Promise<IndexWorkspaceResult> {
   const workspaceRoot = resolveCodeGraphyWorkspacePath(input.workspacePath, dependencies.cwd());
+  const operationId = createIndexOperationId();
+  input.diagnostics?.emit(createDiagnosticEvent({
+    area: 'workspace',
+    event: 'index-started',
+    context: {
+      operationId,
+      workspaceRoot,
+    },
+  }));
   const result = await indexCodeGraphyWorkspace({ workspaceRoot });
+  const graphCache = path.relative(result.workspaceRoot, result.graphCachePath);
+
+  input.diagnostics?.emit(createDiagnosticEvent({
+    area: 'indexing',
+    event: 'completed',
+    context: {
+      operationId,
+      graphCache,
+      files: result.files.length,
+      nodes: result.graph.nodes.length,
+      edges: result.graph.edges.length,
+    },
+  }));
 
   return {
     workspaceRoot: result.workspaceRoot,
-    graphCache: path.relative(result.workspaceRoot, result.graphCachePath),
+    graphCache,
     message: 'CodeGraphy indexing completed. Query tools can now read the Graph Cache.',
     files: result.files.length,
     nodes: result.graph.nodes.length,

--- a/packages/core/src/workspace/requestQuery.ts
+++ b/packages/core/src/workspace/requestQuery.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import type { IFileAnalysisResult } from '@codegraphy-dev/plugin-api';
+import { createDiagnosticEvent } from '../diagnostics/events';
 import { loadWorkspaceAnalysisDatabaseCache, readWorkspaceAnalysisDatabaseSnapshot } from '../graphCache/database/storage';
 import { buildWorkspaceGraphDataFromAnalysis } from '../graph/data';
 import {
@@ -21,6 +22,13 @@ const DEFAULT_DEPENDENCIES: WorkspaceGraphQueryDependencies = {
   cwd: () => process.cwd(),
 };
 
+let graphQueryOperationCounter = 0;
+
+function createGraphQueryOperationId(): string {
+  graphQueryOperationCounter += 1;
+  return `query-${graphQueryOperationCounter}`;
+}
+
 function collectDirectoryPaths(filePaths: Iterable<string>): string[] {
   const directories = new Set<string>();
 
@@ -39,9 +47,31 @@ export async function requestWorkspaceGraphQuery(
   input: WorkspaceGraphQueryInput,
   dependencies: WorkspaceGraphQueryDependencies = DEFAULT_DEPENDENCIES,
 ): Promise<WorkspaceGraphQueryResult> {
+  const startedAt = performance.now();
   const workspaceRoot = resolveCodeGraphyWorkspacePath(input.workspacePath, dependencies.cwd());
+  const operationId = createGraphQueryOperationId();
+  input.diagnostics?.emit(createDiagnosticEvent({
+    area: 'graph-query',
+    event: 'started',
+    context: {
+      operationId,
+      workspaceRoot,
+      report: input.report,
+    },
+  }));
   const status = readCodeGraphyWorkspaceStatus(workspaceRoot);
   if (!status.hasGraphCache) {
+    input.diagnostics?.emit(createDiagnosticEvent({
+      area: 'graph-query',
+      event: 'cache-missing',
+      context: {
+        operationId,
+        workspaceRoot,
+        report: input.report,
+        cacheState: status.state,
+        staleReasons: status.staleReasons,
+      },
+    }));
     return {
       error: 'graph_cache_not_found',
       message: 'This CodeGraphy Workspace has not been indexed. Run `codegraphy_index`, then retry.',
@@ -65,16 +95,30 @@ export async function requestWorkspaceGraphQuery(
     showOrphans: settings.showOrphans,
     workspaceRoot,
   });
+  const queryResult = executeGraphQuery({
+    graphData,
+    symbols: snapshot.symbols,
+    relations: snapshot.relations,
+  }, {
+    report: input.report,
+    arguments: input.arguments,
+  } as GraphQueryRequest);
+  input.diagnostics?.emit(createDiagnosticEvent({
+    area: 'graph-query',
+    event: 'completed',
+    context: {
+      operationId,
+      report: input.report,
+      cacheState: status.state,
+      staleReasons: status.staleReasons,
+      nodeCount: graphData.nodes.length,
+      edgeCount: graphData.edges.length,
+      durationMs: Math.round(performance.now() - startedAt),
+    },
+  }));
 
   return {
-    ...executeGraphQuery({
-      graphData,
-      symbols: snapshot.symbols,
-      relations: snapshot.relations,
-    }, {
-      report: input.report,
-      arguments: input.arguments,
-    } as GraphQueryRequest),
+    ...queryResult,
     workspaceRoot,
     cacheStatus: {
       state: status.state,

--- a/packages/core/src/workspace/requestStatus.ts
+++ b/packages/core/src/workspace/requestStatus.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path';
+import { createDiagnosticEvent } from '../diagnostics/events';
 import {
   readCodeGraphyWorkspaceSettingsOrInitial,
 } from './settings';
@@ -33,6 +34,18 @@ export function readCodeGraphyWorkspaceStatusForCli(
   const workspaceRoot = resolveCodeGraphyWorkspacePath(input.workspacePath, dependencies.cwd());
   const status = readCodeGraphyWorkspaceStatus(workspaceRoot);
   const settings = readCodeGraphyWorkspaceSettingsOrInitial(workspaceRoot);
+  input.diagnostics?.emit(createDiagnosticEvent({
+    area: 'workspace',
+    event: 'status-read',
+    context: {
+      workspaceRoot: status.workspaceRoot,
+      graphCache: path.relative(status.workspaceRoot, status.graphCachePath),
+      state: status.state,
+      hasGraphCache: status.hasGraphCache,
+      staleReasons: status.staleReasons,
+      enabledPluginCount: settings.plugins.length,
+    },
+  }));
 
   return {
     workspaceRoot: status.workspaceRoot,

--- a/packages/core/src/workspace/requestTypes.ts
+++ b/packages/core/src/workspace/requestTypes.ts
@@ -1,3 +1,5 @@
+import type { DiagnosticEventSink } from '../diagnostics/events';
+
 export type GraphQueryReport =
   | 'nodes'
   | 'edges'
@@ -6,6 +8,7 @@ export type GraphQueryReport =
   | 'paths';
 
 export interface WorkspacePathInput {
+  diagnostics?: DiagnosticEventSink;
   workspacePath?: string;
 }
 

--- a/packages/core/tests/cli/command.test.ts
+++ b/packages/core/tests/cli/command.test.ts
@@ -49,4 +49,25 @@ describe('cli/command', () => {
       '[CodeGraphy][Diagnostics] cli command-completed {"command":"status","exitCode":0}',
     );
   });
+
+  it('forwards verbose diagnostics from workspace indexing', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'codegraphy-cli-diagnostics-'));
+    const diagnostics: string[] = [];
+
+    const result = await runCliCommand(
+      { name: 'index', verbose: true, workspacePath: workspaceRoot },
+      {
+        writeDiagnostic: line => diagnostics.push(line),
+      },
+    );
+
+    expect(JSON.parse(result.output)).toMatchObject({
+      workspaceRoot,
+      graphCache: '.codegraphy/graph.lbug',
+    });
+    expect(diagnostics).toEqual(expect.arrayContaining([
+      expect.stringContaining('[CodeGraphy][Diagnostics] workspace index-started'),
+      expect.stringContaining('[CodeGraphy][Diagnostics] indexing completed'),
+    ]));
+  });
 });

--- a/packages/core/tests/cli/command.test.ts
+++ b/packages/core/tests/cli/command.test.ts
@@ -43,10 +43,10 @@ describe('cli/command', () => {
       workspaceRoot: '/workspace/project',
     });
     expect(diagnostics).toContain(
-      '[CodeGraphy][Diagnostics] cli command-started {"command":"status","workspacePath":"/workspace/project"}',
+      '[CodeGraphy] Starting command: status, workspace=/workspace/project',
     );
     expect(diagnostics).toContain(
-      '[CodeGraphy][Diagnostics] cli command-completed {"command":"status","exitCode":0}',
+      '[CodeGraphy] Command complete: status, exitCode=0',
     );
   });
 
@@ -66,8 +66,8 @@ describe('cli/command', () => {
       graphCache: '.codegraphy/graph.lbug',
     });
     expect(diagnostics).toEqual(expect.arrayContaining([
-      expect.stringContaining('[CodeGraphy][Diagnostics] workspace index-started'),
-      expect.stringContaining('[CodeGraphy][Diagnostics] indexing completed'),
+      expect.stringContaining('[CodeGraphy] Starting indexing:'),
+      expect.stringContaining('[CodeGraphy] Indexing complete:'),
     ]));
   });
 });

--- a/packages/core/tests/cli/command.test.ts
+++ b/packages/core/tests/cli/command.test.ts
@@ -28,4 +28,25 @@ describe('cli/command', () => {
       output: expect.stringContaining('CodeGraphy indexing completed'),
     });
   });
+
+  it('emits verbose diagnostics outside command output', async () => {
+    const diagnostics: string[] = [];
+
+    const result = await runCliCommand(
+      { name: 'status', verbose: true, workspacePath: '/workspace/project' },
+      {
+        writeDiagnostic: line => diagnostics.push(line),
+      },
+    );
+
+    expect(JSON.parse(result.output)).toMatchObject({
+      workspaceRoot: '/workspace/project',
+    });
+    expect(diagnostics).toContain(
+      '[CodeGraphy][Diagnostics] cli command-started {"command":"status","workspacePath":"/workspace/project"}',
+    );
+    expect(diagnostics).toContain(
+      '[CodeGraphy][Diagnostics] cli command-completed {"command":"status","exitCode":0}',
+    );
+  });
 });

--- a/packages/core/tests/cli/index/command.test.ts
+++ b/packages/core/tests/cli/index/command.test.ts
@@ -70,7 +70,7 @@ describe('index/command', () => {
     }, { verbose: true });
 
     expect(diagnosticAreas).toEqual([
-      '[CodeGraphy][Diagnostics] indexing completed {"operationId":"index-1","files":2}',
+      '[CodeGraphy] Indexing complete: 2 files, operation=index-1',
     ]);
   });
 });

--- a/packages/core/tests/cli/index/command.test.ts
+++ b/packages/core/tests/cli/index/command.test.ts
@@ -47,4 +47,30 @@ describe('index/command', () => {
       workspaceRoot: '/workspace/other',
     });
   });
+
+  it('passes verbose diagnostics to the workspace indexing request', async () => {
+    const diagnosticAreas: string[] = [];
+
+    await runIndexCommand('/workspace/other', {
+      cwd: () => '/workspace/project',
+      indexWorkspace: async ({ diagnostics }) => {
+        diagnostics?.emit({
+          area: 'indexing',
+          event: 'completed',
+          context: { operationId: 'index-1', files: 2 },
+        });
+        return {
+          workspaceRoot: '/workspace/other',
+          graphCache: '.codegraphy/graph.lbug',
+          message: 'indexed',
+        };
+      },
+      writeDiagnostic: line => diagnosticAreas.push(line),
+      writeStatus: vi.fn(),
+    }, { verbose: true });
+
+    expect(diagnosticAreas).toEqual([
+      '[CodeGraphy][Diagnostics] indexing completed {"operationId":"index-1","files":2}',
+    ]);
+  });
 });

--- a/packages/core/tests/cli/parse.test.ts
+++ b/packages/core/tests/cli/parse.test.ts
@@ -29,6 +29,30 @@ describe('cli/parse', () => {
     });
   });
 
+  it('parses verbose as a global flag for every command', () => {
+    expect(parseCliCommand(['--verbose', 'index', '/workspace/project'])).toEqual({
+      name: 'index',
+      verbose: true,
+      workspacePath: '/workspace/project',
+    });
+    expect(parseCliCommand(['status', '--verbose', '/workspace/project'])).toEqual({
+      name: 'status',
+      verbose: true,
+      workspacePath: '/workspace/project',
+    });
+    expect(parseCliCommand(['plugins', 'enable', '@codegraphy-dev/plugin-python', '--verbose', '/workspace/project'])).toEqual({
+      name: 'plugins',
+      action: 'enable',
+      packageName: '@codegraphy-dev/plugin-python',
+      verbose: true,
+      workspacePath: '/workspace/project',
+    });
+    expect(parseCliCommand(['--verbose', 'setup'])).toEqual({
+      name: 'setup',
+      verbose: true,
+    });
+  });
+
   it('parses plugin cache and workspace commands', () => {
     expect(parseCliCommand(['plugins', 'register', 'private-plugin'])).toEqual({
       name: 'plugins',

--- a/packages/core/tests/cli/status/command.test.ts
+++ b/packages/core/tests/cli/status/command.test.ts
@@ -49,7 +49,7 @@ describe('status/command', () => {
     }, { verbose: true });
 
     expect(diagnostics).toEqual([
-      '[CodeGraphy][Diagnostics] workspace status-read {"workspaceRoot":"/workspace/project","state":"missing"}',
+      '[CodeGraphy] Workspace status read: missing Graph Cache, workspace=/workspace/project',
     ]);
   });
 });

--- a/packages/core/tests/cli/status/command.test.ts
+++ b/packages/core/tests/cli/status/command.test.ts
@@ -23,4 +23,33 @@ describe('status/command', () => {
       enabledPlugins: ['@codegraphy-dev/plugin-markdown'],
     });
   });
+
+  it('passes verbose diagnostics to the workspace status request', () => {
+    const diagnostics: string[] = [];
+
+    runStatusCommand('/workspace/project', {
+      cwd: () => '/workspace',
+      readStatus: ({ diagnostics: sink }) => {
+        sink?.emit({
+          area: 'workspace',
+          event: 'status-read',
+          context: { workspaceRoot: '/workspace/project', state: 'missing' },
+        });
+        return {
+          workspaceRoot: '/workspace/project',
+          graphCache: '.codegraphy/graph.lbug',
+          state: 'missing',
+          hasGraphCache: false,
+          staleReasons: ['never-indexed'],
+          enabledPlugins: ['@codegraphy-dev/plugin-markdown'],
+          message: 'missing',
+        };
+      },
+      writeDiagnostic: line => diagnostics.push(line),
+    }, { verbose: true });
+
+    expect(diagnostics).toEqual([
+      '[CodeGraphy][Diagnostics] workspace status-read {"workspaceRoot":"/workspace/project","state":"missing"}',
+    ]);
+  });
 });

--- a/packages/core/tests/diagnostics/events.test.ts
+++ b/packages/core/tests/diagnostics/events.test.ts
@@ -44,15 +44,17 @@ describe('diagnostics/events', () => {
     expect(disabled.events).toEqual([]);
   });
 
-  it('formats events with a stable prefix, area, event, and JSON context', () => {
+  it('formats events as concise human-readable CodeGraphy log lines', () => {
     expect(formatDiagnosticEventLine({
       area: 'indexing',
       event: 'completed',
       context: {
         operationId: 'index-1',
-        nodeCount: 12,
+        files: 4,
+        nodes: 12,
+        edges: 20,
       },
-    })).toBe('[CodeGraphy][Diagnostics] indexing completed {"operationId":"index-1","nodeCount":12}');
+    })).toBe('[CodeGraphy] Indexing complete: 4 files, 12 nodes, 20 edges, operation=index-1');
   });
 
   it('normalizes non-JSON primitive context values into readable strings', () => {

--- a/packages/core/tests/diagnostics/events.test.ts
+++ b/packages/core/tests/diagnostics/events.test.ts
@@ -54,4 +54,30 @@ describe('diagnostics/events', () => {
       },
     })).toBe('[CodeGraphy][Diagnostics] indexing completed {"operationId":"index-1","nodeCount":12}');
   });
+
+  it('normalizes non-JSON primitive context values into readable strings', () => {
+    function namedDiagnosticFunction(): void {
+      // The function name is the diagnostic payload under test.
+    }
+
+    expect(createDiagnosticEvent({
+      area: 'diagnostics',
+      event: 'normalized',
+      context: {
+        missing: undefined,
+        token: Symbol('verbose'),
+        count: 12n,
+        callback: namedDiagnosticFunction,
+      },
+    })).toEqual({
+      area: 'diagnostics',
+      event: 'normalized',
+      context: {
+        missing: 'undefined',
+        token: 'Symbol(verbose)',
+        count: '12',
+        callback: '[Function: namedDiagnosticFunction]',
+      },
+    });
+  });
 });

--- a/packages/core/tests/diagnostics/events.test.ts
+++ b/packages/core/tests/diagnostics/events.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectDiagnosticEvents,
+  createDiagnosticEvent,
+  formatDiagnosticEventLine,
+} from '../../src/diagnostics/events';
+
+describe('diagnostics/events', () => {
+  it('collects JSON-safe diagnostic events only when enabled', () => {
+    const collected = collectDiagnosticEvents(true);
+
+    collected.emit(createDiagnosticEvent({
+      area: 'graph-cache',
+      event: 'load',
+      context: {
+        operationId: 'index-1',
+        workspacePath: '/workspace/project',
+        paths: new Set(['src/a.ts', 'src/b.ts']),
+        error: new Error('cache unavailable'),
+      },
+    }));
+
+    expect(collected.events).toEqual([{
+      area: 'graph-cache',
+      event: 'load',
+      context: {
+        operationId: 'index-1',
+        workspacePath: '/workspace/project',
+        paths: ['src/a.ts', 'src/b.ts'],
+        error: {
+          name: 'Error',
+          message: 'cache unavailable',
+        },
+      },
+    }]);
+
+    const disabled = collectDiagnosticEvents(false);
+    disabled.emit(createDiagnosticEvent({
+      area: 'indexing',
+      event: 'started',
+      context: { operationId: 'index-2' },
+    }));
+
+    expect(disabled.events).toEqual([]);
+  });
+
+  it('formats events with a stable prefix, area, event, and JSON context', () => {
+    expect(formatDiagnosticEventLine({
+      area: 'indexing',
+      event: 'completed',
+      context: {
+        operationId: 'index-1',
+        nodeCount: 12,
+      },
+    })).toBe('[CodeGraphy][Diagnostics] indexing completed {"operationId":"index-1","nodeCount":12}');
+  });
+});

--- a/packages/core/tests/workspace/coreBacked.test.ts
+++ b/packages/core/tests/workspace/coreBacked.test.ts
@@ -75,4 +75,26 @@ describe('core-backed CodeGraphy Workspace commands', () => {
       }),
     ]));
   });
+
+  it('emits factual verbose diagnostics for status requests', async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-status-diagnostics-'));
+    const diagnostics = collectDiagnosticEvents(true);
+
+    readCodeGraphyWorkspaceStatusForCli({
+      workspacePath: workspaceRoot,
+      diagnostics,
+    });
+
+    expect(diagnostics.events).toContainEqual(expect.objectContaining({
+      area: 'workspace',
+      event: 'status-read',
+      context: expect.objectContaining({
+        workspaceRoot,
+        state: 'missing',
+        hasGraphCache: false,
+        staleReasons: ['never-indexed'],
+        enabledPluginCount: 1,
+      }),
+    }));
+  });
 });

--- a/packages/core/tests/workspace/coreBacked.test.ts
+++ b/packages/core/tests/workspace/coreBacked.test.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { collectDiagnosticEvents } from '../../src/diagnostics/events';
 import { requestCodeGraphyIndexWorkspace } from '../../src/workspace/requestIndexing';
 import { requestWorkspaceGraphQuery } from '../../src/workspace/requestQuery';
 import { readCodeGraphyWorkspaceStatusForCli } from '../../src/workspace/requestStatus';
@@ -40,5 +41,38 @@ describe('core-backed CodeGraphy Workspace commands', () => {
         to: 'Target.md',
       }),
     ]);
+  });
+
+  it('emits high-signal verbose diagnostics for indexing requests', async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-diagnostics-workspace-'));
+    await fs.writeFile(path.join(workspaceRoot, 'Home.md'), 'See [[Target.md]].\n', 'utf-8');
+    await fs.writeFile(path.join(workspaceRoot, 'Target.md'), 'Done.\n', 'utf-8');
+    const diagnostics = collectDiagnosticEvents(true);
+
+    await requestCodeGraphyIndexWorkspace({
+      workspacePath: workspaceRoot,
+      diagnostics,
+    });
+
+    expect(diagnostics.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        area: 'workspace',
+        event: 'index-started',
+        context: expect.objectContaining({
+          operationId: expect.any(String),
+          workspaceRoot,
+        }),
+      }),
+      expect.objectContaining({
+        area: 'indexing',
+        event: 'completed',
+        context: expect.objectContaining({
+          operationId: expect.any(String),
+          files: 2,
+          nodes: 2,
+          graphCache: '.codegraphy/graph.lbug',
+        }),
+      }),
+    ]));
   });
 });

--- a/packages/core/tests/workspace/coreBacked.test.ts
+++ b/packages/core/tests/workspace/coreBacked.test.ts
@@ -97,4 +97,42 @@ describe('core-backed CodeGraphy Workspace commands', () => {
       }),
     }));
   });
+
+  it('emits factual verbose diagnostics for graph query requests', async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-query-diagnostics-'));
+    await fs.writeFile(path.join(workspaceRoot, 'Home.md'), 'See [[Target.md]].\n', 'utf-8');
+    await fs.writeFile(path.join(workspaceRoot, 'Target.md'), 'Done.\n', 'utf-8');
+    await requestCodeGraphyIndexWorkspace({ workspacePath: workspaceRoot });
+    const diagnostics = collectDiagnosticEvents(true);
+
+    await requestWorkspaceGraphQuery({
+      workspacePath: workspaceRoot,
+      report: 'edges',
+      arguments: { from: 'Home.md' },
+      diagnostics,
+    });
+
+    expect(diagnostics.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        area: 'graph-query',
+        event: 'started',
+        context: expect.objectContaining({
+          operationId: expect.any(String),
+          workspaceRoot,
+          report: 'edges',
+        }),
+      }),
+      expect.objectContaining({
+        area: 'graph-query',
+        event: 'completed',
+        context: expect.objectContaining({
+          operationId: expect.any(String),
+          report: 'edges',
+          cacheState: 'fresh',
+          nodeCount: 2,
+          edgeCount: 1,
+        }),
+      }),
+    ]));
+  });
 });

--- a/packages/extension/src/extension/actions/resetSettings.ts
+++ b/packages/extension/src/extension/actions/resetSettings.ts
@@ -37,6 +37,7 @@ const CONFIG_TO_SNAPSHOT: Record<string, keyof ISettingsSnapshot> = {
   particleSize: 'particleSize',
   showLabels: 'showLabels',
   maxFiles: 'maxFiles',
+  verboseDiagnostics: 'verboseDiagnostics',
 };
 
 /** Repo settings key for node size mode */

--- a/packages/extension/src/extension/activate.ts
+++ b/packages/extension/src/extension/activate.ts
@@ -7,6 +7,8 @@ import { registerEditorChangeHandler } from './workspaceFiles/editorSync';
 import { registerFileWatcher, registerSaveHandler } from './workspaceFiles/refresh/watchers';
 import { createCodeGraphyAgentUriHandler } from './agentBridge/uri';
 import type { GraphQueryRequest, GraphQueryResult } from '@codegraphy-dev/core';
+import { getCodeGraphyConfiguration } from './repoSettings/current';
+import { createExtensionDiagnosticLogger } from './diagnostics/logger';
 import type { IGraphData } from '../shared/graph/contracts';
 import type { WebviewToExtensionMessage } from '../shared/protocol/webviewToExtension';
 
@@ -34,6 +36,14 @@ export interface CodeGraphyAPI {
 
 export function activate(context: vscode.ExtensionContext): CodeGraphyAPI {
   initializeCurrentCodeGraphyConfiguration(context);
+  const diagnostics = createExtensionDiagnosticLogger({
+    isEnabled: () => getCodeGraphyConfiguration().get('verboseDiagnostics', false),
+  });
+  diagnostics.emit({
+    area: 'extension.lifecycle',
+    event: 'activation-started',
+    context: { workspaceFolders: vscode.workspace.workspaceFolders?.length ?? 0 },
+  });
   const provider = new GraphViewProvider(context.extensionUri, context);
 
   context.subscriptions.push(
@@ -63,6 +73,11 @@ export function activate(context: vscode.ExtensionContext): CodeGraphyAPI {
   registerSaveHandler(context, provider);
   registerFileWatcher(context, provider);
   registerCommands(context, provider);
+  diagnostics.emit({
+    area: 'extension.lifecycle',
+    event: 'activation-completed',
+    context: { registeredWebviewProviders: 2 },
+  });
 
   return {
     refresh: () => provider.refresh(),

--- a/packages/extension/src/extension/diagnostics/logger.ts
+++ b/packages/extension/src/extension/diagnostics/logger.ts
@@ -1,0 +1,30 @@
+import {
+  createDiagnosticEvent,
+  formatDiagnosticEventLine,
+  type DiagnosticEventInput,
+} from '@codegraphy-dev/core';
+
+export interface ExtensionDiagnosticLogger {
+  emit(this: void, input: DiagnosticEventInput): void;
+}
+
+export interface ExtensionDiagnosticLoggerOptions {
+  isEnabled(this: void): boolean;
+  write?(this: void, line: string): void;
+}
+
+export function createExtensionDiagnosticLogger(
+  options: ExtensionDiagnosticLoggerOptions,
+): ExtensionDiagnosticLogger {
+  const write = options.write ?? (line => console.log(line));
+
+  return {
+    emit(input): void {
+      if (!options.isEnabled()) {
+        return;
+      }
+
+      write(formatDiagnosticEventLine(createDiagnosticEvent(input)));
+    },
+  };
+}

--- a/packages/extension/src/extension/graphView/analysis/execution.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution.ts
@@ -1,4 +1,5 @@
 import type { IGraphData } from '../../../shared/graph/contracts';
+import type { DiagnosticEventInput } from '@codegraphy-dev/core';
 import { publishAnalysisFailure } from './execution/publish';
 import { prepareGraphViewAnalysis } from './execution/prepare';
 import { runGraphViewAnalysis } from './execution/run';
@@ -83,6 +84,7 @@ export interface GraphViewAnalysisExecutionHandlers {
   markWorkspaceReady(graphData: IGraphData): void;
   isAbortError(error: unknown): boolean;
   logError(message: string, error: unknown): void;
+  emitDiagnostic?(input: DiagnosticEventInput): void;
 }
 
 export async function executeGraphViewAnalysis(

--- a/packages/extension/src/extension/graphView/analysis/execution/load.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/load.ts
@@ -40,6 +40,17 @@ export async function loadGraphViewRawData(
     indexFreshness,
     typeof analyzer.loadCachedGraph === 'function',
   );
+  handlers.emitDiagnostic?.({
+    area: 'extension.analysis',
+    event: 'load-decision',
+    context: {
+      mode: state.mode,
+      route: decision.route,
+      shouldDiscover: decision.shouldDiscover,
+      indexFreshness,
+      canReplayCache: typeof analyzer.loadCachedGraph === 'function',
+    },
+  });
   const forwardProgress = createGraphViewAnalysisProgressForwarder(state.mode, handlers);
 
   if (!decision.shouldDiscover) {

--- a/packages/extension/src/extension/graphView/analysis/lifecycle.ts
+++ b/packages/extension/src/extension/graphView/analysis/lifecycle.ts
@@ -8,6 +8,7 @@ import {
   runGraphViewAnalysisRequest,
   type GraphViewAnalysisRequestState,
 } from './request';
+import type { DiagnosticEventInput } from '@codegraphy-dev/core';
 
 interface GraphViewWorkspaceReadyRegistryLike {
   notifyWorkspaceReady(graphData: IGraphData): void;
@@ -21,6 +22,7 @@ export interface GraphViewProviderAnalysisRequestHandlers {
   executeAnalysis(signal: AbortSignal, requestId: number): Promise<void>;
   isAbortError(error: unknown): boolean;
   logError(message: string, error: unknown): void;
+  emitDiagnostic?(input: DiagnosticEventInput): void;
   updateAnalysisController?(controller: AbortController | undefined): void;
   updateAnalysisRequestId?(requestId: number): void;
 }
@@ -50,6 +52,7 @@ export async function runGraphViewProviderAnalysisRequest(
     logError: (message, error) => {
       handlers.logError(message, error);
     },
+    emitDiagnostic: input => handlers.emitDiagnostic?.(input),
     updateAnalysisController: controller => {
       state.analysisController = controller;
       handlers.updateAnalysisController?.(controller);

--- a/packages/extension/src/extension/graphView/analysis/request.ts
+++ b/packages/extension/src/extension/graphView/analysis/request.ts
@@ -1,3 +1,5 @@
+import type { DiagnosticEventInput } from '@codegraphy-dev/core';
+
 export interface GraphViewAnalysisRequestState {
   analysisController: AbortController | undefined;
   analysisRequestId: number;
@@ -7,8 +9,27 @@ export interface GraphViewAnalysisRequestHandlers {
   executeAnalysis(signal: AbortSignal, requestId: number): Promise<void>;
   isAbortError(error: unknown): boolean;
   logError(message: string, error: unknown): void;
+  emitDiagnostic?(input: DiagnosticEventInput): void;
   updateAnalysisController(controller: AbortController | undefined): void;
   updateAnalysisRequestId(requestId: number): void;
+}
+
+function createRequestContext(
+  state: GraphViewAnalysisRequestState,
+  requestId: number,
+): Record<string, number | string | undefined> {
+  const diagnosticState = state as GraphViewAnalysisRequestState & {
+    mode?: string;
+    filterPatterns?: readonly string[];
+    disabledPlugins?: ReadonlySet<string>;
+  };
+
+  return {
+    requestId,
+    mode: diagnosticState.mode,
+    filterPatternCount: diagnosticState.filterPatterns?.length ?? 0,
+    disabledPluginCount: diagnosticState.disabledPlugins?.size ?? 0,
+  };
 }
 
 export async function runGraphViewAnalysisRequest(
@@ -21,11 +42,35 @@ export async function runGraphViewAnalysisRequest(
   handlers.updateAnalysisController(controller);
   const requestId = ++state.analysisRequestId;
   handlers.updateAnalysisRequestId(requestId);
+  const startedAt = Date.now();
+  const requestContext = createRequestContext(state, requestId);
+  handlers.emitDiagnostic?.({
+    area: 'extension.analysis',
+    event: 'request-started',
+    context: requestContext,
+  });
 
   try {
     await handlers.executeAnalysis(controller.signal, requestId);
+    handlers.emitDiagnostic?.({
+      area: 'extension.analysis',
+      event: 'request-completed',
+      context: {
+        ...requestContext,
+        durationMs: Date.now() - startedAt,
+      },
+    });
   } catch (error) {
     if (!handlers.isAbortError(error)) {
+      handlers.emitDiagnostic?.({
+        area: 'extension.analysis',
+        event: 'request-failed',
+        context: {
+          ...requestContext,
+          durationMs: Date.now() - startedAt,
+          error,
+        },
+      });
       handlers.logError('[CodeGraphy] Analysis failed:', error);
     }
   } finally {

--- a/packages/extension/src/extension/graphView/provider/analysis/handlers.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/handlers.ts
@@ -69,6 +69,7 @@ export function createGraphViewProviderAnalysisHandlers(
     logError: (message, error) => {
       dependencies.logError(message, error);
     },
+    emitDiagnostic: input => dependencies.emitDiagnostic?.(input),
   };
 }
 
@@ -83,6 +84,7 @@ export function createGraphViewProviderAnalysisRequestHandlers(
     logError: (message, error) => {
       dependencies.logError(message, error);
     },
+    emitDiagnostic: input => dependencies.emitDiagnostic?.(input),
     updateAnalysisController: controller => {
       source._analysisController = controller;
     },

--- a/packages/extension/src/extension/graphView/provider/analysis/methods.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/methods.ts
@@ -11,6 +11,9 @@ import {
   type GraphViewProviderAnalysisRequestHandlers,
   type GraphViewProviderAnalysisState,
 } from '../../analysis/lifecycle';
+import type { DiagnosticEventInput } from '@codegraphy-dev/core';
+import { getCodeGraphyConfiguration } from '../../../repoSettings/current';
+import { createExtensionDiagnosticLogger } from '../../../diagnostics/logger';
 import { createGraphViewProviderAnalysisDelegates } from './delegates';
 import {
   createGraphViewProviderWorkspaceReadyState,
@@ -100,9 +103,14 @@ export interface GraphViewProviderAnalysisMethodDependencies {
   isAbortError(error: unknown): boolean;
   hasWorkspace(): boolean;
   logError(message: string, error: unknown): void;
+  emitDiagnostic?(input: DiagnosticEventInput): void;
 }
 
 export function createDefaultGraphViewProviderAnalysisMethodDependencies(): GraphViewProviderAnalysisMethodDependencies {
+  const diagnostics = createExtensionDiagnosticLogger({
+    isEnabled: () => getCodeGraphyConfiguration().get('verboseDiagnostics', false),
+  });
+
   return {
     runAnalysisRequest: runGraphViewProviderAnalysisRequest,
     executeAnalysis: executeGraphViewProviderAnalysis,
@@ -113,6 +121,7 @@ export function createDefaultGraphViewProviderAnalysisMethodDependencies(): Grap
     logError: (message, error) => {
       console.error(message, error);
     },
+    emitDiagnostic: input => diagnostics.emit(input),
   };
 }
 

--- a/packages/extension/src/extension/graphView/settings/messages.ts
+++ b/packages/extension/src/extension/graphView/settings/messages.ts
@@ -71,6 +71,10 @@ export function buildGraphViewAllSettingsMessages(
         payload: { maxFiles: snapshot.maxFiles },
       },
       {
+        type: 'VERBOSE_DIAGNOSTICS_UPDATED',
+        payload: { verboseDiagnostics: snapshot.verboseDiagnostics },
+      },
+      {
         type: 'NODE_SIZE_MODE_UPDATED',
         payload: { nodeSizeMode: snapshot.nodeSizeMode },
       },

--- a/packages/extension/src/extension/graphView/settings/snapshot.ts
+++ b/packages/extension/src/extension/graphView/settings/snapshot.ts
@@ -48,6 +48,7 @@ export function captureGraphViewSettingsSnapshot(
     particleSize: config.get('particleSize', 4),
     showLabels: config.get('showLabels', true),
     maxFiles: config.get('maxFiles', DEFAULT_MAX_FILES),
+    verboseDiagnostics: config.get('verboseDiagnostics', false),
     nodeSizeMode,
   };
 }

--- a/packages/extension/src/extension/graphView/webview/dispatch/pluginReady.ts
+++ b/packages/extension/src/extension/graphView/webview/dispatch/pluginReady.ts
@@ -49,6 +49,7 @@ export async function dispatchGraphViewPluginReadyMessage(
   return applyWebviewReady(
     {
       maxFiles: context.getMaxFiles(),
+      verboseDiagnostics: context.getConfig('verboseDiagnostics', false),
       playbackSpeed: context.getPlaybackSpeed(),
       depthMode: context.getDepthMode?.() ?? false,
       dagMode: context.getDagMode(),

--- a/packages/extension/src/extension/graphView/webview/messages/listener.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/listener.ts
@@ -57,6 +57,7 @@ function applyGraphViewPluginMessageResult(
 function createReadyState(context: GraphViewMessageListenerContext) {
   return {
     maxFiles: context.getMaxFiles(),
+    verboseDiagnostics: context.getConfig('verboseDiagnostics', false),
     playbackSpeed: context.getPlaybackSpeed(),
     depthMode: context.getDepthMode?.() ?? false,
     dagMode: context.getDagMode(),

--- a/packages/extension/src/extension/graphView/webview/messages/ready.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/ready.ts
@@ -3,6 +3,7 @@ import type { IPluginFilterPatternGroup } from '../../../../shared/protocol/exte
 
 export interface GraphViewReadyState {
   maxFiles: number;
+  verboseDiagnostics: boolean;
   playbackSpeed: number;
   depthMode?: boolean;
   dagMode: DagMode;
@@ -66,6 +67,10 @@ export function replayWebviewReadySettings(
   handlers.sendMessage({
     type: 'MAX_FILES_UPDATED',
     payload: { maxFiles: state.maxFiles },
+  });
+  handlers.sendMessage({
+    type: 'VERBOSE_DIAGNOSTICS_UPDATED',
+    payload: { verboseDiagnostics: state.verboseDiagnostics },
   });
   handlers.sendMessage({
     type: 'PLAYBACK_SPEED_UPDATED',

--- a/packages/extension/src/extension/graphView/webview/messages/ready.ts
+++ b/packages/extension/src/extension/graphView/webview/messages/ready.ts
@@ -1,5 +1,6 @@
 import type { DagMode, NodeSizeMode } from '../../../../shared/settings/modes';
 import type { IPluginFilterPatternGroup } from '../../../../shared/protocol/extensionToWebview';
+import { createExtensionDiagnosticLogger } from '../../../diagnostics/logger';
 
 export interface GraphViewReadyState {
   maxFiles: number;
@@ -46,6 +47,18 @@ export function replayWebviewReadySettings(
   state: GraphViewReadyState,
   handlers: GraphViewReadyHandlers,
 ): void {
+  createExtensionDiagnosticLogger({
+    isEnabled: () => state.verboseDiagnostics,
+  }).emit({
+    area: 'extension.webview',
+    event: 'ready-replayed',
+    context: {
+      hasWorkspace: state.hasWorkspace,
+      firstAnalysis: state.firstAnalysis,
+      readyNotified: state.readyNotified,
+      maxFiles: state.maxFiles,
+    },
+  });
   handlers.loadGroupsAndFilterPatterns();
   handlers.loadDisabledRulesAndPlugins();
   handlers.sendDepthState();
@@ -112,6 +125,17 @@ export async function applyWebviewReady(
   }
 
   handlers.sendMessage({ type: 'APP_BOOTSTRAP_COMPLETE' });
+  createExtensionDiagnosticLogger({
+    isEnabled: () => state.verboseDiagnostics,
+  }).emit({
+    area: 'extension.webview',
+    event: 'bootstrap-completed',
+    context: {
+      hasWorkspace: state.hasWorkspace,
+      firstAnalysis: state.firstAnalysis,
+      readyNotified: state.readyNotified,
+    },
+  });
 
   if (state.readyNotified) {
     return true;

--- a/packages/extension/src/extension/graphView/webview/settingsMessages/updates/simple.ts
+++ b/packages/extension/src/extension/graphView/webview/settingsMessages/updates/simple.ts
@@ -4,7 +4,8 @@ import type { GraphViewSettingsMessageHandlers } from '../router';
 type SettingsUpdateConfigKey =
   | 'showOrphans'
   | 'bidirectionalEdges'
-  | 'maxFiles';
+  | 'maxFiles'
+  | 'verboseDiagnostics';
 
 function getSimpleSettingsUpdateConfig(
   message: WebviewToExtensionMessage,
@@ -16,6 +17,8 @@ function getSimpleSettingsUpdateConfig(
       return { key: 'bidirectionalEdges', value: message.payload.bidirectionalMode };
     case 'UPDATE_MAX_FILES':
       return { key: 'maxFiles', value: message.payload.maxFiles };
+    case 'UPDATE_VERBOSE_DIAGNOSTICS':
+      return { key: 'verboseDiagnostics', value: message.payload.verboseDiagnostics };
     default:
       return undefined;
   }

--- a/packages/extension/src/extension/repoSettings/defaults.ts
+++ b/packages/extension/src/extension/repoSettings/defaults.ts
@@ -15,6 +15,7 @@ import {
 export interface ICodeGraphyRepoSettings {
   version: 1;
   maxFiles: number;
+  verboseDiagnostics: boolean;
   include: string[];
   respectGitignore: boolean;
   showOrphans: boolean;
@@ -58,6 +59,7 @@ export function createDefaultCodeGraphyRepoSettings(): ICodeGraphyRepoSettings {
   return {
     version: 1,
     maxFiles: DEFAULT_MAX_FILES,
+    verboseDiagnostics: false,
     include: ['**/*'],
     respectGitignore: true,
     showOrphans: true,

--- a/packages/extension/src/extension/repoSettings/store/model/persistedShape/allowedKeys.ts
+++ b/packages/extension/src/extension/repoSettings/store/model/persistedShape/allowedKeys.ts
@@ -1,6 +1,7 @@
 export const TOP_LEVEL_SETTINGS_KEYS = new Set([
   'version',
   'maxFiles',
+  'verboseDiagnostics',
   'include',
   'respectGitignore',
   'showOrphans',

--- a/packages/extension/src/shared/protocol/extensionToWebview.ts
+++ b/packages/extension/src/shared/protocol/extensionToWebview.ts
@@ -94,6 +94,7 @@ export type ExtensionToWebviewMessage =
   | { type: 'SHOW_LABELS_UPDATED'; payload: { showLabels: boolean } }
   | { type: 'PLUGINS_UPDATED'; payload: { plugins: IPluginStatus[] } }
   | { type: 'MAX_FILES_UPDATED'; payload: { maxFiles: number } }
+  | { type: 'VERBOSE_DIAGNOSTICS_UPDATED'; payload: { verboseDiagnostics: boolean } }
   | { type: 'ACTIVE_FILE_UPDATED'; payload: { filePath: string | undefined } }
   | { type: 'INDEX_PROGRESS'; payload: { phase: string; current: number; total: number } }
   | { type: 'TIMELINE_DATA'; payload: ITimelineData }

--- a/packages/extension/src/shared/protocol/webviewToExtension.ts
+++ b/packages/extension/src/shared/protocol/webviewToExtension.ts
@@ -79,6 +79,7 @@ export type WebviewToExtensionMessage =
   | { type: 'UPDATE_NODE_VISIBILITY'; payload: { nodeType: string; visible: boolean } }
   | { type: 'UPDATE_EDGE_VISIBILITY'; payload: { edgeKind: string; visible: boolean } }
   | { type: 'UPDATE_MAX_FILES'; payload: { maxFiles: number } }
+  | { type: 'UPDATE_VERBOSE_DIAGNOSTICS'; payload: { verboseDiagnostics: boolean } }
   | { type: 'INDEX_REPO' }
   | { type: 'JUMP_TO_COMMIT'; payload: { sha: string } }
   | { type: 'RESET_TIMELINE' }

--- a/packages/extension/src/shared/settings/snapshot.ts
+++ b/packages/extension/src/shared/settings/snapshot.ts
@@ -22,4 +22,5 @@ export interface ISettingsSnapshot {
   showLabels: boolean;
   nodeSizeMode: NodeSizeMode;
   maxFiles: number;
+  verboseDiagnostics: boolean;
 }

--- a/packages/extension/src/webview/components/settingsPanel/performance/Section.tsx
+++ b/packages/extension/src/webview/components/settingsPanel/performance/Section.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { postMessage } from '../../../vscodeApi';
 import { useGraphStore } from '../../../store/state';
 import { MaxFilesControl } from '../display/MaxFilesControl';
+import { Label } from '../../ui/form/label';
+import { Switch } from '../../ui/switch';
 import {
   clampMaxFiles,
   decreaseMaxFiles,
@@ -11,7 +13,9 @@ import {
 
 export function PerformanceSection(): React.ReactElement {
   const maxFiles = useGraphStore((state) => state.maxFiles);
+  const verboseDiagnostics = useGraphStore((state) => state.verboseDiagnostics);
   const setMaxFiles = useGraphStore((state) => state.setMaxFiles);
+  const setVerboseDiagnostics = useGraphStore((state) => state.setVerboseDiagnostics);
 
   const commitMaxFiles = (value: number): void => {
     const clamped = clampMaxFiles(value);
@@ -38,6 +42,22 @@ export function PerformanceSection(): React.ReactElement {
           }
         }}
       />
+      <div className="flex items-center justify-between py-0.5">
+        <Label htmlFor="verbose-diagnostics" className="text-xs">
+          Verbose Diagnostics
+        </Label>
+        <Switch
+          id="verbose-diagnostics"
+          checked={verboseDiagnostics}
+          onCheckedChange={(checked) => {
+            setVerboseDiagnostics(checked);
+            postMessage({
+              type: 'UPDATE_VERBOSE_DIAGNOSTICS',
+              payload: { verboseDiagnostics: checked },
+            });
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/packages/extension/src/webview/store/actions/scalars.ts
+++ b/packages/extension/src/webview/store/actions/scalars.ts
@@ -12,6 +12,7 @@ export function createScalarActions(set: SetState) {
     setDepthMode: (depthMode: boolean) => set({ depthMode }),
     setDagMode: (mode: GraphState['dagMode']) => set({ dagMode: mode }),
     setMaxFiles: (max: number) => set({ maxFiles: max }),
+    setVerboseDiagnostics: (enabled: boolean) => set({ verboseDiagnostics: enabled }),
     setPlaybackSpeed: (speed: number) => set({ playbackSpeed: speed }),
     setIsPlaying: (playing: boolean) => set({ isPlaying: playing }),
   };

--- a/packages/extension/src/webview/store/initialState.ts
+++ b/packages/extension/src/webview/store/initialState.ts
@@ -56,6 +56,7 @@ export const INITIAL_STATE: GraphStateFields = {
   expandedGroupId: null,
   activePanel: 'none' as const,
   maxFiles: DEFAULT_MAX_FILES,
+  verboseDiagnostics: false,
   activeFilePath: null,
   timelineActive: false,
   timelineCommits: [],

--- a/packages/extension/src/webview/store/messageHandlers/graph.ts
+++ b/packages/extension/src/webview/store/messageHandlers/graph.ts
@@ -178,6 +178,12 @@ export function handleMaxFilesUpdated(
   return { maxFiles: message.payload.maxFiles };
 }
 
+export function handleVerboseDiagnosticsUpdated(
+  message: Extract<ExtensionToWebviewMessage, { type: 'VERBOSE_DIAGNOSTICS_UPDATED' }>,
+): PartialState {
+  return { verboseDiagnostics: message.payload.verboseDiagnostics };
+}
+
 export function handleActiveFileUpdated(
   message: Extract<ExtensionToWebviewMessage, { type: 'ACTIVE_FILE_UPDATED' }>,
 ): PartialState {

--- a/packages/extension/src/webview/store/messageTypes.ts
+++ b/packages/extension/src/webview/store/messageTypes.ts
@@ -76,6 +76,7 @@ export interface IStoreFields {
   graphViewContributionStatuses: IGraphViewContributionStatus[];
   activePanel: 'none' | 'settings' | 'plugins' | 'legends' | 'graphScope' | 'nodes' | 'edges' | 'export';
   maxFiles: number;
+  verboseDiagnostics: boolean;
   activeFilePath: string | null;
   timelineActive: boolean;
   timelineCommits: ICommitInfo[];

--- a/packages/extension/src/webview/store/messages.ts
+++ b/packages/extension/src/webview/store/messages.ts
@@ -15,6 +15,7 @@ import {
   handleDirectionSettingsUpdated,
   handleShowLabelsUpdated,
   handleMaxFilesUpdated,
+  handleVerboseDiagnosticsUpdated,
   handleActiveFileUpdated,
   handleAppBootstrapComplete,
 } from './messageHandlers/graph';
@@ -97,6 +98,10 @@ export const MESSAGE_HANDLERS: Record<
     handlePluginsUpdated(msg as Extract<ExtensionToWebviewMessage, { type: 'PLUGINS_UPDATED' }>),
   MAX_FILES_UPDATED: (msg) =>
     handleMaxFilesUpdated(msg as Extract<ExtensionToWebviewMessage, { type: 'MAX_FILES_UPDATED' }>),
+  VERBOSE_DIAGNOSTICS_UPDATED: (msg) =>
+    handleVerboseDiagnosticsUpdated(
+      msg as Extract<ExtensionToWebviewMessage, { type: 'VERBOSE_DIAGNOSTICS_UPDATED' }>
+    ),
   ACTIVE_FILE_UPDATED: (msg) =>
     handleActiveFileUpdated(msg as Extract<ExtensionToWebviewMessage, { type: 'ACTIVE_FILE_UPDATED' }>),
   INDEX_PROGRESS: (msg) =>

--- a/packages/extension/src/webview/store/state.ts
+++ b/packages/extension/src/webview/store/state.ts
@@ -79,6 +79,7 @@ export interface GraphState {
   edgeVisibility: Record<string, boolean>;
   activePanel: 'none' | 'settings' | 'plugins' | 'legends' | 'graphScope' | 'nodes' | 'edges' | 'export';
   maxFiles: number;
+  verboseDiagnostics: boolean;
   activeFilePath: string | null;
   timelineActive: boolean;
   timelineCommits: ICommitInfo[];
@@ -115,6 +116,7 @@ export interface GraphState {
   setDepthMode: (depthMode: boolean) => void;
   setDagMode: (mode: DagMode) => void;
   setMaxFiles: (max: number) => void;
+  setVerboseDiagnostics: (enabled: boolean) => void;
   setPlaybackSpeed: (speed: number) => void;
   setIsPlaying: (playing: boolean) => void;
   beginInitialBootstrap: () => void;

--- a/packages/extension/tests/extension/actions/reset/extra.test.ts
+++ b/packages/extension/tests/extension/actions/reset/extra.test.ts
@@ -70,6 +70,7 @@ describe('ResetSettingsAction (extra mutant coverage)', () => {
     particleSize: 4,
     showLabels: true,
     maxFiles: 500,
+    verboseDiagnostics: false,
     nodeSizeMode: 'connections',
   };
 
@@ -96,6 +97,7 @@ describe('ResetSettingsAction (extra mutant coverage)', () => {
       particleSize: 4,
       showLabels: true,
       maxFiles: 500,
+      verboseDiagnostics: false,
       nodeSizeMode: 'file-size',
     };
   });

--- a/packages/extension/tests/extension/actions/reset/mutations.test.ts
+++ b/packages/extension/tests/extension/actions/reset/mutations.test.ts
@@ -67,6 +67,7 @@ describe('ResetSettingsAction (config section mutant coverage)', () => {
     particleSize: 4,
     showLabels: true,
     maxFiles: 500,
+    verboseDiagnostics: false,
     nodeSizeMode: 'connections',
   };
 
@@ -96,6 +97,7 @@ describe('ResetSettingsAction (config section mutant coverage)', () => {
       particleSize: 4,
       showLabels: true,
       maxFiles: 500,
+      verboseDiagnostics: false,
       nodeSizeMode: 'connections',
     };
     mockConfig = createMockConfig(settingsStore);

--- a/packages/extension/tests/extension/actions/reset/view.test.ts
+++ b/packages/extension/tests/extension/actions/reset/view.test.ts
@@ -78,6 +78,7 @@ describe('ResetSettingsAction', () => {
     particleSize: 8,
     showLabels: false,
     maxFiles: 1000,
+    verboseDiagnostics: true,
     nodeSizeMode: 'file-size',
   };
 
@@ -121,6 +122,7 @@ describe('ResetSettingsAction', () => {
       particleSize: 8,
       showLabels: false,
       maxFiles: 1000,
+      verboseDiagnostics: true,
       nodeSizeMode: 'file-size',
     };
 

--- a/packages/extension/tests/extension/actions/resetSettings.test.ts
+++ b/packages/extension/tests/extension/actions/resetSettings.test.ts
@@ -33,6 +33,7 @@ const SNAPSHOT: ISettingsSnapshot = {
   particleSize: 6,
   showLabels: false,
   maxFiles: 321,
+  verboseDiagnostics: true,
   nodeSizeMode: 'churn',
 };
 
@@ -70,6 +71,7 @@ describe('extension/actions/resetSettings', () => {
       ['particleSize', undefined],
       ['showLabels', undefined],
       ['maxFiles', undefined],
+      ['verboseDiagnostics', undefined],
       ['nodeSizeMode', 'connections'],
     ]);
   });
@@ -102,6 +104,7 @@ describe('extension/actions/resetSettings', () => {
       ['particleSize', 6],
       ['showLabels', false],
       ['maxFiles', 321],
+      ['verboseDiagnostics', true],
       ['nodeSizeMode', 'churn'],
     ]);
   });

--- a/packages/extension/tests/extension/activate.test.ts
+++ b/packages/extension/tests/extension/activate.test.ts
@@ -98,4 +98,27 @@ describe('activate', () => {
 
     expect(activateDependentExtension).not.toHaveBeenCalled();
   });
+
+  it('emits verbose lifecycle diagnostics during activation when enabled', () => {
+    vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+      get: vi.fn(<T>(key: string, defaultValue: T) =>
+        key === 'verboseDiagnostics' ? true as T : defaultValue
+      ),
+      inspect: vi.fn(() => undefined),
+      update: vi.fn(),
+    } as never);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    activate(makeMockContext() as unknown as vscode.ExtensionContext);
+
+    const diagnosticLines = log.mock.calls
+      .map(call => call[0])
+      .filter(line => typeof line === 'string' && line.includes('[CodeGraphy][Diagnostics]'));
+    expect(diagnosticLines).toEqual([
+      '[CodeGraphy][Diagnostics] extension.lifecycle activation-started {"workspaceFolders":0}',
+      '[CodeGraphy][Diagnostics] extension.lifecycle activation-completed {"registeredWebviewProviders":2}',
+    ]);
+
+    log.mockRestore();
+  });
 });

--- a/packages/extension/tests/extension/activate.test.ts
+++ b/packages/extension/tests/extension/activate.test.ts
@@ -113,10 +113,10 @@ describe('activate', () => {
 
     const diagnosticLines = log.mock.calls
       .map(call => call[0])
-      .filter(line => typeof line === 'string' && line.includes('[CodeGraphy][Diagnostics]'));
+      .filter(line => typeof line === 'string' && line.startsWith('[CodeGraphy] Extension activation'));
     expect(diagnosticLines).toEqual([
-      '[CodeGraphy][Diagnostics] extension.lifecycle activation-started {"workspaceFolders":0}',
-      '[CodeGraphy][Diagnostics] extension.lifecycle activation-completed {"registeredWebviewProviders":2}',
+      '[CodeGraphy] Extension activation started: workspaceFolders=0',
+      '[CodeGraphy] Extension activation complete: registeredWebviewProviders=2',
     ]);
 
     log.mockRestore();

--- a/packages/extension/tests/extension/diagnostics/logger.test.ts
+++ b/packages/extension/tests/extension/diagnostics/logger.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createExtensionDiagnosticLogger } from '../../../src/extension/diagnostics/logger';
+
+describe('extension/diagnostics/logger', () => {
+  it('stays quiet when verbose diagnostics are disabled', () => {
+    const write = vi.fn();
+    const logger = createExtensionDiagnosticLogger({
+      isEnabled: () => false,
+      write,
+    });
+
+    logger.emit({
+      area: 'extension.lifecycle',
+      event: 'activation-started',
+      context: { workspaceFolders: 1 },
+    });
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('writes CodeGraphy-prefixed diagnostic facts when enabled', () => {
+    const write = vi.fn();
+    const logger = createExtensionDiagnosticLogger({
+      isEnabled: () => true,
+      write,
+    });
+
+    logger.emit({
+      area: 'extension.lifecycle',
+      event: 'activation-started',
+      context: { workspaceFolders: 1 },
+    });
+
+    expect(write).toHaveBeenCalledOnce();
+    expect(write.mock.calls[0][0]).toBe(
+      '[CodeGraphy][Diagnostics] extension.lifecycle activation-started {"workspaceFolders":1}',
+    );
+  });
+});

--- a/packages/extension/tests/extension/diagnostics/logger.test.ts
+++ b/packages/extension/tests/extension/diagnostics/logger.test.ts
@@ -18,7 +18,7 @@ describe('extension/diagnostics/logger', () => {
     expect(write).not.toHaveBeenCalled();
   });
 
-  it('writes CodeGraphy-prefixed diagnostic facts when enabled', () => {
+  it('writes human-readable CodeGraphy-prefixed diagnostic facts when enabled', () => {
     const write = vi.fn();
     const logger = createExtensionDiagnosticLogger({
       isEnabled: () => true,
@@ -33,7 +33,7 @@ describe('extension/diagnostics/logger', () => {
 
     expect(write).toHaveBeenCalledOnce();
     expect(write.mock.calls[0][0]).toBe(
-      '[CodeGraphy][Diagnostics] extension.lifecycle activation-started {"workspaceFolders":1}',
+      '[CodeGraphy] Extension activation started: workspaceFolders=1',
     );
   });
 });

--- a/packages/extension/tests/extension/graphView/analysis/execution/fixtures.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/fixtures.ts
@@ -64,6 +64,7 @@ export function createExecutionHandlers(
     markWorkspaceReady: vi.fn(),
     isAbortError: vi.fn(() => false),
     logError: vi.fn(),
+    emitDiagnostic: vi.fn(),
     ...overrides,
   };
 

--- a/packages/extension/tests/extension/graphView/analysis/execution/load.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/load.test.ts
@@ -85,11 +85,12 @@ describe('graph view analysis execution load', () => {
       }),
       analyzerInitialized: true,
     });
+    const { handlers } = createExecutionHandlers();
 
     const result = await loadGraphViewRawData(
       new AbortController().signal,
       state,
-      createExecutionHandlers().handlers,
+      handlers,
     );
 
     expect(result.shouldDiscover).toBe(false);
@@ -97,6 +98,17 @@ describe('graph view analysis execution load', () => {
     expect(loadCachedGraph).toHaveBeenCalledOnce();
     expect(analyze).not.toHaveBeenCalled();
     expect(refreshIndex).not.toHaveBeenCalled();
+    expect(handlers.emitDiagnostic).toHaveBeenCalledWith({
+      area: 'extension.analysis',
+      event: 'load-decision',
+      context: {
+        mode: 'load',
+        route: 'cached',
+        shouldDiscover: false,
+        indexFreshness: 'fresh',
+        canReplayCache: true,
+      },
+    });
   });
 
   it('loads cached graph data instead of blocking on refresh when a stale index can be replayed', async () => {

--- a/packages/extension/tests/extension/graphView/analysis/lifecycle.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/lifecycle.test.ts
@@ -77,12 +77,14 @@ describe('graph view provider analysis lifecycle helper', () => {
     const handlers = createHandlers();
     const updateAnalysisController = vi.fn();
     const updateAnalysisRequestId = vi.fn();
+    const emitDiagnostic = vi.fn();
 
     await runGraphViewProviderAnalysisRequest(state, {
       executeAnalysis: (signal, requestId) =>
         executeGraphViewProviderAnalysis(signal, requestId, state, handlers),
       isAbortError: error => isGraphViewAbortError(error),
       logError: handlers.logError,
+      emitDiagnostic,
       updateAnalysisController,
       updateAnalysisRequestId,
     });
@@ -97,6 +99,25 @@ describe('graph view provider analysis lifecycle helper', () => {
     );
     expect(updateAnalysisController).toHaveBeenLastCalledWith(undefined);
     expect(updateAnalysisRequestId).toHaveBeenCalledWith(1);
+    expect(emitDiagnostic).toHaveBeenCalledWith({
+      area: 'extension.analysis',
+      event: 'request-started',
+      context: {
+        requestId: 1,
+        mode: 'analyze',
+        filterPatternCount: 0,
+        disabledPluginCount: 0,
+      },
+    });
+    expect(emitDiagnostic).toHaveBeenCalledWith({
+      area: 'extension.analysis',
+      event: 'request-completed',
+      context: expect.objectContaining({
+        requestId: 1,
+        mode: 'analyze',
+        durationMs: expect.any(Number),
+      }),
+    });
   });
 
   it('updates request state even when optional request update callbacks are absent', async () => {

--- a/packages/extension/tests/extension/graphView/provider/analysis/handlers.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/analysis/handlers.test.ts
@@ -63,6 +63,7 @@ function createDependencies(
     isAbortError: vi.fn(() => false),
     hasWorkspace: vi.fn(() => true),
     logError: vi.fn(),
+    emitDiagnostic: vi.fn(),
     ...overrides,
   };
 }
@@ -258,10 +259,20 @@ describe('graphView/provider/analysis/handlers', () => {
     handlers.updateAnalysisRequestId?.(6);
     expect(handlers.isAbortError(new Error('boom'))).toBe(false);
     handlers.logError('label', new Error('boom'));
+    handlers.emitDiagnostic?.({
+      area: 'extension.analysis',
+      event: 'request-started',
+      context: { requestId: 6 },
+    });
 
     expect(callbacks.executeAnalysis).toHaveBeenCalledWith(controller.signal, 6);
     expect(source._analysisController).toBe(controller);
     expect(source._analysisRequestId).toBe(6);
     expect(dependencies.logError).toHaveBeenCalledOnce();
+    expect(dependencies.emitDiagnostic).toHaveBeenCalledWith({
+      area: 'extension.analysis',
+      event: 'request-started',
+      context: { requestId: 6 },
+    });
   });
 });

--- a/packages/extension/tests/extension/graphView/settings/lifecycle.test.ts
+++ b/packages/extension/tests/extension/graphView/settings/lifecycle.test.ts
@@ -34,6 +34,7 @@ function createSnapshot(
     showLabels: true,
     nodeSizeMode: 'uniform',
     maxFiles: 500,
+    verboseDiagnostics: false,
     ...overrides,
   };
 }

--- a/packages/extension/tests/extension/graphView/settings/snapshotMessages.test.ts
+++ b/packages/extension/tests/extension/graphView/settings/snapshotMessages.test.ts
@@ -54,6 +54,7 @@ describe('graphView/settings/snapshotMessages', () => {
       particleSize: 4,
       showLabels: true,
       maxFiles: DEFAULT_MAX_FILES,
+      verboseDiagnostics: false,
       nodeSizeMode: 'uniform',
     });
   });
@@ -76,6 +77,7 @@ describe('graphView/settings/snapshotMessages', () => {
         particleSize: 6,
         showLabels: false,
         maxFiles: 250,
+        verboseDiagnostics: true,
       }),
       {
         repelForce: 10,
@@ -112,6 +114,7 @@ describe('graphView/settings/snapshotMessages', () => {
       particleSize: 6,
       showLabels: false,
       maxFiles: 250,
+      verboseDiagnostics: true,
       nodeSizeMode: 'churn',
     });
   });
@@ -176,6 +179,7 @@ describe('graphView/settings/snapshotMessages', () => {
           particleSize: 6,
           showLabels: false,
           maxFiles: 250,
+          verboseDiagnostics: true,
           nodeSizeMode: 'churn',
         },
         ['venv/**'],
@@ -224,6 +228,10 @@ describe('graphView/settings/snapshotMessages', () => {
         {
           type: 'MAX_FILES_UPDATED',
           payload: { maxFiles: 250 },
+        },
+        {
+          type: 'VERBOSE_DIAGNOSTICS_UPDATED',
+          payload: { verboseDiagnostics: true },
         },
         {
           type: 'NODE_SIZE_MODE_UPDATED',

--- a/packages/extension/tests/extension/graphView/settings/sync.test.ts
+++ b/packages/extension/tests/extension/graphView/settings/sync.test.ts
@@ -34,6 +34,7 @@ function createSnapshot(
     showLabels: true,
     nodeSizeMode: 'uniform',
     maxFiles: 500,
+    verboseDiagnostics: false,
     ...overrides,
   };
 }
@@ -115,9 +116,10 @@ describe('graphView/settings/sync', () => {
       },
     });
 
-    expect(order.slice(-3)).toEqual([
+    expect(order.slice(-4)).toEqual([
       'FILTER_PATTERNS_UPDATED',
       'MAX_FILES_UPDATED',
+      'VERBOSE_DIAGNOSTICS_UPDATED',
       'NODE_SIZE_MODE_UPDATED',
     ]);
   });

--- a/packages/extension/tests/extension/graphView/webview/dispatch/stateful.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/dispatch/stateful.test.ts
@@ -41,6 +41,25 @@ describe('graph view primary stateful dispatch', () => {
     });
   });
 
+  it('persists verbose diagnostics updates from settings messages', async () => {
+    const context = createPrimaryMessageContext();
+
+    await expect(
+      dispatchGraphViewPrimaryStateMessage(
+        {
+          type: 'UPDATE_VERBOSE_DIAGNOSTICS',
+          payload: { verboseDiagnostics: true },
+        },
+        context,
+      ),
+    ).resolves.toEqual({
+      handled: true,
+      filterPatterns: undefined,
+    });
+
+    expect(context.updateConfig).toHaveBeenCalledWith('verboseDiagnostics', true);
+  });
+
   it('returns false when neither stateful family handles the input', async () => {
     await expect(
       dispatchGraphViewPrimaryStateMessage({ type: 'GET_PHYSICS_SETTINGS' }, createPrimaryMessageContext()),

--- a/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
@@ -102,10 +102,10 @@ describe('graph view ready message', () => {
     expect(handlers.notifyWebviewReady).toHaveBeenCalledOnce();
     expect(readyNotified).toBe(true);
     expect(log.mock.calls.map(call => call[0])).toContain(
-      '[CodeGraphy][Diagnostics] extension.webview ready-replayed {"hasWorkspace":false,"firstAnalysis":false,"readyNotified":false,"maxFiles":500}',
+      '[CodeGraphy] Webview ready replayed: hasWorkspace=false, firstAnalysis=false, readyNotified=false, maxFiles=500',
     );
     expect(log.mock.calls.map(call => call[0])).toContain(
-      '[CodeGraphy][Diagnostics] extension.webview bootstrap-completed {"hasWorkspace":false,"firstAnalysis":false,"readyNotified":false}',
+      '[CodeGraphy] Webview bootstrap complete: hasWorkspace=false, firstAnalysis=false, readyNotified=false',
     );
     log.mockRestore();
   });

--- a/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
@@ -36,6 +36,7 @@ describe('graph view ready message', () => {
     const readyNotified = await applyWebviewReady(
       {
         maxFiles: 500,
+        verboseDiagnostics: true,
         playbackSpeed: 1,
         dagMode: 'td',
         nodeSizeMode: 'connections',
@@ -78,6 +79,10 @@ describe('graph view ready message', () => {
       payload: { maxFiles: 500 },
     });
     expect(handlers.sendMessage).toHaveBeenCalledWith({
+      type: 'VERBOSE_DIAGNOSTICS_UPDATED',
+      payload: { verboseDiagnostics: true },
+    });
+    expect(handlers.sendMessage).toHaveBeenCalledWith({
       type: 'PLAYBACK_SPEED_UPDATED',
       payload: { speed: 1 },
     });
@@ -106,6 +111,7 @@ describe('graph view ready message', () => {
     await applyWebviewReady(
       {
         maxFiles: 500,
+        verboseDiagnostics: false,
         playbackSpeed: 1,
         dagMode: null,
         nodeSizeMode: 'connections',
@@ -146,6 +152,7 @@ describe('graph view ready message', () => {
     await applyWebviewReady(
       {
         maxFiles: 500,
+        verboseDiagnostics: false,
         playbackSpeed: 1,
         dagMode: null,
         nodeSizeMode: 'connections',
@@ -166,6 +173,7 @@ describe('graph view ready message', () => {
     await applyWebviewReady(
       {
         maxFiles: 500,
+        verboseDiagnostics: false,
         playbackSpeed: 1,
         dagMode: null,
         nodeSizeMode: 'connections',
@@ -186,6 +194,7 @@ describe('graph view ready message', () => {
     await applyWebviewReady(
       {
         maxFiles: 500,
+        verboseDiagnostics: false,
         playbackSpeed: 1,
         dagMode: null,
         nodeSizeMode: 'connections',
@@ -206,6 +215,7 @@ describe('graph view ready message', () => {
     const readyNotified = await applyWebviewReady(
       {
         maxFiles: 500,
+        verboseDiagnostics: false,
         playbackSpeed: 1,
         dagMode: null,
         nodeSizeMode: 'connections',
@@ -236,6 +246,7 @@ describe('graph view ready message', () => {
     await applyWebviewReady(
       {
         maxFiles: 500,
+        verboseDiagnostics: false,
         playbackSpeed: 1,
         dagMode: null,
         nodeSizeMode: 'connections',

--- a/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/messages/ready.test.ts
@@ -32,6 +32,7 @@ function createHandlers() {
 describe('graph view ready message', () => {
   it('sends the initial webview payloads and notifies readiness', async () => {
     const handlers = createHandlers();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     const readyNotified = await applyWebviewReady(
       {
@@ -96,6 +97,13 @@ describe('graph view ready message', () => {
     });
     expect(handlers.notifyWebviewReady).toHaveBeenCalledOnce();
     expect(readyNotified).toBe(true);
+    expect(log.mock.calls.map(call => call[0])).toContain(
+      '[CodeGraphy][Diagnostics] extension.webview ready-replayed {"hasWorkspace":false,"firstAnalysis":false,"readyNotified":false,"maxFiles":500}',
+    );
+    expect(log.mock.calls.map(call => call[0])).toContain(
+      '[CodeGraphy][Diagnostics] extension.webview bootstrap-completed {"hasWorkspace":false,"firstAnalysis":false,"readyNotified":false}',
+    );
+    log.mockRestore();
   });
 
   it('sends available views before kicking off analysis', async () => {

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/listener.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/listener.test.ts
@@ -44,6 +44,7 @@ function createSettingsSnapshot(): ISettingsSnapshot {
     particleSize: 4,
     showLabels: true,
     maxFiles: DEFAULT_MAX_FILES,
+    verboseDiagnostics: false,
     nodeSizeMode: 'connections',
     physics: {
       repelForce: 1,

--- a/packages/extension/tests/extension/repoSettings/defaults.test.ts
+++ b/packages/extension/tests/extension/repoSettings/defaults.test.ts
@@ -14,6 +14,7 @@ describe('extension/repoSettings/defaults', () => {
     expect(createDefaultCodeGraphyRepoSettings()).toEqual({
       version: 1,
       maxFiles: DEFAULT_MAX_FILES,
+      verboseDiagnostics: false,
       include: ['**/*'],
       respectGitignore: true,
       showOrphans: true,

--- a/packages/extension/tests/extension/repoSettings/store/model/persistedShape/view.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store/model/persistedShape/view.test.ts
@@ -10,10 +10,12 @@ describe('extension/repoSettings/store/model/persistedShape', () => {
 
   it('deduplicates filter patterns and drops unknown top-level settings', () => {
     expect(normalizePersistedSettingsShape({
+      verboseDiagnostics: true,
       filterPatterns: ['**/*.png', '**/*.png', 42, '**/*.tmp'],
       edgeColors: { import: '#123456' },
       plugins: ['codegraphy.typescript'],
     })).toEqual({
+      verboseDiagnostics: true,
       filterPatterns: ['**/*.png', '**/*.tmp'],
     });
   });

--- a/packages/extension/tests/webview/settingsPanel/performance/Section.test.tsx
+++ b/packages/extension/tests/webview/settingsPanel/performance/Section.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../../../src/webview/vscodeApi', () => ({
 describe('PerformanceSection', () => {
   beforeEach(() => {
     sentMessages.length = 0;
-    graphStore.setState({ maxFiles: 20 });
+    graphStore.setState({ maxFiles: 20, verboseDiagnostics: false });
   });
 
   it('commits max files through blur and enter handlers', () => {
@@ -35,6 +35,21 @@ describe('PerformanceSection', () => {
     expect(sentMessages).toContainEqual({
       type: 'UPDATE_MAX_FILES',
       payload: { maxFiles: 5 },
+    });
+  });
+
+  it('toggles verbose diagnostics through the Performance settings section', () => {
+    render(<PerformanceSection />);
+
+    const toggle = screen.getByRole('switch', { name: 'Verbose Diagnostics' });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(toggle);
+
+    expect(graphStore.getState().verboseDiagnostics).toBe(true);
+    expect(sentMessages).toContainEqual({
+      type: 'UPDATE_VERBOSE_DIAGNOSTICS',
+      payload: { verboseDiagnostics: true },
     });
   });
 });

--- a/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
+++ b/packages/extension/tests/webview/store/messageHandlers/graph.test.ts
@@ -17,6 +17,7 @@ import {
   handlePhysicsSettingsUpdated,
   handleSettingsUpdated,
   handleShowLabelsUpdated,
+  handleVerboseDiagnosticsUpdated,
 } from '../../../../src/webview/store/messageHandlers/graph';
 import type { IStoreFields } from '../../../../src/webview/store/messageTypes';
 import type { IGraphControlsSnapshot } from '../../../../src/shared/graphControls/contracts';
@@ -76,6 +77,7 @@ function createState(
     graphViewContributionStatuses: [],
     activePanel: 'none',
     maxFiles: 500,
+    verboseDiagnostics: false,
     activeFilePath: null,
     timelineActive: false,
     timelineCommits: [],
@@ -263,6 +265,11 @@ describe('webview/store/messageHandlers/graph', () => {
       type: 'MAX_FILES_UPDATED',
       payload: { maxFiles: 250 },
     })).toEqual({ maxFiles: 250 });
+
+    expect(handleVerboseDiagnosticsUpdated({
+      type: 'VERBOSE_DIAGNOSTICS_UPDATED',
+      payload: { verboseDiagnostics: true },
+    })).toEqual({ verboseDiagnostics: true });
 
     expect(handleActiveFileUpdated({
       type: 'ACTIVE_FILE_UPDATED',

--- a/packages/mcp/src/mcp/diagnostics.ts
+++ b/packages/mcp/src/mcp/diagnostics.ts
@@ -1,0 +1,23 @@
+import {
+  collectDiagnosticEvents,
+  type DiagnosticEventSink,
+} from '@codegraphy-dev/core';
+
+export interface McpVerboseDiagnosticsInput {
+  verboseDiagnostics?: unknown;
+}
+
+export function createMcpDiagnostics(input: McpVerboseDiagnosticsInput): {
+  diagnostics?: DiagnosticEventSink;
+  withDiagnostics<T extends Record<string, unknown>>(result: T): T & { diagnostics?: unknown };
+} {
+  const enabled = input.verboseDiagnostics === true;
+  const collector = collectDiagnosticEvents(enabled);
+
+  return {
+    ...(enabled ? { diagnostics: collector } : {}),
+    withDiagnostics<T extends Record<string, unknown>>(result: T): T & { diagnostics?: unknown } {
+      return enabled ? { ...result, diagnostics: collector.events } : result;
+    },
+  };
+}

--- a/packages/mcp/src/mcp/graphQueryTool.ts
+++ b/packages/mcp/src/mcp/graphQueryTool.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { WorkspaceGraphQueryReport } from '@codegraphy-dev/core';
 import * as z from 'zod/v4';
 import type { CodeGraphyMcpServerDependencies } from './contracts';
+import { createMcpDiagnostics } from './diagnostics';
 import { createToolResult } from './toolResult';
 import { resolveInputWorkspacePath, splitWorkspacePath } from './workspacePath';
 
@@ -20,12 +21,16 @@ export function registerGraphQueryTool(
       inputSchema: z.object(inputSchema),
     },
     async (input) => {
+      const diagnostics = createMcpDiagnostics(input);
       const queryInput = splitWorkspacePath(input);
-      return createToolResult(await dependencies.runGraphQuery({
+      delete queryInput.arguments.verboseDiagnostics;
+      const result = await dependencies.runGraphQuery({
         workspacePath: resolveInputWorkspacePath(queryInput.workspacePath, dependencies),
         report,
         arguments: queryInput.arguments,
-      }));
+        ...(diagnostics.diagnostics ? { diagnostics: diagnostics.diagnostics } : {}),
+      });
+      return createToolResult(diagnostics.withDiagnostics(result));
     },
   );
 }

--- a/packages/mcp/src/mcp/pluginTools.ts
+++ b/packages/mcp/src/mcp/pluginTools.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { runPluginsCommand, type CliCommand, type CommandExecutionResult, type PluginsCommandAction } from '@codegraphy-dev/core';
 import * as z from 'zod/v4';
 import type { CodeGraphyMcpServerDependencies } from './contracts';
+import { createMcpDiagnostics } from './diagnostics';
 import { packagePluginSchema, workspacePathSchema } from './schemas';
 import { createToolResult } from './toolResult';
 
@@ -12,13 +13,6 @@ async function executePluginsCommand(
   return dependencies.runPluginsCommand
     ? dependencies.runPluginsCommand(command)
     : runPluginsCommand(command, { cwd: () => dependencies.cwd() });
-}
-
-function createPluginCommandResult(result: CommandExecutionResult) {
-  return createToolResult({
-    exitCode: result.exitCode,
-    output: result.output,
-  });
 }
 
 function registerPluginToggleTool(
@@ -32,12 +26,20 @@ function registerPluginToggleTool(
       description: `${action === 'enable' ? 'Enable' : 'Disable'} a registered plugin package for the current or explicit CodeGraphy Workspace.`,
       inputSchema: z.object(packagePluginSchema),
     },
-    async ({ packageName, path }) => createPluginCommandResult(await executePluginsCommand({
-      name: 'plugins',
-      action,
-      packageName,
-      workspacePath: path,
-    }, dependencies)),
+    async (input) => {
+      const diagnostics = createMcpDiagnostics(input);
+      const result = await executePluginsCommand({
+        name: 'plugins',
+        action,
+        packageName: input.packageName,
+        workspacePath: input.path,
+        ...(input.verboseDiagnostics === true ? { verbose: true } : {}),
+      }, dependencies);
+      return createToolResult(diagnostics.withDiagnostics({
+        exitCode: result.exitCode,
+        output: result.output,
+      }));
+    },
   );
 }
 
@@ -49,13 +51,24 @@ export function registerPluginTools(
     'codegraphy_plugins_register',
     {
       description: 'Register an explicitly named globally installed CodeGraphy plugin package in ~/.codegraphy/plugins.json.',
-      inputSchema: z.object({ packageName: packagePluginSchema.packageName }),
+      inputSchema: z.object({
+        packageName: packagePluginSchema.packageName,
+        verboseDiagnostics: workspacePathSchema.verboseDiagnostics,
+      }),
     },
-    async ({ packageName }) => createPluginCommandResult(await executePluginsCommand({
-      name: 'plugins',
-      action: 'register',
-      packageName,
-    }, dependencies)),
+    async (input) => {
+      const diagnostics = createMcpDiagnostics(input);
+      const result = await executePluginsCommand({
+        name: 'plugins',
+        action: 'register',
+        packageName: input.packageName,
+        ...(input.verboseDiagnostics === true ? { verbose: true } : {}),
+      }, dependencies);
+      return createToolResult(diagnostics.withDiagnostics({
+        exitCode: result.exitCode,
+        output: result.output,
+      }));
+    },
   );
 
   server.registerTool(
@@ -64,11 +77,19 @@ export function registerPluginTools(
       description: 'List registered plugins and which ones are enabled for the current or explicit CodeGraphy Workspace.',
       inputSchema: z.object(workspacePathSchema),
     },
-    async ({ path }) => createPluginCommandResult(await executePluginsCommand({
-      name: 'plugins',
-      action: 'list',
-      workspacePath: path,
-    }, dependencies)),
+    async (input) => {
+      const diagnostics = createMcpDiagnostics(input);
+      const result = await executePluginsCommand({
+        name: 'plugins',
+        action: 'list',
+        workspacePath: input.path,
+        ...(input.verboseDiagnostics === true ? { verbose: true } : {}),
+      }, dependencies);
+      return createToolResult(diagnostics.withDiagnostics({
+        exitCode: result.exitCode,
+        output: result.output,
+      }));
+    },
   );
 
   for (const action of ['enable', 'disable'] satisfies PluginsCommandAction[]) {

--- a/packages/mcp/src/mcp/schemas.ts
+++ b/packages/mcp/src/mcp/schemas.ts
@@ -17,6 +17,7 @@ const scopeSchema = z.object({
 
 export const workspacePathSchema = {
   path: z.string().optional(),
+  verboseDiagnostics: z.boolean().optional(),
 };
 
 export const packagePluginSchema = {

--- a/packages/mcp/src/mcp/workspaceTools.ts
+++ b/packages/mcp/src/mcp/workspaceTools.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as z from 'zod/v4';
 import type { CodeGraphyMcpServerDependencies } from './contracts';
+import { createMcpDiagnostics } from './diagnostics';
 import { workspacePathSchema } from './schemas';
 import { createToolResult } from './toolResult';
 import { resolveInputWorkspacePath } from './workspacePath';
@@ -15,9 +16,14 @@ export function registerWorkspaceTools(
       description: 'Report CodeGraphy Workspace status for the current folder or an explicit path.',
       inputSchema: z.object(workspacePathSchema),
     },
-    async ({ path }) => createToolResult(await dependencies.statusWorkspace({
-      workspacePath: resolveInputWorkspacePath(path, dependencies),
-    })),
+    async (input) => {
+      const diagnostics = createMcpDiagnostics(input);
+      const result = await dependencies.statusWorkspace({
+        workspacePath: resolveInputWorkspacePath(input.path, dependencies),
+        ...(diagnostics.diagnostics ? { diagnostics: diagnostics.diagnostics } : {}),
+      });
+      return createToolResult(diagnostics.withDiagnostics(result));
+    },
   );
 
   server.registerTool(
@@ -26,8 +32,13 @@ export function registerWorkspaceTools(
       description: 'Run Indexing for the current or explicit CodeGraphy Workspace path without focusing VS Code.',
       inputSchema: z.object(workspacePathSchema),
     },
-    async ({ path }) => createToolResult(await dependencies.indexWorkspace({
-      workspacePath: resolveInputWorkspacePath(path, dependencies),
-    })),
+    async (input) => {
+      const diagnostics = createMcpDiagnostics(input);
+      const result = await dependencies.indexWorkspace({
+        workspacePath: resolveInputWorkspacePath(input.path, dependencies),
+        ...(diagnostics.diagnostics ? { diagnostics: diagnostics.diagnostics } : {}),
+      });
+      return createToolResult(diagnostics.withDiagnostics(result));
+    },
   );
 }

--- a/packages/mcp/tests/mcp/server.test.ts
+++ b/packages/mcp/tests/mcp/server.test.ts
@@ -220,6 +220,17 @@ describe('mcp/server', () => {
     });
   });
 
+  it('accepts verbose diagnostics on every MCP tool schema', async () => {
+    const client = await connectServer(createDependencies());
+    const tools = await client.listTools();
+
+    for (const tool of tools.tools) {
+      expect(propertiesFor(tool).verboseDiagnostics).toMatchObject({
+        type: 'boolean',
+      });
+    }
+  });
+
   it('falls back to the core plugin command runner with the dependency cwd', async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'codegraphy-mcp-plugin-list-'));
     const client = await connectServer(createDependencies(workspaceRoot));
@@ -431,6 +442,62 @@ describe('mcp/server', () => {
       'index:/workspace/other',
       'query:/workspace/other:relationships',
     ]);
+  });
+
+  it('returns verbose diagnostics when MCP tools request them', async () => {
+    const client = await connectServer({
+      ...createDependencies(),
+      statusWorkspace: async ({ diagnostics, workspacePath }) => {
+        diagnostics?.emit({
+          area: 'workspace',
+          event: 'status-read',
+          context: { workspaceRoot: workspacePath ?? '/workspace/project', state: 'fresh' },
+        });
+        return {
+          workspaceRoot: workspacePath ?? '/workspace/project',
+          graphCache: '.codegraphy/graph.lbug',
+          state: 'fresh',
+          hasGraphCache: true,
+          staleReasons: [],
+          enabledPlugins: [],
+          message: 'fresh',
+        };
+      },
+      runGraphQuery: async ({ diagnostics, report }) => {
+        diagnostics?.emit({
+          area: 'graph-query',
+          event: 'completed',
+          context: { report, nodeCount: 0 },
+        });
+        return { nodes: [] };
+      },
+    });
+
+    const statusResult = await client.callTool({
+      name: 'codegraphy_status',
+      arguments: { verboseDiagnostics: true },
+    });
+    const queryResult = await client.callTool({
+      name: 'codegraphy_list_nodes',
+      arguments: { verboseDiagnostics: true },
+    });
+
+    expect(statusResult.structuredContent).toMatchObject({
+      workspaceRoot: '/workspace/project',
+      diagnostics: [{
+        area: 'workspace',
+        event: 'status-read',
+        context: { workspaceRoot: '/workspace/project', state: 'fresh' },
+      }],
+    });
+    expect(queryResult.structuredContent).toMatchObject({
+      nodes: [],
+      diagnostics: [{
+        area: 'graph-query',
+        event: 'completed',
+        context: { report: 'nodes', nodeCount: 0 },
+      }],
+    });
   });
 
   it('returns missing Graph Cache guidance from query tools without focusing VS Code', async () => {


### PR DESCRIPTION
## Summary

Implements Trello #165: Verbose Diagnostics across the VS Code extension, Core CLI, and MCP.

- Adds a **Verbose Diagnostics** toggle under Settings > Performance and persists it to `.codegraphy/settings.json` as `verboseDiagnostics`.
- Adds a Core diagnostic event contract and shared `[CodeGraphy][Diagnostics]` renderer.
- Adds global CLI `--verbose` support without corrupting JSON stdout.
- Adds `verboseDiagnostics?: boolean` to every MCP tool and returns diagnostics in tool results only when requested.
- Emits extension diagnostics for activation, webview/bootstrap replay, analysis requests, and Graph Cache load decisions.
- Documents the VS Code support workflow, CLI usage, and MCP usage in `docs/DIAGNOSTICS.md`.

## Example Outputs

VS Code Developer Tools, with Settings > Performance > Verbose Diagnostics enabled:

```text
[CodeGraphy][Diagnostics] extension.lifecycle activation-started {"workspaceFolders":1}
[CodeGraphy][Diagnostics] extension.webview ready-replayed {"hasWorkspace":true,"firstAnalysis":true,"readyNotified":false,"maxFiles":1000}
[CodeGraphy][Diagnostics] extension.analysis request-started {"requestId":4,"mode":"load","filterPatternCount":2,"disabledPluginCount":0}
[CodeGraphy][Diagnostics] extension.analysis load-decision {"mode":"load","route":"cached","shouldDiscover":false,"indexFreshness":"fresh","canReplayCache":true}
```

CLI, with diagnostics on stderr and normal output preserved:

```bash
codegraphy --verbose status /path/to/workspace
```

```text
[CodeGraphy][Diagnostics] cli command-started {"command":"status","workspacePath":"/path/to/workspace"}
[CodeGraphy][Diagnostics] workspace status-read {"workspaceRoot":"/path/to/workspace","graphCache":"fresh","enabledPluginCount":1}
[CodeGraphy][Diagnostics] cli command-completed {"command":"status","durationMs":12}
```

MCP tool input:

```json
{
  "path": "/path/to/workspace",
  "verboseDiagnostics": true
}
```

MCP tool result excerpt:

```json
{
  "diagnostics": [
    {
      "area": "workspace",
      "event": "status-read",
      "context": {
        "workspaceRoot": "/path/to/workspace",
        "state": "fresh",
        "enabledPluginCount": 1
      }
    }
  ]
}
```

## Validation

- `pnpm --filter @codegraphy-dev/core exec vitest run --config vitest.config.ts tests/diagnostics/events.test.ts tests/cli/parse.test.ts tests/cli/command.test.ts tests/cli/index/command.test.ts tests/cli/status/command.test.ts tests/workspace/coreBacked.test.ts`
- `pnpm --filter @codegraphy-dev/mcp exec vitest run --config vitest.config.ts tests/mcp/server.test.ts`
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts ...` across diagnostics/settings/reset/analysis/webview clusters: 143 extension tests passed
- Pre-commit hooks on commits ran full repo `pnpm run typecheck` and lint successfully