### PR TITLE
Extension: respect committable CodeGraphy settings in gitignore

### DIFF
--- a/.changeset/codegraphy-gitignore-policy.md
+++ b/.changeset/codegraphy-gitignore-policy.md
@@ -1,0 +1,9 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Update CodeGraphy's generated `.gitignore` entry from `.codegraphy/` to `.codegraphy/*`.
+
+CodeGraphy still keeps generated workspace artifacts ignored by default, including Graph Cache files and imported assets, but the new contents-only ignore rule lets teams intentionally commit selected files under `.codegraphy/`. This matters for example projects and shared workspaces that want to version `.codegraphy/settings.json` so collaborators see the same plugin enablement, filters, Graph Scope, and Legend settings.
+
+Existing exact `.codegraphy` or `.codegraphy/` entries are migrated to `.codegraphy/*` the next time CodeGraphy initializes workspace settings, avoiding the Git behavior where ignoring a parent directory prevents later `!` exceptions from re-including files inside it.

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,4 @@ reports/
 .stryker-tmp/
 .pnpm-store/
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -398,14 +398,20 @@ CodeGraphy’s workspace behavior lives under `<workspace-root>/.codegraphy/`.
 - `~/.codegraphy/plugins.json` is user-level Plugin Registry state and is not part of any source workspace.
 - `~/.codegraphy/settings.json` is user-level CodeGraphy default state.
 
-Recommended `.gitignore` entries:
+Recommended default `.gitignore` entry:
 
 ```gitignore
-.codegraphy/graph.lbug
-.codegraphy/cache/
+.codegraphy/*
 ```
 
-Do not ignore all of `.codegraphy/` if you want to share workspace plugin enablement, filters, Graph Scope, or Legend settings with teammates.
+That default keeps generated Graph Cache artifacts, imported icons, and other CodeGraphy-managed files out of source control. If you want to share workspace plugin enablement, filters, Graph Scope, or Legend settings with teammates, add an explicit exception for the settings file:
+
+```gitignore
+.codegraphy/*
+!.codegraphy/settings.json
+```
+
+Do not use `.codegraphy/` if you want to share any files under `.codegraphy/`; ignoring the directory itself prevents Git from re-including files inside it.
 
 ## Troubleshooting
 

--- a/docs/plans/2026-04-07-code-index-rearchitecture.md
+++ b/docs/plans/2026-04-07-code-index-rearchitecture.md
@@ -45,7 +45,7 @@ Replace CodeGraphy's current parser-orchestrator core with a persistent symbol-a
 - Symbols are primarily for indexing, resolution, querying, exports, timeline overlays, and optional visualizations.
 - Drop the optional symbol visualization surface from scope.
 - `.codegraphy/` is the canonical local cache/index location.
-- CodeGraphy should auto-add `.codegraphy/` to repo `.gitignore` when safe.
+- CodeGraphy should auto-add `.codegraphy/*` to repo `.gitignore` when safe.
 - Move all meaningful repo-specific CodeGraphy settings out of `.vscode/settings.json` and into `.codegraphy/settings.json`.
 - LadybugDB is the default persistence layer unless blocked by integration constraints discovered during implementation.
 - Use native Tree-sitter in the extension host for this rewrite; do not add WASM Tree-sitter to CodeGraphy core right now.
@@ -66,7 +66,7 @@ Replace CodeGraphy's current parser-orchestrator core with a persistent symbol-a
 - `package` means real workspace/package boundaries such as monorepo packages or equivalent project units.
 - Built-in plugins should be aggressively simplified once the new Tree-sitter core covers their current baseline work.
 - Plugin output should override core output directly, like replacing object fields, not coexist as parallel conflicting results.
-- Create `.gitignore` automatically when absent, then add `.codegraphy/`.
+- Create `.gitignore` automatically when absent, then add `.codegraphy/*`.
 - Loading UI can stay simple: one percent-based progress bar at the bottom of the graph.
 - Reorganize graph controls:
   - keep the `Plugins` popup, but repurpose it for plugin enable/disable and drag reordering
@@ -299,7 +299,7 @@ Replace CodeGraphy's current parser-orchestrator core with a persistent symbol-a
   - `meta.json` for index metadata
   - optional embeddings/vector data
 - Git hygiene:
-  - auto-add `.codegraphy/` to `.gitignore` when absent
+  - auto-add `.codegraphy/*` to `.gitignore` when absent
   - never index `.codegraphy/` itself
 - Do not depend on `.vscode/settings.json` for repo-specific CodeGraphy behavior.
 

--- a/docs/plans/2026-05-13-extract-core-from-extension-package.md
+++ b/docs/plans/2026-05-13-extract-core-from-extension-package.md
@@ -732,12 +732,13 @@ Graph Cache sharing decision:
 - Graph Cache can be large, stale, branch-sensitive, plugin-version-sensitive, and machine/path-sensitive
 - teams should commit workspace settings when desired, not the Graph Cache
 - `codegraphy index` should regenerate Graph Cache for the current CodeGraphy Workspace
-- recommended ignore entries:
+- recommended default ignore entry:
 
 ```gitignore
-.codegraphy/graph.lbug
-.codegraphy/cache/
+.codegraphy/*
 ```
+
+- teams that want shared workspace settings should add `!.codegraphy/settings.json`
 
 Graph Cache staleness decision:
 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-c/.gitignore
+++ b/examples/example-c/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-cpp/.gitignore
+++ b/examples/example-cpp/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-csharp/.gitignore
+++ b/examples/example-csharp/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-dart/.gitignore
+++ b/examples/example-dart/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-go/.gitignore
+++ b/examples/example-go/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-godot/.gitignore
+++ b/examples/example-godot/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-haskell/.gitignore
+++ b/examples/example-haskell/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-java/.gitignore
+++ b/examples/example-java/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-kotlin/.gitignore
+++ b/examples/example-kotlin/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-lua/.gitignore
+++ b/examples/example-lua/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-markdown/.gitignore
+++ b/examples/example-markdown/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-php/.gitignore
+++ b/examples/example-php/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-python/.gitignore
+++ b/examples/example-python/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-ruby/.gitignore
+++ b/examples/example-ruby/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-rust/.gitignore
+++ b/examples/example-rust/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-swift/.gitignore
+++ b/examples/example-swift/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/examples/example-typescript/.gitignore
+++ b/examples/example-typescript/.gitignore
@@ -1,3 +1,2 @@
 .codegraphy/*
-!.codegraphy/
 !.codegraphy/settings.json

--- a/packages/extension/src/extension/repoSettings/store/persistence/files.ts
+++ b/packages/extension/src/extension/repoSettings/store/persistence/files.ts
@@ -2,7 +2,8 @@ import * as fs from 'node:fs';
 
 export const SETTINGS_DIR_NAME = '.codegraphy';
 export const SETTINGS_FILE_NAME = 'settings.json';
-const SETTINGS_IGNORE_ENTRY = '.codegraphy/';
+const SETTINGS_IGNORE_ENTRY = '.codegraphy/*';
+const LEGACY_SETTINGS_IGNORE_ENTRIES = new Set(['.codegraphy', '.codegraphy/']);
 
 export function ensureGitIgnoreContainsCodeGraphyEntry(gitIgnorePath: string): void {
   if (!fs.existsSync(gitIgnorePath)) {
@@ -16,7 +17,15 @@ export function ensureGitIgnoreContainsCodeGraphyEntry(gitIgnorePath: string): v
     .map(line => line.trim())
     .filter(Boolean);
 
-  if (lines.some(line => line === '.codegraphy' || line === SETTINGS_IGNORE_ENTRY)) {
+  if (lines.includes(SETTINGS_IGNORE_ENTRY)) {
+    return;
+  }
+
+  if (lines.some(line => LEGACY_SETTINGS_IGNORE_ENTRIES.has(line))) {
+    fs.writeFileSync(
+      gitIgnorePath,
+      existing.replace(/(^|\r?\n)([ \t]*)\.codegraphy\/?([ \t]*)(?=\r?\n|$)/, `$1$2${SETTINGS_IGNORE_ENTRY}$3`),
+    );
     return;
   }
 

--- a/packages/extension/test-fixtures/workspace/.gitignore
+++ b/packages/extension/test-fixtures/workspace/.gitignore
@@ -1,1 +1,1 @@
-.codegraphy/
+.codegraphy/*

--- a/packages/extension/tests/extension/repoSettings/store.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store.test.ts
@@ -52,7 +52,7 @@ describe('extension/repoSettings/store', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('creates .gitignore when missing and adds .codegraphy/ once', () => {
+  it('creates .gitignore when missing and adds the CodeGraphy contents ignore once', () => {
     const workspaceRoot = createTempWorkspace();
     tempDirectories.push(workspaceRoot);
 
@@ -60,7 +60,7 @@ describe('extension/repoSettings/store', () => {
     new CodeGraphyRepoSettingsStore(workspaceRoot);
 
     const gitIgnorePath = path.join(workspaceRoot, '.gitignore');
-    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('.codegraphy/\n');
+    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('.codegraphy/*\n');
   });
 
   it('updates nested settings keys and persists the result', async () => {

--- a/packages/extension/tests/extension/repoSettings/store/persistence/files.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store/persistence/files.test.ts
@@ -32,7 +32,7 @@ describe('extension/repoSettings/store/persistence/files', () => {
 
     ensureGitIgnoreContainsCodeGraphyEntry(gitIgnorePath);
 
-    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('.codegraphy/\n');
+    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('.codegraphy/*\n');
   });
 
   it('appends the entry to an empty gitignore without a leading blank line', () => {
@@ -42,7 +42,7 @@ describe('extension/repoSettings/store/persistence/files', () => {
 
     ensureGitIgnoreContainsCodeGraphyEntry(gitIgnorePath);
 
-    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('.codegraphy/\n');
+    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('.codegraphy/*\n');
   });
 
   it('appends the repo-local entry once and preserves existing newline state', () => {
@@ -53,10 +53,22 @@ describe('extension/repoSettings/store/persistence/files', () => {
     ensureGitIgnoreContainsCodeGraphyEntry(gitIgnorePath);
     ensureGitIgnoreContainsCodeGraphyEntry(gitIgnorePath);
 
-    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('dist\ncoverage\n.codegraphy/\n');
+    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('dist\ncoverage\n.codegraphy/*\n');
   });
 
-  it('treats both .codegraphy and .codegraphy/ as existing entries', () => {
+  it('preserves a repo policy that ignores CodeGraphy contents but shares settings', () => {
+    const gitIgnorePath = createTempFilePath('.gitignore');
+    tempDirectories.push(path.dirname(gitIgnorePath));
+    fs.writeFileSync(gitIgnorePath, '.codegraphy/*\n!.codegraphy/settings.json\n', 'utf8');
+
+    ensureGitIgnoreContainsCodeGraphyEntry(gitIgnorePath);
+
+    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe(
+      '.codegraphy/*\n!.codegraphy/settings.json\n',
+    );
+  });
+
+  it('migrates legacy directory ignore entries to a contents ignore entry', () => {
     const barePath = createTempFilePath('bare.gitignore');
     const suffixedPath = createTempFilePath('suffixed.gitignore');
     tempDirectories.push(path.dirname(barePath));
@@ -67,17 +79,17 @@ describe('extension/repoSettings/store/persistence/files', () => {
     ensureGitIgnoreContainsCodeGraphyEntry(barePath);
     ensureGitIgnoreContainsCodeGraphyEntry(suffixedPath);
 
-    expect(fs.readFileSync(barePath, 'utf8')).toBe('.codegraphy\n');
-    expect(fs.readFileSync(suffixedPath, 'utf8')).toBe('.codegraphy/\n');
+    expect(fs.readFileSync(barePath, 'utf8')).toBe('.codegraphy/*\n');
+    expect(fs.readFileSync(suffixedPath, 'utf8')).toBe('.codegraphy/*\n');
   });
 
-  it('treats whitespace-padded existing entries as already present', () => {
+  it('migrates whitespace-padded legacy entries', () => {
     const gitIgnorePath = createTempFilePath('spaced.gitignore');
     tempDirectories.push(path.dirname(gitIgnorePath));
     fs.writeFileSync(gitIgnorePath, 'dist\n   .codegraphy/   \n\n', 'utf8');
 
     ensureGitIgnoreContainsCodeGraphyEntry(gitIgnorePath);
 
-    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('dist\n   .codegraphy/   \n\n');
+    expect(fs.readFileSync(gitIgnorePath, 'utf8')).toBe('dist\n   .codegraphy/*   \n\n');
   });
 });


### PR DESCRIPTION
## Summary

Draft PR for Trello https://trello.com/c/3iscbGYa.

Updates CodeGraphy's generated `.gitignore` policy from ignoring the `.codegraphy` directory itself to ignoring the directory contents with `.codegraphy/*`. That keeps generated Graph Cache and other CodeGraphy artifacts out of user commits by default while still allowing a user to manually unignore selected files such as `.codegraphy/settings.json`.

## What Changed

- Changed the extension repo-settings persistence default ignore entry to `.codegraphy/*`
- Migrated exact legacy `.codegraphy` / `.codegraphy/` ignore entries to `.codegraphy/*` when CodeGraphy touches repo settings
- Preserved manual include exceptions such as `!.codegraphy/settings.json`
- Updated package/example `.gitignore` files to remove the unnecessary `!.codegraphy/` exception
- Refreshed settings/planning docs and added a changeset with the user-facing rationale
- Updated the stale repo settings store test expectation that was failing extension CI

## Tests

- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/repoSettings/store.test.ts tests/extension/repoSettings/store/persistence/files.test.ts`
- `pnpm --filter @codegraphy-dev/extension test`
- `pnpm run lint`
- Pre-commit hook: acceptance spec ownership, `pnpm run typecheck`, lint-staged
- `pnpm run test` partially: unit suite passed; local `test:vscode` failed before CodeGraphy opened because Electron closed during `firstWindow()`

## CI

All GitHub checks are passing on the latest push, including extension node/webview unit shards and Playwright.