### PR TITLE
[codex] Support extends export for Java language

### DIFF
--- a/.changeset/java-extends-symbol-export.md
+++ b/.changeset/java-extends-symbol-export.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/core": patch
+---
+
+Export Java class `extends` relationships as symbol-level inheritance evidence without adding superclass file edges to the basic graph.

--- a/packages/core/src/treeSitter/runtime/analyzeJava/file.ts
+++ b/packages/core/src/treeSitter/runtime/analyzeJava/file.ts
@@ -25,6 +25,7 @@ function visitJavaNode(
   walk: (node: Parser.SyntaxNode, context: SymbolWalkState) => void,
   filePath: string,
   sourceRoot: string | null,
+  packageName: string | null,
   relations: IAnalysisRelation[],
   symbols: IAnalysisSymbol[],
   importedBindings: Map<string, ImportedBinding>,
@@ -39,7 +40,15 @@ function visitJavaNode(
     case 'interface_declaration':
     case 'enum_declaration': {
       if (symbolsEnabled) {
-        handleJavaTypeDeclaration(node, filePath, symbols);
+        handleJavaTypeDeclaration(
+          node,
+          filePath,
+          sourceRoot,
+          packageName,
+          relations,
+          symbols,
+          importedBindings,
+        );
       }
       return;
     }
@@ -67,7 +76,7 @@ export function analyzeJavaFile(
   const relations: IAnalysisRelation[] = [];
   const symbols: IAnalysisSymbol[] = [];
   const symbolsEnabled = shouldIncludeTreeSitterSymbols(options);
-  const { sourceRoot } = resolveJavaSourceInfo(filePath, tree);
+  const { packageName, sourceRoot } = resolveJavaSourceInfo(filePath, tree);
   walkTree(tree.rootNode, {}, (node, state, walk) =>
     visitJavaNode(
       node,
@@ -75,6 +84,7 @@ export function analyzeJavaFile(
       walk,
       filePath,
       sourceRoot,
+      packageName,
       relations,
       symbols,
       importedBindings,

--- a/packages/core/src/treeSitter/runtime/analyzeJava/typeDeclarations.ts
+++ b/packages/core/src/treeSitter/runtime/analyzeJava/typeDeclarations.ts
@@ -1,9 +1,18 @@
 import type Parser from 'tree-sitter';
 import type {
+  IAnalysisRelation,
   IAnalysisSymbol,
 } from '@codegraphy-dev/plugin-api';
+import { resolveJavaTypePath } from '../projectRoots';
+import type { ImportedBinding } from '../analyze/model';
 import { getIdentifierText } from '../analyze/nodes';
-import { createSymbol } from '../analyze/results';
+import { addRelation, createSymbol, createSymbolId } from '../analyze/results';
+import { TREE_SITTER_SOURCE_IDS } from '../languages';
+
+interface JavaExtendsType {
+  specifier: string;
+  symbolName: string;
+}
 
 function getJavaTypeDeclarationKind(node: Parser.SyntaxNode): 'interface' | 'enum' | 'class' {
   if (node.type === 'interface_declaration') {
@@ -20,10 +29,90 @@ function getJavaTypeDeclarationKind(node: Parser.SyntaxNode): 'interface' | 'enu
 export function handleJavaTypeDeclaration(
   node: Parser.SyntaxNode,
   filePath: string,
+  sourceRoot: string | null,
+  packageName: string | null,
+  relations: IAnalysisRelation[],
   symbols: IAnalysisSymbol[],
+  importedBindings: ReadonlyMap<string, ImportedBinding>,
 ): void {
   const name = getIdentifierText(node.childForFieldName('name'));
-  if (name) {
-    symbols.push(createSymbol(filePath, getJavaTypeDeclarationKind(node), name, node));
+  if (!name) {
+    return;
   }
+
+  const symbol = createSymbol(filePath, getJavaTypeDeclarationKind(node), name, node);
+  symbols.push(symbol);
+
+  if (node.type !== 'class_declaration') {
+    return;
+  }
+
+  const extendsType = getJavaExtendsType(node);
+  if (!extendsType) {
+    return;
+  }
+
+  const resolvedPath = resolveJavaReferencePath(
+    sourceRoot,
+    packageName,
+    importedBindings,
+    extendsType.specifier,
+  );
+
+  addRelation(relations, {
+    kind: 'inherit',
+    sourceId: TREE_SITTER_SOURCE_IDS.inherit,
+    fromFilePath: filePath,
+    fromSymbolId: symbol.id,
+    specifier: extendsType.specifier,
+    ...(resolvedPath ? { toSymbolId: createSymbolId(resolvedPath, 'class', extendsType.symbolName) } : {}),
+  });
+}
+
+function getJavaExtendsType(node: Parser.SyntaxNode): JavaExtendsType | null {
+  const superclass = node.childForFieldName('superclass');
+  if (!superclass) {
+    return null;
+  }
+
+  const typeNode = superclass.namedChildren[0];
+  if (!typeNode) {
+    return null;
+  }
+
+  if (typeNode.type === 'scoped_type_identifier') {
+    const symbolName = getLastTypeIdentifier(typeNode);
+    return symbolName ? { specifier: typeNode.text, symbolName } : null;
+  }
+
+  const typeIdentifier = typeNode.type === 'generic_type'
+    ? typeNode.descendantsOfType('type_identifier')[0]
+    : typeNode;
+  const symbolName = getIdentifierText(typeIdentifier);
+  return symbolName ? { specifier: symbolName, symbolName } : null;
+}
+
+function getLastTypeIdentifier(node: Parser.SyntaxNode): string | null {
+  const identifiers = node.descendantsOfType('type_identifier');
+  return getIdentifierText(identifiers.at(-1));
+}
+
+function resolveJavaReferencePath(
+  sourceRoot: string | null,
+  packageName: string | null,
+  importedBindings: ReadonlyMap<string, ImportedBinding>,
+  typeName: string,
+): string | null {
+  const importedBinding = importedBindings.get(typeName);
+  if (importedBinding?.resolvedPath) {
+    return importedBinding.resolvedPath;
+  }
+
+  if (typeName.includes('.')) {
+    return resolveJavaTypePath(sourceRoot, typeName);
+  }
+
+  return packageName
+    ? resolveJavaTypePath(sourceRoot, `${packageName}.${typeName}`)
+    : null;
 }

--- a/packages/core/tests/treeSitter/analyze.languageRelations.test.ts
+++ b/packages/core/tests/treeSitter/analyze.languageRelations.test.ts
@@ -236,7 +236,7 @@ describe('pipeline/plugins/treesitter/runtime/analyze', () => {
 
 
 
-    it('extracts Java imports and imported-call relations without file-level inheritance', async () => {
+    it('extracts Java imports, imported-call relations, and symbol-only inheritance', async () => {
       const workspaceRoot = await createWorkspace({});
       const appPath = path.join(workspaceRoot, 'App.java');
       const appSource = [
@@ -276,10 +276,19 @@ describe('pipeline/plugins/treesitter/runtime/analyze', () => {
             fromSymbolId: expect.stringContaining(`${appPath}:method:run`),
             sourceId: 'codegraphy.treesitter:call',
           }),
+          expect.objectContaining({
+            kind: 'inherit',
+            specifier: 'Base',
+            fromFilePath: appPath,
+            fromSymbolId: expect.stringContaining(`${appPath}:class:App`),
+            sourceId: 'codegraphy.treesitter:inherit',
+          }),
         ]),
       );
-      expect(result?.relations).toHaveLength(2);
-      expect(result?.relations?.some((relation) => relation.kind === 'inherit')).toBe(false);
+      expect(result?.relations).toHaveLength(3);
+      const inheritRelation = result?.relations?.find((relation) => relation.kind === 'inherit');
+      expect(inheritRelation).not.toHaveProperty('toFilePath');
+      expect(inheritRelation).not.toHaveProperty('resolvedPath');
     });
 
 

--- a/packages/core/tests/treeSitter/java/analyze.test.ts
+++ b/packages/core/tests/treeSitter/java/analyze.test.ts
@@ -1,0 +1,66 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { analyzeFileWithTreeSitter } from '../../../src/treeSitter/runtime/analyze';
+
+const tempRoots: string[] = [];
+
+async function createWorkspace(files: Record<string, string>): Promise<string> {
+  const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-treesitter-java-'));
+  tempRoots.push(workspaceRoot);
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(workspaceRoot, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, content, 'utf8');
+  }
+
+  return workspaceRoot;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((workspaceRoot) =>
+      fs.rm(workspaceRoot, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe('pipeline/plugins/treesitter/runtime/analyzeJava', () => {
+  it('exports class extends relationships as symbol inheritance without file-level edges', async () => {
+    const workspaceRoot = await createWorkspace({
+      'src/com/example/app/BaseService.java': [
+        'package com.example.app;',
+        '',
+        'public class BaseService {}',
+        '',
+      ].join('\n'),
+    });
+    const appPath = path.join(workspaceRoot, 'src/com/example/app/App.java');
+    const baseServicePath = path.join(workspaceRoot, 'src/com/example/app/BaseService.java');
+    const appSource = [
+      'package com.example.app;',
+      '',
+      'public class App extends BaseService {}',
+      '',
+    ].join('\n');
+
+    const result = await analyzeFileWithTreeSitter(appPath, appSource, workspaceRoot);
+
+    expect(result?.relations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'inherit',
+        sourceId: 'codegraphy.treesitter:inherit',
+        pluginId: 'codegraphy.treesitter',
+        specifier: 'BaseService',
+        fromFilePath: appPath,
+        fromSymbolId: `${appPath}:class:App`,
+        toSymbolId: `${baseServicePath}:class:BaseService`,
+      }),
+    ]));
+    const inheritRelation = result?.relations?.find((relation) => relation.kind === 'inherit');
+    expect(inheritRelation).not.toHaveProperty('toFilePath');
+    expect(inheritRelation).not.toHaveProperty('resolvedPath');
+  });
+});

--- a/packages/core/tests/treeSitter/java/file.test.ts
+++ b/packages/core/tests/treeSitter/java/file.test.ts
@@ -70,6 +70,15 @@ describe('pipeline/plugins/treesitter/runtime/analyzeJava/file', () => {
     visit?.({ type: 'interface_declaration' }, state, walk);
     visit?.({ type: 'enum_declaration' }, state, walk);
     expect(handleJavaTypeDeclaration).toHaveBeenCalledTimes(3);
+    expect(handleJavaTypeDeclaration).toHaveBeenCalledWith(
+      { type: 'class_declaration' },
+      '/workspace/src/App.java',
+      '/workspace/src',
+      'pkg',
+      expect.any(Array),
+      expect.any(Array),
+      expect.any(Map),
+    );
 
     visit?.({ type: 'method_declaration' }, state, walk);
     expect(handleJavaMethodDeclaration).toHaveBeenCalledWith(

--- a/packages/core/tests/treeSitter/java/typeDeclarations.test.ts
+++ b/packages/core/tests/treeSitter/java/typeDeclarations.test.ts
@@ -1,22 +1,33 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { handleJavaTypeDeclaration } from '../../../src/treeSitter/runtime/analyzeJava/typeDeclarations';
 import { getIdentifierText } from '../../../src/treeSitter/runtime/analyze/nodes';
-import { createSymbol } from '../../../src/treeSitter/runtime/analyze/results';
+import { addRelation, createSymbol, createSymbolId } from '../../../src/treeSitter/runtime/analyze/results';
+import { resolveJavaTypePath } from '../../../src/treeSitter/runtime/projectRoots';
+
+vi.mock('../../../src/treeSitter/runtime/projectRoots', () => ({
+  resolveJavaTypePath: vi.fn(),
+}));
 
 vi.mock('../../../src/treeSitter/runtime/analyze/nodes', () => ({
   getIdentifierText: vi.fn(),
 }));
 
 vi.mock('../../../src/treeSitter/runtime/analyze/results', () => ({
+  addRelation: vi.fn(),
   createSymbol: vi.fn(),
+  createSymbolId: vi.fn((filePath: string, kind: string, name: string) => `${filePath}:${kind}:${name}`),
 }));
 
 function createNode(overrides: Partial<{
   type: string;
+  descendantsOfType: (type: string) => unknown[];
+  namedChildren: unknown[];
   childForFieldName: (name: string) => unknown;
 }> = {}) {
   return {
     type: 'class_declaration',
+    descendantsOfType: () => [],
+    namedChildren: [],
     childForFieldName: () => null,
     ...overrides,
   };
@@ -25,6 +36,9 @@ function createNode(overrides: Partial<{
 describe('pipeline/plugins/treesitter/runtime/analyzeJava/typeDeclarations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(resolveJavaTypePath).mockImplementation((_sourceRoot: string | null, typeName: string) =>
+      typeName === 'com.example.BaseService' ? '/workspace/src/com/example/BaseService.java' : null,
+    );
   });
 
   it('creates symbols for class, interface, and enum declarations while skipping unnamed nodes', () => {
@@ -40,12 +54,20 @@ describe('pipeline/plugins/treesitter/runtime/analyzeJava/typeDeclarations', () 
       createNode({
         type: 'class_declaration',
         childForFieldName: (name: string) => {
-          expect(name).toBe('name');
-          return createNode({ type: 'identifier' });
+          if (name === 'name') {
+            return createNode({ type: 'identifier' });
+          }
+
+          expect(name).toBe('superclass');
+          return null;
         },
       }) as never,
       '/workspace/App.java',
+      '/workspace/src',
+      'com.example',
+      [],
       symbols as never,
+      new Map(),
     );
     handleJavaTypeDeclaration(
       createNode({
@@ -56,7 +78,11 @@ describe('pipeline/plugins/treesitter/runtime/analyzeJava/typeDeclarations', () 
         },
       }) as never,
       '/workspace/App.java',
+      '/workspace/src',
+      'com.example',
+      [],
       symbols as never,
+      new Map(),
     );
     handleJavaTypeDeclaration(
       createNode({
@@ -67,7 +93,11 @@ describe('pipeline/plugins/treesitter/runtime/analyzeJava/typeDeclarations', () 
         },
       }) as never,
       '/workspace/App.java',
+      '/workspace/src',
+      'com.example',
+      [],
       symbols as never,
+      new Map(),
     );
     handleJavaTypeDeclaration(
       createNode({
@@ -78,7 +108,11 @@ describe('pipeline/plugins/treesitter/runtime/analyzeJava/typeDeclarations', () 
         },
       }) as never,
       '/workspace/App.java',
+      '/workspace/src',
+      'com.example',
+      [],
       symbols as never,
+      new Map(),
     );
 
     expect(symbols).toEqual([
@@ -86,5 +120,52 @@ describe('pipeline/plugins/treesitter/runtime/analyzeJava/typeDeclarations', () 
       { kind: 'interface', name: 'Runnable' },
       { kind: 'enum', name: 'Status' },
     ]);
+  });
+
+  it('adds symbol inheritance for Java class extends declarations', () => {
+    const symbols: unknown[] = [];
+    const relations: unknown[] = [];
+    vi.mocked(getIdentifierText)
+      .mockReturnValueOnce('App')
+      .mockReturnValueOnce('BaseService');
+    vi.mocked(createSymbol).mockReturnValue({ id: '/workspace/src/com/example/App.java:class:App' } as never);
+
+    handleJavaTypeDeclaration(
+      createNode({
+        type: 'class_declaration',
+        childForFieldName: (name: string) =>
+          name === 'name'
+            ? createNode({ type: 'identifier' })
+            : createNode({
+              type: 'superclass',
+              namedChildren: [createNode({ type: 'type_identifier' })],
+              descendantsOfType: (type: string) => {
+                expect(type).toBe('type_identifier');
+                return [createNode({ type: 'type_identifier' })];
+              },
+            }),
+      }) as never,
+      '/workspace/src/com/example/App.java',
+      '/workspace/src',
+      'com.example',
+      relations as never,
+      symbols as never,
+      new Map(),
+    );
+
+    expect(resolveJavaTypePath).toHaveBeenCalledWith('/workspace/src', 'com.example.BaseService');
+    expect(createSymbolId).toHaveBeenCalledWith(
+      '/workspace/src/com/example/BaseService.java',
+      'class',
+      'BaseService',
+    );
+    expect(addRelation).toHaveBeenCalledWith(relations, {
+      kind: 'inherit',
+      sourceId: 'codegraphy.treesitter:inherit',
+      fromFilePath: '/workspace/src/com/example/App.java',
+      fromSymbolId: '/workspace/src/com/example/App.java:class:App',
+      specifier: 'BaseService',
+      toSymbolId: '/workspace/src/com/example/BaseService.java:class:BaseService',
+    });
   });
 });


### PR DESCRIPTION
## Summary

Scaffold PR for https://trello.com/c/bYo1WZK0/184-support-extends-export-for-java-language.

Expected first move: add a focused Java fixture/test that proves extends/export relationships are missing, then implement analyzer support.

## Orchestration

- Branch: `codex/184-java-extends-export`
- Base: `main`
- This PR intentionally starts with a scaffold-only commit so the issue has an isolated workstream before implementation begins.
- Follow repo rules: write a failing test before production changes, then make the smallest implementation needed to pass.

## Validation

- Not run yet; implementation thread should add targeted red/green checks first.