### PR TITLE
Fix Vue plugin release workflow setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ on:
           - python
           - csharp
           - godot
+          - markdown
+          - vue
           - plugin-api
           - npm
           - vsce

--- a/packages/plugin-vue/CHANGELOG.md
+++ b/packages/plugin-vue/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @codegraphy-dev/plugin-vue

--- a/packages/plugin-vue/LICENSE
+++ b/packages/plugin-vue/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joe Soboleski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -1,0 +1,35 @@
+# CodeGraphy Vue
+
+Adds Vue Single-File Component script import analysis to [CodeGraphy](https://marketplace.visualstudio.com/items?itemName=codegraphy.codegraphy).
+
+- Package: [`@codegraphy-dev/plugin-vue`](https://www.npmjs.com/package/@codegraphy-dev/plugin-vue)
+- Plugin API: [`@codegraphy-dev/plugin-api`](https://www.npmjs.com/package/@codegraphy-dev/plugin-api)
+
+## Install
+
+Install `@codegraphy-dev/core` first if the `codegraphy` CLI is not already available.
+
+```bash
+npm i -g @codegraphy-dev/plugin-vue
+codegraphy plugins register @codegraphy-dev/plugin-vue
+codegraphy plugins enable @codegraphy-dev/plugin-vue
+codegraphy index
+```
+
+## What It Provides
+
+This plugin parses Vue 3 Single-File Components with `@vue/compiler-sfc` and
+indexes relative imports from `<script>` and `<script setup>` blocks.
+
+- runtime imports become baseline import relationships
+- type-only imports become type-import relationships
+- explicit `.vue` component imports resolve to Vue SFC files
+- TypeScript and JavaScript script imports resolve with the baseline extension candidates
+
+Core CodeGraphy owns the default `.vue` icon and color through Material Icon Theme.
+This plugin does not ship general file theming or Vue-specific graph node/edge types.
+
+## More
+
+- [Plugin guide](https://github.com/joesobo/CodeGraphyV4/blob/main/docs/PLUGINS.md)
+- [Repository](https://github.com/joesobo/CodeGraphyV4/tree/main/packages/plugin-vue)

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -53,6 +53,18 @@ function packageAlias(packageName) {
   return packageName;
 }
 
+function packageAliases(packageName) {
+  const alias = packageAlias(packageName);
+  const aliases = [alias];
+
+  if (alias.startsWith('plugin-')) {
+    aliases.push(alias.slice('plugin-'.length));
+  }
+
+  aliases.push(packageName);
+  return aliases;
+}
+
 function collectWorkspacePackages(baseDir) {
   const rootManifest = readJson(path.join(baseDir, 'package.json'));
   const packages = [];
@@ -134,7 +146,7 @@ function toWorkspaceReleaseTarget(workspacePackage) {
 
   return {
     id: packageAlias(manifest.name),
-    aliases: [packageAlias(manifest.name), manifest.name],
+    aliases: packageAliases(manifest.name),
     kind: hasVsceRelease ? 'vsce' : 'npm',
     packageName: manifest.name,
     version: manifest.version,

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { collectReleaseTargets, resolveReleaseTargets } from './release.mjs';
+
+test('language plugin release targets resolve by short language name', () => {
+  const repoRoot = createReleaseFixture({
+    'packages/plugin-typescript/package.json': packageManifest('@codegraphy-dev/plugin-typescript'),
+    'packages/plugin-vue/package.json': packageManifest('@codegraphy-dev/plugin-vue'),
+  });
+
+  assert.deepEqual(resolveReleaseTargets('typescript', repoRoot).map(target => target.packageName), [
+    '@codegraphy-dev/plugin-typescript',
+  ]);
+  assert.deepEqual(resolveReleaseTargets('vue', repoRoot).map(target => target.packageName), [
+    '@codegraphy-dev/plugin-vue',
+  ]);
+});
+
+test('release target list exposes plugin and short aliases', () => {
+  const repoRoot = createReleaseFixture({
+    'packages/plugin-vue/package.json': packageManifest('@codegraphy-dev/plugin-vue'),
+  });
+
+  const targets = collectReleaseTargets(repoRoot);
+
+  assert.equal(targets.length, 2);
+  assert.deepEqual(targets[0], {
+    id: 'plugin-vue',
+    aliases: ['plugin-vue', 'vue', '@codegraphy-dev/plugin-vue'],
+    kind: 'npm',
+    packageName: '@codegraphy-dev/plugin-vue',
+    version: '1.0.0',
+    hasBuildScript: true,
+    access: 'public',
+  });
+  assert.deepEqual(targets[1], {
+    id: 'extension',
+    aliases: ['extension', 'vsix', 'marketplace', 'core-extension'],
+    kind: 'extension',
+  });
+});
+
+function createReleaseFixture(files) {
+  const repoRoot = mkdtempSync(path.join(tmpdir(), 'codegraphy-release-test-'));
+  writeFile(repoRoot, 'package.json', {
+    workspaces: ['packages/*'],
+  });
+
+  for (const [relativePath, contents] of Object.entries(files)) {
+    writeFile(repoRoot, relativePath, contents);
+  }
+
+  return repoRoot;
+}
+
+function writeFile(repoRoot, relativePath, contents) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, `${JSON.stringify(contents, null, 2)}\n`);
+}
+
+function packageManifest(name) {
+  return {
+    name,
+    version: '1.0.0',
+    publishConfig: { access: 'public' },
+    scripts: { build: 'echo build' },
+  };
+}


### PR DESCRIPTION
## Summary
- add short language aliases for plugin release targets so workflow choices like typescript/python/vue resolve to npm packages
- add markdown and vue to the release workflow target dropdown
- add Vue plugin README, CHANGELOG stub, and LICENSE so the npm package includes the same release docs as the other public plugins
- cover release target aliases with a focused node --test regression

## Verification
- node --test scripts/release.test.mjs
- node -e release target smoke for vue/markdown/typescript
- pnpm --filter @codegraphy-dev/plugin-vue test
- pnpm --filter @codegraphy-dev/plugin-vue run typecheck
- pnpm --filter @codegraphy-dev/plugin-vue run build && pnpm --filter @codegraphy-dev/plugin-vue pack --dry-run
- pre-commit: full repo typecheck