### PR TITLE
Default fresh graph scope to imports-only edges

### DIFF
--- a/.changeset/imports-only-edge-defaults.md
+++ b/.changeset/imports-only-edge-defaults.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Default fresh Graph Scope Edge Types to Imports on and other built-in edges off.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -271,6 +271,10 @@ Node, edge, Legend, and Plugin Settings Controls are in dedicated toolbar popups
 - **Plugins**: enable/disable plugins and reorder them
 - **Depth Mode**: optional toolbar mode that focuses the Visible Graph around the Focused Node
 
+Fresh CodeGraphy Workspaces default built-in Edge Type scope to **Imports** on and all other built-in Edge Types off. Plugin-contributed Edge Types default off unless the plugin explicitly defines a different `defaultVisible` value. Existing values saved in `.codegraphy/settings.json` remain the expected workspace values and are not migrated to new defaults. Users can enable additional Edge Types from Graph Scope without re-indexing when those relationships are already present in the Graph Cache.
+
+Graph Scope lists built-in Edge Types by common usefulness: **Imports**, **References**, **Calls**, **Tests**, **Re-exports**, **Type imports**, **Inherits**, **Loads**, **Nests**, **Contains**, then **Overrides**. Plugin-contributed Edge Types appear after built-ins unless a later product decision defines plugin grouping.
+
 Graph Cache enrichment follows Graph Scope. CodeGraphy caches baseline file nodes and file-level edges first; enabling Symbols or a plugin computes the missing tier and keeps it cached when that scope is turned off again.
 
 ## File discovery settings

--- a/packages/extension/src/shared/graphControls/defaults/edgeTypes.ts
+++ b/packages/extension/src/shared/graphControls/defaults/edgeTypes.ts
@@ -5,16 +5,34 @@ export const STRUCTURAL_NESTS_EDGE_KIND = 'nests' as const;
 export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
   return [
     {
-      id: STRUCTURAL_NESTS_EDGE_KIND,
-      label: 'Nests',
-      defaultColor: '#64748B',
-      defaultVisible: true,
-    },
-    {
       id: 'import',
       label: 'Imports',
       defaultColor: '#60A5FA',
       defaultVisible: true,
+    },
+    {
+      id: 'reference',
+      label: 'References',
+      defaultColor: '#F97316',
+      defaultVisible: false,
+    },
+    {
+      id: 'call',
+      label: 'Calls',
+      defaultColor: '#22C55E',
+      defaultVisible: false,
+    },
+    {
+      id: 'test',
+      label: 'Tests',
+      defaultColor: '#EF4444',
+      defaultVisible: false,
+    },
+    {
+      id: 'reexport',
+      label: 'Re-exports',
+      defaultColor: '#A78BFA',
+      defaultVisible: false,
     },
     {
       id: 'type-import',
@@ -23,52 +41,34 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultVisible: false,
     },
     {
-      id: 'reexport',
-      label: 'Re-exports',
-      defaultColor: '#A78BFA',
-      defaultVisible: true,
-    },
-    {
-      id: 'call',
-      label: 'Calls',
-      defaultColor: '#22C55E',
-      defaultVisible: true,
-    },
-    {
       id: 'inherit',
       label: 'Inherits',
       defaultColor: '#F59E0B',
-      defaultVisible: true,
-    },
-    {
-      id: 'reference',
-      label: 'References',
-      defaultColor: '#F97316',
-      defaultVisible: true,
-    },
-    {
-      id: 'test',
-      label: 'Tests',
-      defaultColor: '#EF4444',
-      defaultVisible: true,
+      defaultVisible: false,
     },
     {
       id: 'load',
       label: 'Loads',
       defaultColor: '#06B6D4',
-      defaultVisible: true,
+      defaultVisible: false,
+    },
+    {
+      id: STRUCTURAL_NESTS_EDGE_KIND,
+      label: 'Nests',
+      defaultColor: '#64748B',
+      defaultVisible: false,
     },
     {
       id: 'contains',
       label: 'Contains',
       defaultColor: '#94A3B8',
-      defaultVisible: true,
+      defaultVisible: false,
     },
     {
       id: 'overrides',
       label: 'Overrides',
       defaultColor: '#EC4899',
-      defaultVisible: true,
+      defaultVisible: false,
     },
   ];
 }

--- a/packages/extension/tests/extension/graphView/controls/definitions/snapshot.test.ts
+++ b/packages/extension/tests/extension/graphView/controls/definitions/snapshot.test.ts
@@ -101,7 +101,7 @@ describe('extension/graphView/controls/snapshot', () => {
     expect(snapshot.edgeVisibility).toEqual(expect.objectContaining({
       import: true,
       'plugin:route': false,
-      [STRUCTURAL_NESTS_EDGE_KIND]: true,
+      [STRUCTURAL_NESTS_EDGE_KIND]: false,
       'custom:route': true,
     }));
   });
@@ -144,6 +144,7 @@ describe('extension/graphView/controls/snapshot', () => {
       'plugin:codegraphy.gdscript:symbol:godot-class-name': false,
     });
     expect(snapshot.edgeTypes.map((edgeType) => edgeType.id)).toContain('import');
-    expect(snapshot.edgeVisibility[STRUCTURAL_NESTS_EDGE_KIND]).toBe(true);
+    expect(snapshot.edgeVisibility.import).toBe(true);
+    expect(snapshot.edgeVisibility[STRUCTURAL_NESTS_EDGE_KIND]).toBe(false);
   });
 });

--- a/packages/extension/tests/shared/graphControls/defaults/edgeTypes.test.ts
+++ b/packages/extension/tests/shared/graphControls/defaults/edgeTypes.test.ts
@@ -10,16 +10,34 @@ describe('shared/graphControls/defaults/edgeTypes', () => {
     expect(STRUCTURAL_NESTS_EDGE_KIND).toBe('nests');
     expect(createCoreGraphEdgeTypes()).toEqual([
       {
-        id: 'nests',
-        label: 'Nests',
-        defaultColor: '#64748B',
-        defaultVisible: true,
-      },
-      {
         id: 'import',
         label: 'Imports',
         defaultColor: '#60A5FA',
         defaultVisible: true,
+      },
+      {
+        id: 'reference',
+        label: 'References',
+        defaultColor: '#F97316',
+        defaultVisible: false,
+      },
+      {
+        id: 'call',
+        label: 'Calls',
+        defaultColor: '#22C55E',
+        defaultVisible: false,
+      },
+      {
+        id: 'test',
+        label: 'Tests',
+        defaultColor: '#EF4444',
+        defaultVisible: false,
+      },
+      {
+        id: 'reexport',
+        label: 'Re-exports',
+        defaultColor: '#A78BFA',
+        defaultVisible: false,
       },
       {
         id: 'type-import',
@@ -28,52 +46,34 @@ describe('shared/graphControls/defaults/edgeTypes', () => {
         defaultVisible: false,
       },
       {
-        id: 'reexport',
-        label: 'Re-exports',
-        defaultColor: '#A78BFA',
-        defaultVisible: true,
-      },
-      {
-        id: 'call',
-        label: 'Calls',
-        defaultColor: '#22C55E',
-        defaultVisible: true,
-      },
-      {
         id: 'inherit',
         label: 'Inherits',
         defaultColor: '#F59E0B',
-        defaultVisible: true,
-      },
-      {
-        id: 'reference',
-        label: 'References',
-        defaultColor: '#F97316',
-        defaultVisible: true,
-      },
-      {
-        id: 'test',
-        label: 'Tests',
-        defaultColor: '#EF4444',
-        defaultVisible: true,
+        defaultVisible: false,
       },
       {
         id: 'load',
         label: 'Loads',
         defaultColor: '#06B6D4',
-        defaultVisible: true,
+        defaultVisible: false,
+      },
+      {
+        id: 'nests',
+        label: 'Nests',
+        defaultColor: '#64748B',
+        defaultVisible: false,
       },
       {
         id: 'contains',
         label: 'Contains',
         defaultColor: '#94A3B8',
-        defaultVisible: true,
+        defaultVisible: false,
       },
       {
         id: 'overrides',
         label: 'Overrides',
         defaultColor: '#EC4899',
-        defaultVisible: true,
+        defaultVisible: false,
       },
     ]);
     expect(CORE_GRAPH_EDGE_TYPES).toEqual(createCoreGraphEdgeTypes());


### PR DESCRIPTION
## Summary
- default fresh CodeGraphy Workspace Edge Type scope to Imports on and other built-in edges off
- reorder built-in Edge Types by common usefulness with Imports first
- document that saved .codegraphy/settings.json edge visibility remains explicit workspace intent
- add a patch changeset for the fresh-workspace behavior change

Trello: https://trello.com/c/pLe00BUI

## Verification
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/shared/graphControls/defaults/edgeTypes.test.ts
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/shared/graphControls/defaults tests/webview/graphScope tests/webview/search/visibleGraphConfig.test.ts tests/webview/search/useFilteredGraph.test.ts tests/shared/visibleGraph
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/controls/definitions/snapshot.test.ts
- pnpm --filter @codegraphy-dev/extension test
- PR CI: all checks passing, including playwright

Note: I tried the local VS Code Playwright command, but it launched the host VS Code keychain prompt on this Mac. I stopped using that local route and used PR CI as the Playwright signal.