### PR TITLE
[codex] Tooltips for graph scope

### DIFF
--- a/.changeset/graph-scope-type-tooltips.md
+++ b/.changeset/graph-scope-type-tooltips.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy-dev/extension": minor
+"@codegraphy-dev/plugin-api": minor
+---
+
+Add Graph Scope tooltips for Node Types and Edge Types, with optional plugin-provided descriptions and compact examples.

--- a/.changeset/typescript-alias-import-tooltip.md
+++ b/.changeset/typescript-alias-import-tooltip.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/plugin-typescript": patch
+---
+
+Add Graph Scope tooltip copy and an example for TypeScript Alias Import edges.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,10 @@ _Avoid_: Vertex, dot, point
 The category that describes what kind of thing a node represents, such as file, folder, package, or a plugin-defined type.
 _Avoid_: Legend entry, node style
 
+**Node Type Definition**:
+The shared description of a **Node Type**, including its label, default visibility, visual defaults, and optional user-facing explanation or examples. **Graph Scope**, **Legend**, and plugin contributions consume Node Type Definitions instead of redefining what a Node Type means locally.
+_Avoid_: Graph Scope tooltip source, local node metadata, UI-only node description
+
 **File Node**:
 A node representing a concrete file in the workspace or selected graph revision.
 _Avoid_: Folder node, package node
@@ -63,6 +67,10 @@ _Avoid_: Line, link, connector
 **Edge Type**:
 The category that describes what kind of relationship an edge represents.
 _Avoid_: Edge kind, relation type, connection type
+
+**Edge Type Definition**:
+The shared description of an **Edge Type**, including its label, default visibility, visual defaults, and optional user-facing explanation or examples. **Graph Scope**, **Legend**, and plugin contributions consume Edge Type Definitions instead of redefining what an Edge Type means locally.
+_Avoid_: Graph Scope tooltip source, local edge metadata, UI-only edge description
 
 **Edge Direction**:
 The source-to-target orientation of an edge, where the source node initiates the relationship and the target node is the thing being used, referenced, tested, or contained.

--- a/docs/INTERACTIONS.md
+++ b/docs/INTERACTIONS.md
@@ -94,11 +94,11 @@ Physics and general graph behavior. See [Settings](./SETTINGS.md) for details.
 
 ### Nodes (shape icon)
 
-Choose Graph Scope for Node Types such as files, folders, packages, and plugin-added Node Types. Each row also shows the current color for that Node Type.
+Choose Graph Scope for Node Types such as files, folders, packages, and plugin-added Node Types. Each row shows the current color for that Node Type. Hover a row to see a brief description and, when available, a compact example.
 
 ### Edges (line icon)
 
-Choose Graph Scope for Edge Types such as `NESTS`, imports, calls, references, and plugin-added Edge Types. Each row also shows the current color for that Edge Type.
+Choose Graph Scope for Edge Types such as `NESTS`, imports, calls, references, and plugin-added Edge Types. Each row shows the current color for that Edge Type. Hover a row to see what the relationship means and, when available, a source-style example.
 
 ### Legends (paint icon)
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -271,6 +271,8 @@ Node, edge, Legend, and Plugin Settings Controls are in dedicated toolbar popups
 - **Plugins**: enable/disable plugins and reorder them
 - **Depth Mode**: optional toolbar mode that focuses the Visible Graph around the Focused Node
 
+Hover a Graph Scope row to see a short description of what that Node Type or Edge Type means. Rows may include a compact example, such as a file path for File Nodes or a source snippet for an Edge Type. These tooltips explain the meaning of the type only; they do not explain why a contextual toggle is currently visible.
+
 Fresh CodeGraphy Workspaces default built-in Edge Type scope to **Imports** on and all other built-in Edge Types off. Plugin-contributed Edge Types default off unless the plugin explicitly defines a different `defaultVisible` value. Existing values saved in `.codegraphy/settings.json` remain the expected workspace values and are not migrated to new defaults. Users can enable additional Edge Types from Graph Scope without re-indexing when those relationships are already present in the Graph Cache.
 
 Graph Scope lists built-in Edge Types by common usefulness: **Imports**, **References**, **Calls**, **Tests**, **Re-exports**, **Type imports**, **Inherits**, **Loads**, **Nests**, **Contains**, then **Overrides**. Plugin-contributed Edge Types appear after built-ins unless a later product decision defines plugin grouping.

--- a/docs/plugin-api/TYPES.md
+++ b/docs/plugin-api/TYPES.md
@@ -38,7 +38,7 @@ Key points:
 - `fileColors?: Record<string, string | IPluginFileColorDefinition>` lets plugins provide default color/shape/imagePath styling by pattern.
 - `analyzeFile(filePath, content, workspaceRoot, context?)` is the plugin analysis hook for returning relationships, symbols, and contributed Node Types or Edge Types.
 - core builds the base file result first, then plugin results are merged on top in plugin order.
-- `contributeNodeTypes()` and `contributeEdgeTypes()` let plugins register new Node Types, Edge Types, and defaults.
+- `contributeNodeTypes()` and `contributeEdgeTypes()` let plugins register new Node Types, Edge Types, defaults, and optional user-facing descriptions for Graph Scope.
 - Optional hooks: `initialize`, `onWorkspaceReady`, `onPreAnalyze`, `onFilesChanged`, `onPostAnalyze`, `onGraphRebuild`, `onUnload`.
 
 ### `IPluginAnalysisContext`
@@ -60,6 +60,8 @@ Higher-priority plugins only override data when both sides hit the same merge ke
 
 - `nodeTypes`, `edgeTypes`, `nodes`, and `symbols` merge by `id`
 - `relations` merge by relationship identity
+
+Node Type and Edge Type definitions can include an optional `description` object. The description should explain what the type means in product language, not how the analyzer detects it. Use `examples` for compact, real-looking snippets or paths that help users recognize the type in Graph Scope.
 
 Current relationship identity:
 

--- a/packages/core/src/graphControls/contracts.ts
+++ b/packages/core/src/graphControls/contracts.ts
@@ -8,6 +8,7 @@ export interface IGraphNodeTypeDefinition {
   label: string;
   defaultColor: string;
   defaultVisible: boolean;
+  description?: IGraphTypeDescription;
   parentId?: NodeType;
   pluginName?: string;
   matchSymbolKinds?: string[];
@@ -22,4 +23,15 @@ export interface IGraphEdgeTypeDefinition {
   label: string;
   defaultColor: string;
   defaultVisible: boolean;
+  description?: IGraphTypeDescription;
+}
+
+export interface IGraphTypeExample {
+  label?: string;
+  code: string;
+}
+
+export interface IGraphTypeDescription {
+  description: string;
+  examples?: IGraphTypeExample[];
 }

--- a/packages/extension/src/extension/graphView/controls/send/definitions/contracts.ts
+++ b/packages/extension/src/extension/graphView/controls/send/definitions/contracts.ts
@@ -3,6 +3,7 @@ export interface GraphNodeTypeLike {
   label: string;
   defaultColor: string;
   defaultVisible: boolean;
+  description?: GraphTypeDescriptionLike;
 }
 
 export interface GraphEdgeTypeLike {
@@ -10,6 +11,17 @@ export interface GraphEdgeTypeLike {
   label: string;
   defaultColor: string;
   defaultVisible: boolean;
+  description?: GraphTypeDescriptionLike;
+}
+
+export interface GraphTypeExampleLike {
+  label?: string;
+  code: string;
+}
+
+export interface GraphTypeDescriptionLike {
+  description: string;
+  examples?: GraphTypeExampleLike[];
 }
 
 export interface GraphControlsAnalyzerLike {

--- a/packages/extension/src/extension/graphView/controls/send/definitions/descriptionGuard.ts
+++ b/packages/extension/src/extension/graphView/controls/send/definitions/descriptionGuard.ts
@@ -1,0 +1,27 @@
+export function isGraphTypeDescriptionLike(description: unknown): boolean {
+  if (!description || typeof description !== 'object') {
+    return false;
+  }
+
+  const record = description as Record<string, unknown>;
+  if (typeof record.description !== 'string') {
+    return false;
+  }
+
+  if (record.examples === undefined) {
+    return true;
+  }
+
+  return Array.isArray(record.examples)
+    && record.examples.every((example) => {
+      if (!example || typeof example !== 'object') {
+        return false;
+      }
+
+      const exampleRecord = example as Record<string, unknown>;
+      return (
+        typeof exampleRecord.code === 'string'
+        && (exampleRecord.label === undefined || typeof exampleRecord.label === 'string')
+      );
+    });
+}

--- a/packages/extension/src/extension/graphView/controls/send/definitions/edgeGuard.ts
+++ b/packages/extension/src/extension/graphView/controls/send/definitions/edgeGuard.ts
@@ -1,4 +1,5 @@
 import type { GraphEdgeTypeLike } from './contracts';
+import { isGraphTypeDescriptionLike } from './descriptionGuard';
 
 export function isGraphEdgeTypeLike(definition: unknown): definition is GraphEdgeTypeLike {
   if (!definition || typeof definition !== 'object') {
@@ -11,5 +12,6 @@ export function isGraphEdgeTypeLike(definition: unknown): definition is GraphEdg
     && typeof record.label === 'string'
     && typeof record.defaultColor === 'string'
     && typeof record.defaultVisible === 'boolean'
+    && (record.description === undefined || isGraphTypeDescriptionLike(record.description))
   );
 }

--- a/packages/extension/src/extension/graphView/controls/send/definitions/merge.ts
+++ b/packages/extension/src/extension/graphView/controls/send/definitions/merge.ts
@@ -67,6 +67,7 @@ export function mergeEdgeTypes(
       label: definition.label,
       defaultColor: definition.defaultColor,
       defaultVisible: definition.defaultVisible,
+      description: definition.description,
     });
   }
 

--- a/packages/extension/src/extension/graphView/controls/send/definitions/nodeGuard.ts
+++ b/packages/extension/src/extension/graphView/controls/send/definitions/nodeGuard.ts
@@ -1,4 +1,5 @@
 import type { GraphNodeTypeLike } from './contracts';
+import { isGraphTypeDescriptionLike } from './descriptionGuard';
 
 export function isGraphNodeTypeLike(definition: unknown): definition is GraphNodeTypeLike {
   if (!definition || typeof definition !== 'object') {
@@ -11,5 +12,6 @@ export function isGraphNodeTypeLike(definition: unknown): definition is GraphNod
     && typeof record.label === 'string'
     && typeof record.defaultColor === 'string'
     && typeof record.defaultVisible === 'boolean'
+    && (record.description === undefined || isGraphTypeDescriptionLike(record.description))
   );
 }

--- a/packages/extension/src/shared/graphControls/contracts.ts
+++ b/packages/extension/src/shared/graphControls/contracts.ts
@@ -8,6 +8,7 @@ export interface IGraphNodeTypeDefinition {
   label: string;
   defaultColor: string;
   defaultVisible: boolean;
+  description?: IGraphTypeDescription;
   parentId?: NodeType;
   pluginName?: string;
   matchSymbolKinds?: string[];
@@ -22,6 +23,17 @@ export interface IGraphEdgeTypeDefinition {
   label: string;
   defaultColor: string;
   defaultVisible: boolean;
+  description?: IGraphTypeDescription;
+}
+
+export interface IGraphTypeExample {
+  label?: string;
+  code: string;
+}
+
+export interface IGraphTypeDescription {
+  description: string;
+  examples?: IGraphTypeExample[];
 }
 
 export interface IGraphControlsSnapshot {

--- a/packages/extension/src/shared/graphControls/defaults/edgeTypes.ts
+++ b/packages/extension/src/shared/graphControls/defaults/edgeTypes.ts
@@ -10,8 +10,8 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#60A5FA',
       defaultVisible: true,
       description: {
-        description: 'One file uses exports from another file or package.',
-        examples: [{ label: 'TypeScript', code: 'import { Button } from "./Button";' }],
+        description: 'Shows source files that depend on exports from another file or package.',
+        examples: [{ code: 'import { thing } from "./module";' }],
       },
     },
     {
@@ -20,8 +20,8 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#F97316',
       defaultVisible: false,
       description: {
-        description: 'One symbol or file mentions another symbol without necessarily calling it.',
-        examples: [{ label: 'TypeScript', code: 'const selected: GraphNode = node;' }],
+        description: 'Shows symbols or files that mention another symbol without necessarily calling it.',
+        examples: [{ code: 'const selected = current;' }],
       },
     },
     {
@@ -30,8 +30,8 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#22C55E',
       defaultVisible: false,
       description: {
-        description: 'One function, method, or code path invokes another callable symbol.',
-        examples: [{ label: 'TypeScript', code: 'renderGraph(scope);' }],
+        description: 'Shows a function, method, or code path invoking another callable symbol.',
+        examples: [{ code: 'runTask();' }],
       },
     },
     {
@@ -40,8 +40,8 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#EF4444',
       defaultVisible: false,
       description: {
-        description: 'A test file or test symbol verifies behavior from another file or symbol.',
-        examples: [{ label: 'Vitest', code: "import { buildScope } from './scope';" }],
+        description: 'Shows test code that verifies behavior from another file or symbol.',
+        examples: [{ code: 'expect(result).toEqual(value);' }],
       },
     },
     {
@@ -50,8 +50,8 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#A78BFA',
       defaultVisible: false,
       description: {
-        description: 'One file forwards exports from another file or package.',
-        examples: [{ label: 'TypeScript', code: 'export { Button } from "./Button";' }],
+        description: 'Shows files that forward exports from another file or package.',
+        examples: [{ code: 'export { thing } from "./module";' }],
       },
     },
     {
@@ -60,8 +60,8 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#38BDF8',
       defaultVisible: false,
       description: {
-        description: 'One file uses types from another file without pulling in runtime code.',
-        examples: [{ label: 'TypeScript', code: 'import type { GraphNode } from "./types";' }],
+        description: 'Shows type-only relationships that do not pull in runtime code.',
+        examples: [{ code: 'import type { Thing } from "./types";' }],
       },
     },
     {
@@ -70,8 +70,8 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#F59E0B',
       defaultVisible: false,
       description: {
-        description: 'One type extends, implements, or derives behavior from another type.',
-        examples: [{ label: 'Java', code: 'class Runner extends BaseRunner {}' }],
+        description: 'Shows types that extend, implement, or derive behavior from another type.',
+        examples: [{ code: 'class Child extends Parent {}' }],
       },
     },
     {
@@ -80,8 +80,8 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#06B6D4',
       defaultVisible: false,
       description: {
-        description: 'One file loads another file or resource at runtime.',
-        examples: [{ label: 'GDScript', code: 'const Scene = preload("res://ui/menu.tscn")' }],
+        description: 'Shows runtime loading of another file, module, or resource.',
+        examples: [{ code: 'load("path/to/resource")' }],
       },
     },
     {
@@ -90,7 +90,7 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#64748B',
       defaultVisible: false,
       description: {
-        description: 'A folder or package contains another folder, package, or file.',
+        description: 'Shows folder or package structure around files and nested folders.',
         examples: [{ code: 'src/ contains src/index.ts' }],
       },
     },
@@ -100,7 +100,7 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#94A3B8',
       defaultVisible: false,
       description: {
-        description: 'A file or code container includes a symbol inside it.',
+        description: 'Shows symbols that live inside a file or another code container.',
         examples: [{ code: 'settings.ts contains buildSettings()' }],
       },
     },
@@ -110,8 +110,8 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       defaultColor: '#EC4899',
       defaultVisible: false,
       description: {
-        description: 'One method or member replaces behavior defined by a parent type.',
-        examples: [{ label: 'Java', code: '@Override\npublic void run() {}' }],
+        description: 'Shows methods or members replacing behavior from a parent type.',
+        examples: [{ code: 'override run() {}' }],
       },
     },
   ];

--- a/packages/extension/src/shared/graphControls/defaults/edgeTypes.ts
+++ b/packages/extension/src/shared/graphControls/defaults/edgeTypes.ts
@@ -9,66 +9,110 @@ export function createCoreGraphEdgeTypes(): IGraphEdgeTypeDefinition[] {
       label: 'Imports',
       defaultColor: '#60A5FA',
       defaultVisible: true,
+      description: {
+        description: 'One file uses exports from another file or package.',
+        examples: [{ label: 'TypeScript', code: 'import { Button } from "./Button";' }],
+      },
     },
     {
       id: 'reference',
       label: 'References',
       defaultColor: '#F97316',
       defaultVisible: false,
+      description: {
+        description: 'One symbol or file mentions another symbol without necessarily calling it.',
+        examples: [{ label: 'TypeScript', code: 'const selected: GraphNode = node;' }],
+      },
     },
     {
       id: 'call',
       label: 'Calls',
       defaultColor: '#22C55E',
       defaultVisible: false,
+      description: {
+        description: 'One function, method, or code path invokes another callable symbol.',
+        examples: [{ label: 'TypeScript', code: 'renderGraph(scope);' }],
+      },
     },
     {
       id: 'test',
       label: 'Tests',
       defaultColor: '#EF4444',
       defaultVisible: false,
+      description: {
+        description: 'A test file or test symbol verifies behavior from another file or symbol.',
+        examples: [{ label: 'Vitest', code: "import { buildScope } from './scope';" }],
+      },
     },
     {
       id: 'reexport',
       label: 'Re-exports',
       defaultColor: '#A78BFA',
       defaultVisible: false,
+      description: {
+        description: 'One file forwards exports from another file or package.',
+        examples: [{ label: 'TypeScript', code: 'export { Button } from "./Button";' }],
+      },
     },
     {
       id: 'type-import',
       label: 'Type imports',
       defaultColor: '#38BDF8',
       defaultVisible: false,
+      description: {
+        description: 'One file uses types from another file without pulling in runtime code.',
+        examples: [{ label: 'TypeScript', code: 'import type { GraphNode } from "./types";' }],
+      },
     },
     {
       id: 'inherit',
       label: 'Inherits',
       defaultColor: '#F59E0B',
       defaultVisible: false,
+      description: {
+        description: 'One type extends, implements, or derives behavior from another type.',
+        examples: [{ label: 'Java', code: 'class Runner extends BaseRunner {}' }],
+      },
     },
     {
       id: 'load',
       label: 'Loads',
       defaultColor: '#06B6D4',
       defaultVisible: false,
+      description: {
+        description: 'One file loads another file or resource at runtime.',
+        examples: [{ label: 'GDScript', code: 'const Scene = preload("res://ui/menu.tscn")' }],
+      },
     },
     {
       id: STRUCTURAL_NESTS_EDGE_KIND,
       label: 'Nests',
       defaultColor: '#64748B',
       defaultVisible: false,
+      description: {
+        description: 'A folder or package contains another folder, package, or file.',
+        examples: [{ code: 'src/ contains src/index.ts' }],
+      },
     },
     {
       id: 'contains',
       label: 'Contains',
       defaultColor: '#94A3B8',
       defaultVisible: false,
+      description: {
+        description: 'A file or code container includes a symbol inside it.',
+        examples: [{ code: 'settings.ts contains buildSettings()' }],
+      },
     },
     {
       id: 'overrides',
       label: 'Overrides',
       defaultColor: '#EC4899',
       defaultVisible: false,
+      description: {
+        description: 'One method or member replaces behavior defined by a parent type.',
+        examples: [{ label: 'Java', code: '@Override\npublic void run() {}' }],
+      },
     },
   ];
 }

--- a/packages/extension/src/shared/graphControls/defaults/nodeTypes/structural.ts
+++ b/packages/extension/src/shared/graphControls/defaults/nodeTypes/structural.ts
@@ -12,18 +12,30 @@ export function createStructuralGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       label: 'File',
       defaultColor: DEFAULT_NODE_COLOR,
       defaultVisible: true,
+      description: {
+        description: 'Source, config, docs, and other concrete files in the workspace.',
+        examples: [{ code: 'src/components/Button.tsx' }],
+      },
     },
     {
       id: 'folder',
       label: 'Folder',
       defaultColor: DEFAULT_FOLDER_NODE_COLOR,
       defaultVisible: false,
+      description: {
+        description: 'Directories that group files and other folders.',
+        examples: [{ code: 'src/components/' }],
+      },
     },
     {
       id: 'package',
       label: 'Package',
       defaultColor: DEFAULT_PACKAGE_NODE_COLOR,
       defaultVisible: false,
+      description: {
+        description: 'Workspace or external packages represented as graph nodes.',
+        examples: [{ code: '@codegraphy-dev/extension' }],
+      },
     },
   ];
 }

--- a/packages/extension/src/shared/graphControls/defaults/nodeTypes/symbols.ts
+++ b/packages/extension/src/shared/graphControls/defaults/nodeTypes/symbols.ts
@@ -7,6 +7,10 @@ export function createSymbolGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       label: 'Symbol',
       defaultColor: '#7C3AED',
       defaultVisible: false,
+      description: {
+        description: 'Named code elements inside files, such as functions, classes, interfaces, and types.',
+        examples: [{ code: 'export function loadGraph() {}' }],
+      },
     },
     {
       id: 'symbol:function',
@@ -15,6 +19,10 @@ export function createSymbolGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       defaultVisible: false,
       parentId: 'symbol',
       matchSymbolKinds: ['function', 'method'],
+      description: {
+        description: 'Callable code blocks such as functions, methods, or procedures.',
+        examples: [{ code: 'function parseSettings() {}' }],
+      },
     },
     {
       id: 'symbol:class',
@@ -22,6 +30,10 @@ export function createSymbolGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       defaultColor: '#3B82F6',
       defaultVisible: false,
       parentId: 'symbol',
+      description: {
+        description: 'Class declarations that group state and behavior.',
+        examples: [{ code: 'class GraphRuntime {}' }],
+      },
     },
     {
       id: 'symbol:interface',
@@ -29,6 +41,10 @@ export function createSymbolGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       defaultColor: '#06B6D4',
       defaultVisible: false,
       parentId: 'symbol',
+      description: {
+        description: 'Interface declarations that describe a shape or contract.',
+        examples: [{ code: 'interface GraphNode { id: string; }' }],
+      },
     },
     {
       id: 'symbol:type',
@@ -36,6 +52,10 @@ export function createSymbolGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       defaultColor: '#EC4899',
       defaultVisible: false,
       parentId: 'symbol',
+      description: {
+        description: 'Type aliases and named type definitions.',
+        examples: [{ code: 'type GraphMode = "2d" | "3d";' }],
+      },
     },
     {
       id: 'symbol:struct',
@@ -43,6 +63,10 @@ export function createSymbolGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       defaultColor: '#0EA5E9',
       defaultVisible: false,
       parentId: 'symbol',
+      description: {
+        description: 'Struct declarations that define grouped fields or data.',
+        examples: [{ code: 'struct GraphNode { id: String }' }],
+      },
     },
     {
       id: 'symbol:enum',
@@ -50,6 +74,10 @@ export function createSymbolGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       defaultColor: '#F59E0B',
       defaultVisible: false,
       parentId: 'symbol',
+      description: {
+        description: 'Enum declarations that define a named set of values.',
+        examples: [{ code: 'enum GraphMode { TwoD, ThreeD }' }],
+      },
     },
   ];
 }

--- a/packages/extension/src/shared/graphControls/defaults/nodeTypes/variables.ts
+++ b/packages/extension/src/shared/graphControls/defaults/nodeTypes/variables.ts
@@ -7,6 +7,10 @@ export function createVariableGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       label: 'Variable',
       defaultColor: '#14B8A6',
       defaultVisible: false,
+      description: {
+        description: 'Named values or fields that code can read or write.',
+        examples: [{ code: 'const graphScope = buildScope();' }],
+      },
     },
     {
       id: 'symbol:constant',
@@ -14,6 +18,10 @@ export function createVariableGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       defaultColor: '#22C55E',
       defaultVisible: false,
       parentId: 'variable',
+      description: {
+        description: 'Named values intended to stay unchanged.',
+        examples: [{ code: 'const DEFAULT_MAX_FILES = 5000;' }],
+      },
     },
     {
       id: 'plugin:codegraphy.gdscript:symbol:godot-class-name',
@@ -27,6 +35,10 @@ export function createVariableGraphNodeTypes(): IGraphNodeTypeDefinition[] {
       matchSymbolSource: 'codegraphy.gdscript',
       matchSymbolLanguage: 'gdscript',
       matchSymbolFilePath: '**/*.gd',
+      description: {
+        description: 'Godot script class names registered for use elsewhere in a project.',
+        examples: [{ label: 'GDScript', code: 'class_name PlayerController' }],
+      },
     },
   ];
 }

--- a/packages/extension/src/webview/components/graphScope/Panel.tsx
+++ b/packages/extension/src/webview/components/graphScope/Panel.tsx
@@ -4,6 +4,7 @@ import { useGraphStore } from '../../store/state';
 import { resolveEdgeTypeColors } from '../../graphControls/edgeTypeColors';
 import { Button } from '../ui/button';
 import { MdiIcon } from '../icons/MdiIcon';
+import { TooltipProvider } from '../ui/overlay/tooltip';
 import { ScrollArea } from '../ui/scroll-area';
 import { NodeTypeRows, EdgeTypeRows } from './rows';
 import { type GraphScopeTab, ScopeTabButton } from './tabs';
@@ -34,44 +35,46 @@ export default function GraphScopePanel({
   }
 
   return (
-    <div className="bg-[var(--cg-popover-translucent)] backdrop-blur-sm rounded-lg border w-80 shadow-lg max-h-full flex flex-col overflow-hidden">
-      <div className="flex items-center justify-between px-3 py-2 border-b flex-shrink-0">
-        <span className="text-sm font-medium">Graph Scope</span>
-        <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onClose} title="Close">
-          <MdiIcon path={mdiClose} size={16} />
-        </Button>
-      </div>
-
-      <div className="border-b px-3 py-2">
-        <div className="flex rounded-md border border-[var(--cg-border-subtle)] bg-[var(--cg-surface-subtle)] p-0.5">
-          <ScopeTabButton active={activeTab === 'nodes'} onClick={() => setActiveTab('nodes')}>
-            Node Types
-          </ScopeTabButton>
-          <ScopeTabButton active={activeTab === 'edges'} onClick={() => setActiveTab('edges')}>
-            Edge Types
-          </ScopeTabButton>
+    <TooltipProvider delayDuration={300}>
+      <div className="bg-[var(--cg-popover-translucent)] backdrop-blur-sm rounded-lg border w-80 shadow-lg max-h-full flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-2 border-b flex-shrink-0">
+          <span className="text-sm font-medium">Graph Scope</span>
+          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onClose} title="Close">
+            <MdiIcon path={mdiClose} size={16} />
+          </Button>
         </div>
-      </div>
 
-      <ScrollArea className="flex-1 min-h-0">
-        <div className="px-3 py-2">
-          <div className="overflow-hidden rounded-md border border-[var(--cg-border-subtle)] bg-[var(--cg-surface-subtle)] divide-y divide-[var(--cg-divider-subtle)]">
-            {activeTab === 'nodes' ? (
-              <NodeTypeRows
-                nodeColors={nodeColors}
-                nodeTypes={nodeTypes}
-                nodeVisibility={nodeVisibility}
-              />
-            ) : (
-              <EdgeTypeRows
-                edgeColors={edgeColors}
-                edgeTypes={edgeTypes}
-                edgeVisibility={edgeVisibility}
-              />
-            )}
+        <div className="border-b px-3 py-2">
+          <div className="flex rounded-md border border-[var(--cg-border-subtle)] bg-[var(--cg-surface-subtle)] p-0.5">
+            <ScopeTabButton active={activeTab === 'nodes'} onClick={() => setActiveTab('nodes')}>
+              Node Types
+            </ScopeTabButton>
+            <ScopeTabButton active={activeTab === 'edges'} onClick={() => setActiveTab('edges')}>
+              Edge Types
+            </ScopeTabButton>
           </div>
         </div>
-      </ScrollArea>
-    </div>
+
+        <ScrollArea className="flex-1 min-h-0">
+          <div className="px-3 py-2">
+            <div className="overflow-hidden rounded-md border border-[var(--cg-border-subtle)] bg-[var(--cg-surface-subtle)] divide-y divide-[var(--cg-divider-subtle)]">
+              {activeTab === 'nodes' ? (
+                <NodeTypeRows
+                  nodeColors={nodeColors}
+                  nodeTypes={nodeTypes}
+                  nodeVisibility={nodeVisibility}
+                />
+              ) : (
+                <EdgeTypeRows
+                  edgeColors={edgeColors}
+                  edgeTypes={edgeTypes}
+                  edgeVisibility={edgeVisibility}
+                />
+              )}
+            </div>
+          </div>
+        </ScrollArea>
+      </div>
+    </TooltipProvider>
   );
 }

--- a/packages/extension/src/webview/components/graphScope/rows.tsx
+++ b/packages/extension/src/webview/components/graphScope/rows.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import type {
   IGraphEdgeTypeDefinition,
   IGraphNodeTypeDefinition,
+  IGraphTypeDescription,
 } from '../../../shared/graphControls/contracts';
 import { postMessage } from '../../vscodeApi';
 import { cn } from '../ui/cn';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/overlay/tooltip';
 import { Switch } from '../ui/switch';
 
 interface ScopeRowProps {
@@ -13,6 +15,7 @@ interface ScopeRowProps {
   label: string;
   onCheckedChange: (visible: boolean) => void;
   nested?: boolean;
+  description?: IGraphTypeDescription;
 }
 
 interface NodeTypeRowsProps {
@@ -34,14 +37,44 @@ export function resolveScopeRowClassName(enabled: boolean): string {
   );
 }
 
+function ScopeRowTooltipContent({
+  description,
+  label,
+}: {
+  description: IGraphTypeDescription;
+  label: string;
+}): React.ReactElement {
+  const example = description.examples?.[0];
+
+  return (
+    <div className="max-w-64 space-y-2">
+      <div className="space-y-1">
+        <div className="text-xs font-semibold text-popover-foreground">{label}</div>
+        <p className="text-xs leading-snug text-muted-foreground">{description.description}</p>
+      </div>
+      {example ? (
+        <div className="border-t border-border/70 pt-2">
+          <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Example
+          </div>
+          <code className="block whitespace-pre-wrap rounded bg-muted px-2 py-1 font-mono text-[11px] leading-snug text-popover-foreground">
+            {example.code}
+          </code>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function ScopeRow({
   color,
+  description,
   enabled,
   label,
   nested = false,
   onCheckedChange,
 }: ScopeRowProps): React.ReactElement {
-  return (
+  const row = (
     <div
       className={cn(resolveScopeRowClassName(enabled), nested && 'pl-7')}
       data-scope-row={label}
@@ -62,6 +95,19 @@ function ScopeRow({
       <Switch checked={enabled} onCheckedChange={onCheckedChange} aria-label={`Toggle ${label}`} />
     </div>
   );
+
+  if (!description) {
+    return row;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{row}</TooltipTrigger>
+      <TooltipContent side="left" align="center" className="px-3 py-2">
+        <ScopeRowTooltipContent description={description} label={label} />
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function NodeTypeRows({
@@ -79,6 +125,7 @@ export function NodeTypeRows({
           <ScopeRow
             key={nodeType.id}
             color={color}
+            description={nodeType.description}
             enabled={enabled}
             label={nodeType.label}
             nested={Boolean(nodeType.parentId)}
@@ -110,6 +157,7 @@ export function EdgeTypeRows({
           <ScopeRow
             key={edgeType.id}
             color={color}
+            description={edgeType.description}
             enabled={enabled}
             label={edgeType.label}
             onCheckedChange={(visible) => {

--- a/packages/extension/src/webview/components/graphScope/rows.tsx
+++ b/packages/extension/src/webview/components/graphScope/rows.tsx
@@ -90,7 +90,7 @@ function ScopeRow({
     <div
       className={cn(
         resolveScopeRowClassName(enabled),
-        description && 'cursor-help',
+        description && 'cursor-pointer',
         nested && 'pl-7',
       )}
       data-scope-row={label}

--- a/packages/extension/src/webview/components/graphScope/rows.tsx
+++ b/packages/extension/src/webview/components/graphScope/rows.tsx
@@ -38,26 +38,38 @@ export function resolveScopeRowClassName(enabled: boolean): string {
 }
 
 function ScopeRowTooltipContent({
+  color,
   description,
   label,
 }: {
+  color?: string;
   description: IGraphTypeDescription;
   label: string;
 }): React.ReactElement {
   const example = description.examples?.[0];
 
   return (
-    <div className="max-w-64 space-y-2">
+    <div className="max-w-80 space-y-2" data-scope-tooltip-body={label}>
       <div className="space-y-1">
-        <div className="text-xs font-semibold text-popover-foreground">{label}</div>
+        <div className="flex items-center gap-2 text-xs font-semibold text-popover-foreground">
+          {color ? (
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-full border border-border"
+              style={{ backgroundColor: color }}
+              aria-hidden="true"
+              data-scope-tooltip-swatch={label}
+            />
+          ) : null}
+          <span>{label}</span>
+        </div>
         <p className="text-xs leading-snug text-muted-foreground">{description.description}</p>
       </div>
       {example ? (
         <div className="border-t border-border/70 pt-2">
-          <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            Example
-          </div>
-          <code className="block whitespace-pre-wrap rounded bg-muted px-2 py-1 font-mono text-[11px] leading-snug text-popover-foreground">
+          <code
+            className="block max-w-full overflow-x-auto whitespace-pre rounded bg-muted px-2 py-1 font-mono text-[11px] leading-snug text-popover-foreground"
+            data-scope-tooltip-example={label}
+          >
             {example.code}
           </code>
         </div>
@@ -76,7 +88,11 @@ function ScopeRow({
 }: ScopeRowProps): React.ReactElement {
   const row = (
     <div
-      className={cn(resolveScopeRowClassName(enabled), nested && 'pl-7')}
+      className={cn(
+        resolveScopeRowClassName(enabled),
+        description && 'cursor-help',
+        nested && 'pl-7',
+      )}
       data-scope-row={label}
     >
       {color ? (
@@ -103,8 +119,14 @@ function ScopeRow({
   return (
     <Tooltip>
       <TooltipTrigger asChild>{row}</TooltipTrigger>
-      <TooltipContent side="left" align="center" className="px-3 py-2">
-        <ScopeRowTooltipContent description={description} label={label} />
+      <TooltipContent
+        side="left"
+        align="start"
+        sideOffset={12}
+        collisionPadding={16}
+        className="max-w-80 px-3 py-2"
+      >
+        <ScopeRowTooltipContent color={color} description={description} label={label} />
       </TooltipContent>
     </Tooltip>
   );

--- a/packages/extension/tests/extension/graphView/controls/definitions/edgeGuard.test.ts
+++ b/packages/extension/tests/extension/graphView/controls/definitions/edgeGuard.test.ts
@@ -13,6 +13,21 @@ describe('extension/graphView/controls/send/definitions/edgeGuard', () => {
     ).toBe(true);
   });
 
+  it('accepts edge definitions with optional tooltip descriptions and examples', () => {
+    expect(
+      isGraphEdgeTypeLike({
+        id: 'plugin:route',
+        label: 'Route Links',
+        defaultColor: '#10B981',
+        defaultVisible: true,
+        description: {
+          description: 'A route points at the file that renders it.',
+          examples: [{ label: 'SvelteKit', code: 'src/routes/+page.svelte' }],
+        },
+      }),
+    ).toBe(true);
+  });
+
   it('rejects nullish and non-object edge definitions', () => {
     expect(isGraphEdgeTypeLike(null)).toBe(false);
     expect(isGraphEdgeTypeLike(undefined)).toBe(false);
@@ -50,6 +65,17 @@ describe('extension/graphView/controls/send/definitions/edgeGuard', () => {
         label: 'Import',
         defaultColor: '#3178C6',
         defaultVisible: 'yes',
+      }),
+    ).toBe(false);
+    expect(
+      isGraphEdgeTypeLike({
+        id: 'plugin:route',
+        label: 'Route Links',
+        defaultColor: '#10B981',
+        defaultVisible: true,
+        description: {
+          examples: [{ label: 'SvelteKit', code: 'src/routes/+page.svelte' }],
+        },
       }),
     ).toBe(false);
   });

--- a/packages/extension/tests/extension/graphView/controls/definitions/nodeGuard.test.ts
+++ b/packages/extension/tests/extension/graphView/controls/definitions/nodeGuard.test.ts
@@ -13,6 +13,21 @@ describe('extension/graphView/controls/send/definitions/nodeGuard', () => {
     ).toBe(true);
   });
 
+  it('accepts node definitions with optional tooltip descriptions and examples', () => {
+    expect(
+      isGraphNodeTypeLike({
+        id: 'route',
+        label: 'Route',
+        defaultColor: '#22C55E',
+        defaultVisible: false,
+        description: {
+          description: 'Application routes exposed by a framework.',
+          examples: [{ label: 'SvelteKit', code: 'src/routes/+page.svelte' }],
+        },
+      }),
+    ).toBe(true);
+  });
+
   it('rejects nullish and non-object node definitions', () => {
     expect(isGraphNodeTypeLike(null)).toBe(false);
     expect(isGraphNodeTypeLike(undefined)).toBe(false);
@@ -50,6 +65,18 @@ describe('extension/graphView/controls/send/definitions/nodeGuard', () => {
         label: 'Route',
         defaultColor: '#22C55E',
         defaultVisible: 1,
+      }),
+    ).toBe(false);
+    expect(
+      isGraphNodeTypeLike({
+        id: 'route',
+        label: 'Route',
+        defaultColor: '#22C55E',
+        defaultVisible: true,
+        description: {
+          description: 'Application routes exposed by a framework.',
+          examples: [{ label: 'SvelteKit' }],
+        },
       }),
     ).toBe(false);
   });

--- a/packages/extension/tests/extension/graphView/controls/definitions/snapshot.test.ts
+++ b/packages/extension/tests/extension/graphView/controls/definitions/snapshot.test.ts
@@ -36,6 +36,10 @@ describe('extension/graphView/controls/snapshot', () => {
           label: 'Routes',
           defaultColor: '#22C55E',
           defaultVisible: true,
+          description: {
+            description: 'Application routes exposed by a framework.',
+            examples: [{ label: 'SvelteKit', code: 'src/routes/+page.svelte' }],
+          },
         },
       ],
       [
@@ -44,6 +48,10 @@ describe('extension/graphView/controls/snapshot', () => {
           label: 'Route Links',
           defaultColor: '#10B981',
           defaultVisible: true,
+          description: {
+            description: 'A route points at the file that renders it.',
+            examples: [{ label: 'SvelteKit', code: 'src/routes/+page.svelte' }],
+          },
         },
       ],
     );
@@ -66,6 +74,14 @@ describe('extension/graphView/controls/snapshot', () => {
     ]);
     expect(snapshot.edgeTypes.some(edgeType => edgeType.id === STRUCTURAL_NESTS_EDGE_KIND)).toBe(true);
     expect(snapshot.edgeTypes.some(edgeType => edgeType.id === 'custom:route')).toBe(true);
+    expect(snapshot.nodeTypes.find((nodeType) => nodeType.id === 'route')?.description).toEqual({
+      description: 'Application routes exposed by a framework.',
+      examples: [{ label: 'SvelteKit', code: 'src/routes/+page.svelte' }],
+    });
+    expect(snapshot.edgeTypes.find((edgeType) => edgeType.id === 'plugin:route')?.description).toEqual({
+      description: 'A route points at the file that renders it.',
+      examples: [{ label: 'SvelteKit', code: 'src/routes/+page.svelte' }],
+    });
     expect(snapshot.nodeColors).toEqual({
       file: '#ABCDEF',
       folder: '#A1A1AA',

--- a/packages/extension/tests/shared/graphControls/defaults/edgeTypes.test.ts
+++ b/packages/extension/tests/shared/graphControls/defaults/edgeTypes.test.ts
@@ -80,9 +80,9 @@ describe('shared/graphControls/defaults/edgeTypes', () => {
     ]);
     expect(edgeTypes.every((edgeType) => edgeType.description?.description)).toBe(true);
     expect(edgeTypes.find((edgeType) => edgeType.id === 'import')?.description?.examples?.[0]?.code)
-      .toBe('import { Button } from "./Button";');
-    expect(edgeTypes.find((edgeType) => edgeType.id === 'inherit')?.description?.examples?.[0]?.label)
-      .toBe('Java');
+      .toBe('import { thing } from "./module";');
+    expect(edgeTypes.find((edgeType) => edgeType.id === 'inherit')?.description?.examples?.[0]?.code)
+      .toBe('class Child extends Parent {}');
     expect(CORE_GRAPH_EDGE_TYPES).toEqual(createCoreGraphEdgeTypes());
   });
 });

--- a/packages/extension/tests/shared/graphControls/defaults/edgeTypes.test.ts
+++ b/packages/extension/tests/shared/graphControls/defaults/edgeTypes.test.ts
@@ -8,7 +8,9 @@ import {
 describe('shared/graphControls/defaults/edgeTypes', () => {
   it('declares the structural nests edge and the built-in edge defaults', () => {
     expect(STRUCTURAL_NESTS_EDGE_KIND).toBe('nests');
-    expect(createCoreGraphEdgeTypes()).toEqual([
+    const edgeTypes = createCoreGraphEdgeTypes();
+
+    expect(edgeTypes).toMatchObject([
       {
         id: 'import',
         label: 'Imports',
@@ -76,6 +78,11 @@ describe('shared/graphControls/defaults/edgeTypes', () => {
         defaultVisible: false,
       },
     ]);
+    expect(edgeTypes.every((edgeType) => edgeType.description?.description)).toBe(true);
+    expect(edgeTypes.find((edgeType) => edgeType.id === 'import')?.description?.examples?.[0]?.code)
+      .toBe('import { Button } from "./Button";');
+    expect(edgeTypes.find((edgeType) => edgeType.id === 'inherit')?.description?.examples?.[0]?.label)
+      .toBe('Java');
     expect(CORE_GRAPH_EDGE_TYPES).toEqual(createCoreGraphEdgeTypes());
   });
 });

--- a/packages/extension/tests/shared/graphControls/defaults/nodeTypes.test.ts
+++ b/packages/extension/tests/shared/graphControls/defaults/nodeTypes.test.ts
@@ -11,7 +11,9 @@ import {
 
 describe('shared/graphControls/defaults/nodeTypes', () => {
   it('declares the core graph node defaults', () => {
-    expect(createCoreGraphNodeTypes()).toEqual([
+    const nodeTypes = createCoreGraphNodeTypes();
+
+    expect(nodeTypes).toMatchObject([
       {
         id: 'file',
         label: 'File',
@@ -106,6 +108,11 @@ describe('shared/graphControls/defaults/nodeTypes', () => {
         matchSymbolFilePath: '**/*.gd',
       },
     ]);
+    expect(nodeTypes.every((nodeType) => nodeType.description?.description)).toBe(true);
+    expect(nodeTypes.find((nodeType) => nodeType.id === 'file')?.description?.examples?.[0]?.code)
+      .toBe('src/components/Button.tsx');
+    expect(nodeTypes.find((nodeType) => nodeType.id === 'symbol:function')?.description?.examples?.[0]?.code)
+      .toBe('function parseSettings() {}');
     expect(CORE_GRAPH_NODE_TYPES).toEqual(createCoreGraphNodeTypes());
   });
 });

--- a/packages/extension/tests/webview/graphScope/rows.test.tsx
+++ b/packages/extension/tests/webview/graphScope/rows.test.tsx
@@ -163,7 +163,7 @@ describe('graph scope rows', () => {
     const tooltipSwatch = tooltipBody.querySelector('[data-scope-tooltip-swatch="Imports"]') as HTMLElement;
 
     expect(tooltip).toHaveTextContent('Files imported by another file.');
-    expect(row).toHaveClass('cursor-help');
+    expect(row).toHaveClass('cursor-pointer');
     expect(visibleTooltip).toHaveClass('max-w-80');
     expect(tooltipBody).toHaveClass('max-w-80');
     expect(tooltipSwatch).toHaveStyle('background-color: #333333');
@@ -201,7 +201,7 @@ describe('graph scope rows', () => {
 
     const tooltip = await screen.findByRole('tooltip');
 
-    expect(row).toHaveClass('cursor-help');
+    expect(row).toHaveClass('cursor-pointer');
     expect(tooltip).toHaveTextContent('Folder');
     expect(tooltip).toHaveTextContent('Directories that group files and other folders.');
     expect(tooltip).not.toHaveTextContent('Example');

--- a/packages/extension/tests/webview/graphScope/rows.test.tsx
+++ b/packages/extension/tests/webview/graphScope/rows.test.tsx
@@ -6,6 +6,7 @@ import {
   NodeTypeRows,
   resolveScopeRowClassName,
 } from '../../../src/webview/components/graphScope/rows';
+import { TooltipProvider } from '../../../src/webview/components/ui/overlay/tooltip';
 
 const sentMessages: unknown[] = [];
 
@@ -129,5 +130,63 @@ describe('graph scope rows', () => {
       type: 'UPDATE_EDGE_VISIBILITY',
       payload: { edgeKind: 'reference', visible: true },
     });
+  });
+
+  it('shows example tooltip text for edge rows that define examples', async () => {
+    render(
+      <TooltipProvider delayDuration={0}>
+        <EdgeTypeRows
+          edgeColors={{}}
+          edgeTypes={[
+            {
+              id: 'import',
+              label: 'Imports',
+              defaultColor: '#333333',
+              defaultVisible: true,
+              description: {
+                description: 'Files imported by another file.',
+                examples: [{ label: 'TypeScript', code: 'import { Button } from "./Button";' }],
+              },
+            },
+          ]}
+          edgeVisibility={{}}
+        />
+      </TooltipProvider>,
+    );
+
+    fireEvent.pointerMove(screen.getByText('Imports'), { pointerType: 'mouse' });
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Files imported by another file.');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Example');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('import { Button } from "./Button";');
+  });
+
+  it('shows description-only tooltip text for node rows without examples', async () => {
+    render(
+      <TooltipProvider delayDuration={0}>
+        <NodeTypeRows
+          nodeColors={{}}
+          nodeTypes={[
+            {
+              id: 'folder',
+              label: 'Folder',
+              defaultColor: '#222222',
+              defaultVisible: false,
+              description: {
+                description: 'Directories that group files and other folders.',
+              },
+            },
+          ]}
+          nodeVisibility={{ folder: false }}
+        />
+      </TooltipProvider>,
+    );
+
+    fireEvent.pointerMove(screen.getByText('Folder'), { pointerType: 'mouse' });
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Folder');
+    expect(tooltip).toHaveTextContent('Directories that group files and other folders.');
+    expect(tooltip).not.toHaveTextContent('Example');
   });
 });

--- a/packages/extension/tests/webview/graphScope/rows.test.tsx
+++ b/packages/extension/tests/webview/graphScope/rows.test.tsx
@@ -133,7 +133,7 @@ describe('graph scope rows', () => {
   });
 
   it('shows example tooltip text for edge rows that define examples', async () => {
-    render(
+    const { container } = render(
       <TooltipProvider delayDuration={0}>
         <EdgeTypeRows
           edgeColors={{}}
@@ -145,7 +145,7 @@ describe('graph scope rows', () => {
               defaultVisible: true,
               description: {
                 description: 'Files imported by another file.',
-                examples: [{ label: 'TypeScript', code: 'import { Button } from "./Button";' }],
+                examples: [{ code: 'import { thing } from "./module";' }],
               },
             },
           ]}
@@ -154,15 +154,29 @@ describe('graph scope rows', () => {
       </TooltipProvider>,
     );
 
-    fireEvent.pointerMove(screen.getByText('Imports'), { pointerType: 'mouse' });
+    const row = scopeRow(container, 'Imports');
+    fireEvent.pointerMove(row, { pointerType: 'mouse' });
 
-    expect(await screen.findByRole('tooltip')).toHaveTextContent('Files imported by another file.');
-    expect(screen.getByRole('tooltip')).toHaveTextContent('Example');
-    expect(screen.getByRole('tooltip')).toHaveTextContent('import { Button } from "./Button";');
+    const tooltip = await screen.findByRole('tooltip');
+    const visibleTooltip = document.querySelector('[data-side="left"][data-align="start"]') as HTMLElement;
+    const tooltipBody = tooltip.querySelector('[data-scope-tooltip-body="Imports"]') as HTMLElement;
+    const tooltipSwatch = tooltipBody.querySelector('[data-scope-tooltip-swatch="Imports"]') as HTMLElement;
+
+    expect(tooltip).toHaveTextContent('Files imported by another file.');
+    expect(row).toHaveClass('cursor-help');
+    expect(visibleTooltip).toHaveClass('max-w-80');
+    expect(tooltipBody).toHaveClass('max-w-80');
+    expect(tooltipSwatch).toHaveStyle('background-color: #333333');
+    expect(tooltip).not.toHaveTextContent('Example');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('import { thing } from "./module";');
+
+    const example = tooltipBody.querySelector('[data-scope-tooltip-example="Imports"]') as HTMLElement;
+    expect(example).toHaveClass('whitespace-pre');
+    expect(example).toHaveClass('overflow-x-auto');
   });
 
   it('shows description-only tooltip text for node rows without examples', async () => {
-    render(
+    const { container } = render(
       <TooltipProvider delayDuration={0}>
         <NodeTypeRows
           nodeColors={{}}
@@ -182,9 +196,12 @@ describe('graph scope rows', () => {
       </TooltipProvider>,
     );
 
-    fireEvent.pointerMove(screen.getByText('Folder'), { pointerType: 'mouse' });
+    const row = scopeRow(container, 'Folder');
+    fireEvent.pointerMove(row, { pointerType: 'mouse' });
 
     const tooltip = await screen.findByRole('tooltip');
+
+    expect(row).toHaveClass('cursor-help');
     expect(tooltip).toHaveTextContent('Folder');
     expect(tooltip).toHaveTextContent('Directories that group files and other folders.');
     expect(tooltip).not.toHaveTextContent('Example');

--- a/packages/plugin-api/src/analysis.ts
+++ b/packages/plugin-api/src/analysis.ts
@@ -12,6 +12,7 @@ export interface IPluginNodeType {
   label: string;
   defaultColor: string;
   defaultVisible: boolean;
+  description?: IPluginGraphTypeDescription;
 }
 
 export interface IPluginEdgeType {
@@ -19,6 +20,17 @@ export interface IPluginEdgeType {
   label: string;
   defaultColor: string;
   defaultVisible: boolean;
+  description?: IPluginGraphTypeDescription;
+}
+
+export interface IPluginGraphTypeExample {
+  label?: string;
+  code: string;
+}
+
+export interface IPluginGraphTypeDescription {
+  description: string;
+  examples?: IPluginGraphTypeExample[];
 }
 
 export interface IAnalysisNode {

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -39,6 +39,8 @@ export type {
   IAnalysisSymbol,
   IFileAnalysisResult,
   IPluginEdgeType,
+  IPluginGraphTypeDescription,
+  IPluginGraphTypeExample,
   IPluginNodeType,
 } from './analysis';
 

--- a/packages/plugin-typescript/src/aliasImport/model.ts
+++ b/packages/plugin-typescript/src/aliasImport/model.ts
@@ -1,15 +1,19 @@
-import type { IFileAnalysisResult } from '@codegraphy-dev/plugin-api';
+import type { IFileAnalysisResult, IPluginEdgeType } from '@codegraphy-dev/plugin-api';
 import { readTypeScriptAliasConfig } from './compilerOptions';
 import { collectTypeScriptFilePaths, isTypeScriptConfigFile, isTypeScriptSourceFile } from './files';
 import { resolveAliasImport } from './resolve';
 import { extractModuleSpecifiers } from './specifiers';
 
-export const TYPESCRIPT_ALIAS_IMPORT_EDGE_TYPE = {
+export const TYPESCRIPT_ALIAS_IMPORT_EDGE_TYPE: IPluginEdgeType = {
   id: 'codegraphy.typescript:alias-import',
   label: 'TypeScript Alias Import',
   defaultColor: '#38BDF8',
   defaultVisible: true,
-} as const;
+  description: {
+    description: 'Shows imports resolved through TypeScript path aliases instead of relative paths.',
+    examples: [{ code: 'import { thing } from "@/module";' }],
+  },
+};
 
 const COMPILER_OPTIONS_PATHS_SOURCE_ID = 'compiler-options-paths';
 

--- a/packages/plugin-typescript/tests/plugin.test.ts
+++ b/packages/plugin-typescript/tests/plugin.test.ts
@@ -30,6 +30,10 @@ describe('createTypeScriptPlugin', () => {
         label: 'TypeScript Alias Import',
         defaultColor: '#38BDF8',
         defaultVisible: true,
+        description: {
+          description: 'Shows imports resolved through TypeScript path aliases instead of relative paths.',
+          examples: [{ code: 'import { thing } from "@/module";' }],
+        },
       },
     ]);
   });


### PR DESCRIPTION
## Summary

Scaffold PR for https://trello.com/c/DJDidsZ8/187-edge-toggle-tooltip-with-examples.

Expected first move: test the Graph Scope UI copy/tooltip behavior around edge types after the contextual toggle model is understood.

## Orchestration

- Branch: `codex/187-edge-toggle-tooltips`
- Base: `main`
- This PR intentionally starts with a scaffold-only commit so the issue has an isolated workstream before implementation begins.
- Follow repo rules: write a failing test before production changes, then make the smallest implementation needed to pass.

## Validation

- Not run yet; implementation thread should add targeted red/green checks first.