### PR TITLE
Fix overlapping edge type curves

### DIFF
--- a/.changeset/curved-edge-types.md
+++ b/.changeset/curved-edge-types.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Curve different edge types between the same nodes so every visible edge can be seen.

--- a/packages/extension/src/webview/components/graph/model/link/grouping.ts
+++ b/packages/extension/src/webview/components/graph/model/link/grouping.ts
@@ -29,9 +29,7 @@ export function groupLinksByNodePair<T extends CurvatureLink>(links: T[]): Group
     const orderedPairId = sourceId <= targetId
       ? `${sourceId}_${targetId}`
       : `${targetId}_${sourceId}`;
-    const pairId = link.curvatureGroupId
-      ? `${orderedPairId}_${link.curvatureGroupId}`
-      : orderedPairId;
+    const pairId = orderedPairId;
     link.nodePairId = pairId;
     const map = sourceId === targetId ? selfLoopLinks : sameNodesLinks;
     if (!map[pairId]) map[pairId] = [];

--- a/packages/extension/tests/webview/graph/model/link/build.test.ts
+++ b/packages/extension/tests/webview/graph/model/link/build.test.ts
@@ -37,7 +37,7 @@ describe('graph/model/link/build direct coverage', () => {
     ]);
   });
 
-  it('keeps different edge kinds straight when they share the same nodes', () => {
+  it('curves different edge kinds when they share the same nodes', () => {
     const links = buildGraphLinks(
       [
         { id: 'edge-1', from: 'a.ts', to: 'b.ts' , kind: 'import', sources: [] },
@@ -50,8 +50,9 @@ describe('graph/model/link/build direct coverage', () => {
       expect.objectContaining({ id: 'edge-1', bidirectional: false }),
       expect.objectContaining({ id: 'edge-2', bidirectional: false }),
     ]);
-    expect(links[0]).not.toHaveProperty('curvature');
-    expect(links[1]).not.toHaveProperty('curvature');
+    expect(links[0].curvature).toBeDefined();
+    expect(links[1].curvature).toBeDefined();
+    expect(links[0].curvature).not.toBe(links[1].curvature);
   });
 
   it('defaults one-way links to bidirectional false with no base color', () => {

--- a/packages/extension/tests/webview/graph/model/link/curvature.test.ts
+++ b/packages/extension/tests/webview/graph/model/link/curvature.test.ts
@@ -36,7 +36,7 @@ describe('computeLinkCurvature', () => {
     expect(links[0].curvature).not.toBe(links[1].curvature);
   });
 
-  it('keeps different curvature groups straight even when they share the same node pair', () => {
+  it('assigns distinct curvatures for different edge types between the same nodes', () => {
     const links: CurvatureLink[] = [
       { source: 'A', target: 'B', curvatureGroupId: 'import' },
       { source: 'A', target: 'B', curvatureGroupId: 'call' },
@@ -44,8 +44,9 @@ describe('computeLinkCurvature', () => {
 
     computeLinkCurvature(links);
 
-    expect(links[0].curvature).toBeUndefined();
-    expect(links[1].curvature).toBeUndefined();
+    expect(links[0].curvature).toBeDefined();
+    expect(links[1].curvature).toBeDefined();
+    expect(links[0].curvature).not.toBe(links[1].curvature);
   });
 
   it('distributes curvatures evenly for 3+ parallel links', () => {

--- a/packages/extension/tests/webview/graph/model/link/grouping.test.ts
+++ b/packages/extension/tests/webview/graph/model/link/grouping.test.ts
@@ -76,14 +76,17 @@ describe('groupLinksByNodePair', () => {
     expect(links[0].nodePairId).toBe('X_Y');
   });
 
-  it('appends curvature group id when present', () => {
+  it('keeps edge types in the same curvature group when nodes match', () => {
     const links: CurvatureLink[] = [
       { source: 'X', target: 'Y', curvatureGroupId: 'call' },
+      { source: 'X', target: 'Y', curvatureGroupId: 'import' },
     ];
 
-    groupLinksByNodePair(links);
+    const result = groupLinksByNodePair(links);
 
-    expect(links[0].nodePairId).toBe('X_Y_call');
+    expect(links[0].nodePairId).toBe('X_Y');
+    expect(links[1].nodePairId).toBe('X_Y');
+    expect(result.sameNodesLinks['X_Y']).toHaveLength(2);
   });
 
   it('groups multiple self-loops by the same node', () => {


### PR DESCRIPTION
## Summary
- Curve all edges that share the same node pair, even when their edge types differ
- Keep edge type metadata on links while using the node pair as the curvature bucket
- Add regression coverage for different edge kinds sharing the same source and target

Trello: https://trello.com/c/DjmTPxpS/179-edge-types-overlapping

## Visual verification
Captured before/after screenshots locally from the real VS Code extension graph view against the TypeScript example with the TypeScript plugin enabled and the Calls Edge Type enabled. The captures verified `origin/main` showed 12 nodes / 11 connections with same-node different-type edges stacked, while this PR fans those edges into separate visible curves.

The screenshots are intentionally not committed to the repository.

## Tests
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/graph/model/link
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/graph/model tests/webview/graph/rendering/surface/view/twoDimensional.computesnodevalfromnodesizetosetslinkdirectionalarrowlengthto0when.test.tsx tests/webview/graph/rendering/surface/view/threeDimensional.passeslinkwidthcallbacktopassesgetarrowcoloraslinkdirectionalarrowcolor.test.tsx
- pnpm --filter @codegraphy-dev/extension run typecheck
- pnpm --filter @codegraphy-dev/extension run lint
- pre-commit: pnpm run check:acceptance-specs, pnpm run typecheck, lint-staged eslint --fix
- screenshot capture: temporary Playwright-VS Code spec against `origin/main` and this PR branch; temp spec removed before commit
