### PR TITLE
157 Add JavaScript example workspace

### DIFF
--- a/.changeset/javascript-example-workspace.md
+++ b/.changeset/javascript-example-workspace.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Add a JavaScript example workspace with acceptance coverage for imports, calls, and inheritance.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,9 +4,12 @@ Small repo fixtures for manual testing, screenshots, and extension-host e2e work
 
 The nested `example-typescript/tsconfig.json` demonstrates TypeScript plugin
 alias edges whether you open the full `examples/` workspace or the focused
-`example-typescript/` workspace.
+`example-typescript/` workspace. The `example-javascript/jsconfig.json`
+keeps JavaScript project metadata visible without asserting TypeScript-only
+alias behavior.
 
 - `example-typescript` — small TypeScript workspace used by extension e2e
+- `example-javascript` — small JavaScript workspace mirroring the TypeScript graph story
 - `example-vue` — Vue 3 SFC workspace used to inspect baseline `.vue` graph support
 - `example-godot` — Godot/GDScript workspace used by plugin e2e
 - `example-python` — Python import-resolution workspace
@@ -38,6 +41,7 @@ Open the repo-root `examples/` folder when you want to compare languages side by
 | Example | What To Look For With Symbol Enabled |
 |---------|---------------------------------------|
 | `example-typescript` | `src/index.ts` imports `buildGreeting`, type-imports `UserName`, and declares `currentUser`; `AppRunner` extends `BaseRunner` and implements `RunnableThing` for TypeScript inheritance coverage. |
+| `example-javascript` | `src/index.js` imports `buildGreeting`, calls through `formatUser`, and declares `currentUser`; `AppRunner` imports `RunnableThing` and extends `BaseRunner` for JavaScript import and inheritance coverage. |
 | `example-vue` | A Vue 3 workspace with `<script setup lang="ts">`, normal `<script lang="ts">`, explicit `.vue` component imports, composables, type-only imports, interface inheritance, and a lazy async component import. |
 | `example-godot` | A runnable Godot project with `project.godot`, scenes, resources, autoloads, and GDScript. `enemy.gd` extends a file-backed base entity while Godot `class_name` declarations appear under Variable. |
 | `example-python` | `main.py` imports config, service, and helper functions; `ApiUser` inherits from `BaseApiUser`, and member-import files show how imports and function symbols identify the exact code path. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,7 +41,7 @@ Open the repo-root `examples/` folder when you want to compare languages side by
 | Example | What To Look For With Symbol Enabled |
 |---------|---------------------------------------|
 | `example-typescript` | `src/index.ts` imports `buildGreeting`, type-imports `UserName`, and declares `currentUser`; `AppRunner` extends `BaseRunner` and implements `RunnableThing` for TypeScript inheritance coverage. |
-| `example-javascript` | `src/index.js` imports `buildGreeting`, calls through `formatUser`, and declares `currentUser`; `AppRunner` imports `RunnableThing` and extends `BaseRunner` for JavaScript import and inheritance coverage. |
+| `example-javascript` | `src/index.js` imports `buildGreeting`, calls through `normalizeUserName`, and declares `currentUser`; `AppRunner` imports `RunnableThing` and extends `BaseRunner` for JavaScript import and inheritance coverage. |
 | `example-vue` | A Vue 3 workspace with `<script setup lang="ts">`, normal `<script lang="ts">`, explicit `.vue` component imports, composables, type-only imports, interface inheritance, and a lazy async component import. |
 | `example-godot` | A runnable Godot project with `project.godot`, scenes, resources, autoloads, and GDScript. `enemy.gd` extends a file-backed base entity while Godot `class_name` declarations appear under Variable. |
 | `example-python` | `main.py` imports config, service, and helper functions; `ApiUser` inherits from `BaseApiUser`, and member-import files show how imports and function symbols identify the exact code path. |

--- a/examples/example-javascript/.codegraphy/settings.json
+++ b/examples/example-javascript/.codegraphy/settings.json
@@ -1,0 +1,94 @@
+{
+  "version": 1,
+  "maxFiles": 1000,
+  "verboseDiagnostics": false,
+  "include": [
+    "**/*"
+  ],
+  "respectGitignore": true,
+  "showOrphans": true,
+  "plugins": [
+    {
+      "id": "codegraphy.markdown",
+      "enabled": true
+    },
+    {
+      "id": "codegraphy.typescript",
+      "enabled": true
+    }
+  ],
+  "pluginData": {},
+  "nodeColors": {
+    "file": "#A1A1AA",
+    "folder": "#A1A1AA",
+    "package": "#F59E0B",
+    "symbol": "#7C3AED",
+    "symbol:function": "#8B5CF6",
+    "symbol:class": "#3B82F6",
+    "symbol:interface": "#06B6D4",
+    "symbol:type": "#EC4899",
+    "symbol:struct": "#0EA5E9",
+    "symbol:enum": "#F59E0B",
+    "variable": "#14B8A6",
+    "symbol:constant": "#22C55E",
+    "plugin:codegraphy.gdscript:symbol:godot-class-name": "#478CBF"
+  },
+  "nodeVisibility": {
+    "file": true,
+    "folder": false,
+    "package": false,
+    "symbol": false,
+    "symbol:function": false,
+    "symbol:class": false,
+    "symbol:interface": false,
+    "symbol:type": false,
+    "symbol:struct": false,
+    "symbol:enum": false,
+    "variable": false,
+    "symbol:constant": false,
+    "plugin:codegraphy.gdscript:symbol:godot-class-name": false
+  },
+  "edgeVisibility": {
+    "import": true,
+    "reference": false,
+    "call": false,
+    "type-import": false,
+    "inherit": false,
+    "load": false,
+    "nests": false,
+    "contains": false,
+    "overrides": false,
+    "codegraphy.typescript:alias-import": false
+  },
+  "favorites": [
+    "src/index.js"
+  ],
+  "bidirectionalEdges": "separate",
+  "legend": [],
+  "legendVisibility": {},
+  "legendOrder": [],
+  "filterPatterns": [],
+  "disabledCustomFilterPatterns": [],
+  "disabledPluginFilterPatterns": [],
+  "showLabels": true,
+  "directionMode": "arrows",
+  "directionColor": "#475569",
+  "particleSpeed": 0.005,
+  "particleSize": 4,
+  "depthMode": false,
+  "depthLimit": 1,
+  "dagMode": null,
+  "nodeSizeMode": "connections",
+  "physics": {
+    "repelForce": 19,
+    "linkDistance": 100,
+    "linkForce": 0.57,
+    "damping": 0.7,
+    "centerForce": 0.26,
+    "chargeRange": 200
+  },
+  "timeline": {
+    "maxCommits": 500,
+    "playbackSpeed": 1
+  }
+}

--- a/examples/example-javascript/.gitignore
+++ b/examples/example-javascript/.gitignore
@@ -1,0 +1,2 @@
+.codegraphy/*
+!.codegraphy/settings.json

--- a/examples/example-javascript/README.md
+++ b/examples/example-javascript/README.md
@@ -1,0 +1,40 @@
+# JavaScript Example
+
+This example workspace is used by CodeGraphy's extension-host e2e tests and
+doubles as a small JavaScript project you can open in VS Code to try the Graph
+View.
+
+It mirrors the TypeScript example's file graph with JavaScript source files,
+plain imports, calls, a class inheritance edge, and an intentionally
+disconnected file. It does not include the TypeScript-only alias import demo.
+
+Suggested Depth Mode check:
+
+1. Open this folder in VS Code.
+2. Open `src/index.js`.
+3. Run `CodeGraphy: Open`.
+4. Turn on Depth Mode.
+5. Move the depth slider from `1` to `3`.
+
+Expected behavior:
+
+- Depth `1` shows `src/index.js`, `src/utils.js`, and `src/types.js`.
+- Depth `2` adds `src/depth.js`.
+- Depth `3` adds `src/leaf.js`.
+- `src/orphan.js` stays out of the focused depth area because it is an Orphan Node.
+
+## Symbol Node Demo
+
+Suggested symbol check:
+
+1. Open `src/index.js`.
+2. In Graph Scope, enable **Symbol** and **Variable**.
+3. Search for `buildGreeting`, `AppRunner`, `BaseRunner`, `RunnableThing`, and
+   `currentUser`.
+
+Expected behavior:
+
+- `buildGreeting` appears as a Function symbol imported from `src/utils.js`.
+- `AppRunner` imports `RunnableThing` and extends `BaseRunner`, giving the
+  JavaScript example both import and inheritance checks.
+- `currentUser` appears as a Variable node, giving the tiny app a file/function/value story.

--- a/examples/example-javascript/README.md
+++ b/examples/example-javascript/README.md
@@ -18,7 +18,7 @@ Suggested Depth Mode check:
 
 Expected behavior:
 
-- Depth `1` shows `src/index.js`, `src/utils.js`, and `src/types.js`.
+- Depth `1` shows `src/index.js`, `src/utils.js`, and `src/user.js`.
 - Depth `2` adds `src/depth.js`.
 - Depth `3` adds `src/leaf.js`.
 - `src/orphan.js` stays out of the focused depth area because it is an Orphan Node.

--- a/examples/example-javascript/jsconfig.json
+++ b/examples/example-javascript/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "checkJs": true
+  },
+  "include": [
+    "src/**/*.js"
+  ]
+}

--- a/examples/example-javascript/package.json
+++ b/examples/example-javascript/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "codegraphy-javascript-example",
+  "private": true,
+  "type": "module"
+}

--- a/examples/example-javascript/src/baseRunner.js
+++ b/examples/example-javascript/src/baseRunner.js
@@ -1,0 +1,5 @@
+export class BaseRunner {
+  start() {
+    return 'ready';
+  }
+}

--- a/examples/example-javascript/src/depth.js
+++ b/examples/example-javascript/src/depth.js
@@ -1,0 +1,5 @@
+import { getLeafName } from './leaf.js';
+
+export function getDepthTarget() {
+  return getLeafName();
+}

--- a/examples/example-javascript/src/index.js
+++ b/examples/example-javascript/src/index.js
@@ -1,0 +1,6 @@
+import { formatUser } from './types.js';
+import { buildGreeting } from './utils.js';
+
+export const currentUser = formatUser('CodeGraphy');
+
+console.log(buildGreeting(currentUser));

--- a/examples/example-javascript/src/index.js
+++ b/examples/example-javascript/src/index.js
@@ -1,6 +1,6 @@
-import { formatUser } from './types.js';
+import { normalizeUserName } from './user.js';
 import { buildGreeting } from './utils.js';
 
-export const currentUser = formatUser('CodeGraphy');
+export const currentUser = normalizeUserName('CodeGraphy');
 
 console.log(buildGreeting(currentUser));

--- a/examples/example-javascript/src/leaf.js
+++ b/examples/example-javascript/src/leaf.js
@@ -1,0 +1,3 @@
+export function getLeafName() {
+  return 'leaf';
+}

--- a/examples/example-javascript/src/orphan.js
+++ b/examples/example-javascript/src/orphan.js
@@ -1,0 +1,1 @@
+export const ORPHAN_MESSAGE = 'This file is intentionally disconnected.';

--- a/examples/example-javascript/src/runnableThing.js
+++ b/examples/example-javascript/src/runnableThing.js
@@ -1,0 +1,5 @@
+export class RunnableThing {
+  run() {
+    throw new Error('Not implemented');
+  }
+}

--- a/examples/example-javascript/src/runner.js
+++ b/examples/example-javascript/src/runner.js
@@ -1,0 +1,11 @@
+import { BaseRunner } from './baseRunner.js';
+import { RunnableThing } from './runnableThing.js';
+
+/**
+ * @implements {RunnableThing}
+ */
+export class AppRunner extends BaseRunner {
+  run() {
+    return this.start();
+  }
+}

--- a/examples/example-javascript/src/types.js
+++ b/examples/example-javascript/src/types.js
@@ -1,0 +1,3 @@
+export function formatUser(name) {
+  return name.trim();
+}

--- a/examples/example-javascript/src/types.js
+++ b/examples/example-javascript/src/types.js
@@ -1,3 +1,0 @@
-export function formatUser(name) {
-  return name.trim();
-}

--- a/examples/example-javascript/src/user.js
+++ b/examples/example-javascript/src/user.js
@@ -1,0 +1,3 @@
+export function normalizeUserName(name) {
+  return name.trim();
+}

--- a/examples/example-javascript/src/utils.js
+++ b/examples/example-javascript/src/utils.js
@@ -1,6 +1,6 @@
 import { getDepthTarget } from './depth.js';
-import { formatUser } from './types.js';
+import { normalizeUserName } from './user.js';
 
 export function buildGreeting(name) {
-  return `Hello ${formatUser(name)} from ${getDepthTarget()}`;
+  return `Hello ${normalizeUserName(name)} from ${getDepthTarget()}`;
 }

--- a/examples/example-javascript/src/utils.js
+++ b/examples/example-javascript/src/utils.js
@@ -1,0 +1,6 @@
+import { getDepthTarget } from './depth.js';
+import { formatUser } from './types.js';
+
+export function buildGreeting(name) {
+  return `Hello ${formatUser(name)} from ${getDepthTarget()}`;
+}

--- a/packages/extension/tests/acceptance/graphView/plugins.ts
+++ b/packages/extension/tests/acceptance/graphView/plugins.ts
@@ -32,6 +32,7 @@ interface AcceptanceInstalledPluginRecord {
 
 export function acceptancePluginPackageRelativePathsForExample(exampleName: string | undefined): string[] {
   switch (exampleName) {
+    case 'example-javascript':
     case 'example-typescript':
       return ['packages/plugin-typescript'];
     case 'example-godot':

--- a/packages/extension/tests/acceptance/graphView/steps.ts
+++ b/packages/extension/tests/acceptance/graphView/steps.ts
@@ -876,6 +876,7 @@ async function applyExampleScenarioStartingUiState(
     case 'svelte-example.md':
       await setPluginSwitch(context, 'Svelte', false);
       return;
+    case 'javascript-example.md':
     case 'typescript-example.md':
       await setPluginSwitch(context, 'TypeScript/JavaScript', false);
       return;

--- a/packages/extension/tests/acceptance/specs/javascript-example.md
+++ b/packages/extension/tests/acceptance/specs/javascript-example.md
@@ -17,7 +17,7 @@ And I close the Graph Scope
 
 When I toggle the Imports edge on
 Then I can see there are 13 nodes and 7 connections
-And src/index.js points to src/types.js
+And src/index.js points to src/user.js
 And src/index.js points to src/utils.js
 And src/runner.js points to src/baseRunner.js
 And src/runner.js points to src/runnableThing.js
@@ -38,8 +38,8 @@ And src/runner.js points to src/baseRunner.js
 Then I toggle the Inherits edge off
 And I toggle the Calls edge on
 Then I can see there are 13 nodes and 5 connections
-And src/index.js points to src/types.js
+And src/index.js points to src/user.js
 And src/index.js points to src/utils.js
-And src/utils.js points to src/types.js
+And src/utils.js points to src/user.js
 And src/utils.js points to src/depth.js
 And src/depth.js points to src/leaf.js

--- a/packages/extension/tests/acceptance/specs/javascript-example.md
+++ b/packages/extension/tests/acceptance/specs/javascript-example.md
@@ -1,0 +1,45 @@
+# Feature: JavaScript Example
+
+## Scenario: JavaScript example renders expected file relationships
+
+Given I open the examples/example-javascript workspace in VS Code
+When I open the CodeGraphy extension graph view
+And I have indexed the workspace
+Then I see graph nodes
+And I show no edge types
+Then I can see there are 13 nodes and 0 connections
+And the graph nodes match the expected files in the examples/example-javascript workspace
+
+When I click the Graph Scope button
+And I select edge types
+Then the available edge types are Imports, References, Calls, Inherits
+And I close the Graph Scope
+
+When I toggle the Imports edge on
+Then I can see there are 13 nodes and 7 connections
+And src/index.js points to src/types.js
+And src/index.js points to src/utils.js
+And src/runner.js points to src/baseRunner.js
+And src/runner.js points to src/runnableThing.js
+And src/utils.js points to src/depth.js
+And src/depth.js points to src/leaf.js
+
+And src/orphan.js is an orphan node
+And README.md is an orphan node
+And package.json is an orphan node
+And .gitignore is an orphan node
+And jsconfig.json is an orphan node
+
+Then I toggle the Imports edge off
+And I toggle the Inherits edge on
+Then I can see there are 13 nodes and 1 connection
+And src/runner.js points to src/baseRunner.js
+
+Then I toggle the Inherits edge off
+And I toggle the Calls edge on
+Then I can see there are 13 nodes and 5 connections
+And src/index.js points to src/types.js
+And src/index.js points to src/utils.js
+And src/utils.js points to src/types.js
+And src/utils.js points to src/depth.js
+And src/depth.js points to src/leaf.js

--- a/packages/extension/tests/acceptanceGraphViewPlugins.test.ts
+++ b/packages/extension/tests/acceptanceGraphViewPlugins.test.ts
@@ -32,6 +32,12 @@ describe('acceptance graph view plugin fixtures', () => {
     }
   });
 
+  it('registers the TypeScript plugin for the JavaScript example', () => {
+    expect(acceptancePluginPackageRelativePathsForExample('example-javascript')).toEqual([
+      'packages/plugin-typescript',
+    ]);
+  });
+
   it('registers the Godot plugin for the Godot example', () => {
     expect(acceptancePluginPackageRelativePathsForExample('example-godot')).toEqual([
       'packages/plugin-godot',

--- a/packages/extension/tests/acceptanceGraphViewPlugins.test.ts
+++ b/packages/extension/tests/acceptanceGraphViewPlugins.test.ts
@@ -32,7 +32,7 @@ describe('acceptance graph view plugin fixtures', () => {
     }
   });
 
-  it('registers the TypeScript plugin for the JavaScript example', () => {
+  it('registers the TypeScript/JavaScript plugin for the JavaScript example', () => {
     expect(acceptancePluginPackageRelativePathsForExample('example-javascript')).toEqual([
       'packages/plugin-typescript',
     ]);

--- a/packages/extension/tests/extension/pipeline/examplesWorkspace.test.ts
+++ b/packages/extension/tests/extension/pipeline/examplesWorkspace.test.ts
@@ -158,6 +158,9 @@ describe('WorkspacePipeline examples workspace', { timeout: 30000 }, () => {
       'example-markdown/notes/Home.md->example-markdown/notes/Architecture.md#reference:static',
       'example-markdown/notes/Home.md->example-markdown/src/commented.ts#reference:static',
       'example-markdown/src/commented.ts->example-markdown/notes/Architecture.md#reference:static',
+      'example-javascript/src/index.js->example-javascript/src/utils.js#buildGreeting:function#import',
+      'example-javascript/src/index.js->example-javascript/src/types.js#formatUser:function#import',
+      'example-javascript/src/utils.js->example-javascript/src/depth.js#getDepthTarget:function#import',
       'example-typescript/src/index.ts->example-typescript/src/utils.ts#buildGreeting:function#import',
       'example-typescript/src/index.ts->example-typescript/src/types.ts#UserName:type#type-import',
       'example-typescript/src/utils.ts->example-typescript/src/depth.ts#getDepthTarget:function#import',
@@ -166,8 +169,17 @@ describe('WorkspacePipeline examples workspace', { timeout: 30000 }, () => {
 
     const missingEdgeIds = expectedEdgeIds.filter((edgeId) => !hasFileOrSymbolTargetEdge(edgeId));
     expect(missingEdgeIds).toEqual([]);
+    expect(nodeIds.has('example-javascript/src/index.js#currentUser:constant')).toBe(true);
     expect(nodeIds.has('example-typescript/src/index.ts#currentUser:constant')).toBe(true);
     expect(graph.nodes).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'example-javascript/src/index.js#currentUser:constant',
+        nodeType: 'variable',
+        symbol: expect.objectContaining({
+          kind: 'constant',
+          name: 'currentUser',
+        }),
+      }),
       expect.objectContaining({
         id: 'example-typescript/src/index.ts#currentUser:constant',
         nodeType: 'variable',
@@ -192,10 +204,23 @@ describe('WorkspacePipeline examples workspace', { timeout: 30000 }, () => {
     expect(missingStorySymbolIds).toEqual([]);
 
     const persistedSnapshot = readWorkspaceAnalysisDatabaseSnapshot(workspaceRoot);
+    const persistedJavaScriptFiles = persistedSnapshot.files
+      .map(file => file.filePath)
+      .filter(filePath => filePath.startsWith('example-javascript/'));
     const persistedTypeScriptFiles = persistedSnapshot.files
       .map(file => file.filePath)
       .filter(filePath => filePath.startsWith('example-typescript/'));
 
+    expect(persistedJavaScriptFiles).toEqual(
+      expect.arrayContaining([
+        'example-javascript/src/index.js',
+        'example-javascript/src/orphan.js',
+        'example-javascript/src/utils.js',
+        'example-javascript/src/depth.js',
+        'example-javascript/src/leaf.js',
+        'example-javascript/src/types.js',
+      ]),
+    );
     expect(persistedTypeScriptFiles).toEqual(
       expect.arrayContaining([
         'example-typescript/src/index.ts',

--- a/packages/extension/tests/extension/pipeline/examplesWorkspace.test.ts
+++ b/packages/extension/tests/extension/pipeline/examplesWorkspace.test.ts
@@ -159,7 +159,7 @@ describe('WorkspacePipeline examples workspace', { timeout: 30000 }, () => {
       'example-markdown/notes/Home.md->example-markdown/src/commented.ts#reference:static',
       'example-markdown/src/commented.ts->example-markdown/notes/Architecture.md#reference:static',
       'example-javascript/src/index.js->example-javascript/src/utils.js#buildGreeting:function#import',
-      'example-javascript/src/index.js->example-javascript/src/types.js#formatUser:function#import',
+      'example-javascript/src/index.js->example-javascript/src/user.js#normalizeUserName:function#import',
       'example-javascript/src/utils.js->example-javascript/src/depth.js#getDepthTarget:function#import',
       'example-typescript/src/index.ts->example-typescript/src/utils.ts#buildGreeting:function#import',
       'example-typescript/src/index.ts->example-typescript/src/types.ts#UserName:type#type-import',
@@ -218,7 +218,7 @@ describe('WorkspacePipeline examples workspace', { timeout: 30000 }, () => {
         'example-javascript/src/utils.js',
         'example-javascript/src/depth.js',
         'example-javascript/src/leaf.js',
-        'example-javascript/src/types.js',
+        'example-javascript/src/user.js',
       ]),
     );
     expect(persistedTypeScriptFiles).toEqual(

--- a/packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts
+++ b/packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts
@@ -5657,10 +5657,10 @@ test.describe('JavaScript Example', () => {
       });
 
       // tests/acceptance/specs/javascript-example.md:20
-      await test.step('And src/index.js points to src/types.js', async () => {
-        await runAcceptanceStep(context, 'src/index.js points to src/types.js', {
+      await test.step('And src/index.js points to src/user.js', async () => {
+        await runAcceptanceStep(context, 'src/index.js points to src/user.js', {
           keyword: 'And',
-          text: 'src/index.js points to src/types.js',
+          text: 'src/index.js points to src/user.js',
           sourcePath: 'tests/acceptance/specs/javascript-example.md',
           line: 20
         });
@@ -5837,10 +5837,10 @@ test.describe('JavaScript Example', () => {
       });
 
       // tests/acceptance/specs/javascript-example.md:41
-      await test.step('And src/index.js points to src/types.js', async () => {
-        await runAcceptanceStep(context, 'src/index.js points to src/types.js', {
+      await test.step('And src/index.js points to src/user.js', async () => {
+        await runAcceptanceStep(context, 'src/index.js points to src/user.js', {
           keyword: 'And',
-          text: 'src/index.js points to src/types.js',
+          text: 'src/index.js points to src/user.js',
           sourcePath: 'tests/acceptance/specs/javascript-example.md',
           line: 41
         });
@@ -5857,10 +5857,10 @@ test.describe('JavaScript Example', () => {
       });
 
       // tests/acceptance/specs/javascript-example.md:43
-      await test.step('And src/utils.js points to src/types.js', async () => {
-        await runAcceptanceStep(context, 'src/utils.js points to src/types.js', {
+      await test.step('And src/utils.js points to src/user.js', async () => {
+        await runAcceptanceStep(context, 'src/utils.js points to src/user.js', {
           keyword: 'And',
-          text: 'src/utils.js points to src/types.js',
+          text: 'src/utils.js points to src/user.js',
           sourcePath: 'tests/acceptance/specs/javascript-example.md',
           line: 43
         });

--- a/packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts
+++ b/packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts
@@ -5517,6 +5517,381 @@ test.describe('Java Example', () => {
   });
 });
 
+test.describe('JavaScript Example', () => {
+  test('JavaScript example renders expected file relationships', async ({}, testInfo) => {
+    const context = await createAcceptanceContext({
+      testInfo,
+      sourcePath: 'tests/acceptance/specs/javascript-example.md',
+      scenario: 'JavaScript example renders expected file relationships'
+    });
+
+    try {
+      // tests/acceptance/specs/javascript-example.md:5
+      await test.step('Given I open the examples/example-javascript workspace in VS Code', async () => {
+        await runAcceptanceStep(context, 'I open the examples/example-javascript workspace in VS Code', {
+          keyword: 'Given',
+          text: 'I open the examples/example-javascript workspace in VS Code',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 5
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:6
+      await test.step('When I open the CodeGraphy extension graph view', async () => {
+        await runAcceptanceStep(context, 'I open the CodeGraphy extension graph view', {
+          keyword: 'When',
+          text: 'I open the CodeGraphy extension graph view',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 6
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:7
+      await test.step('And I have indexed the workspace', async () => {
+        await runAcceptanceStep(context, 'I have indexed the workspace', {
+          keyword: 'And',
+          text: 'I have indexed the workspace',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 7
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:8
+      await test.step('Then I see graph nodes', async () => {
+        await runAcceptanceStep(context, 'I see graph nodes', {
+          keyword: 'Then',
+          text: 'I see graph nodes',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 8
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:9
+      await test.step('And I show no edge types', async () => {
+        await runAcceptanceStep(context, 'I show no edge types', {
+          keyword: 'And',
+          text: 'I show no edge types',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 9
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:10
+      await test.step('Then I can see there are 13 nodes and 0 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 13 nodes and 0 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 13 nodes and 0 connections',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 10
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:11
+      await test.step('And the graph nodes match the expected files in the examples/example-javascript workspace', async () => {
+        await runAcceptanceStep(context, 'the graph nodes match the expected files in the examples/example-javascript workspace', {
+          keyword: 'And',
+          text: 'the graph nodes match the expected files in the examples/example-javascript workspace',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 11
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:13
+      await test.step('When I click the Graph Scope button', async () => {
+        await runAcceptanceStep(context, 'I click the Graph Scope button', {
+          keyword: 'When',
+          text: 'I click the Graph Scope button',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 13
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:14
+      await test.step('And I select edge types', async () => {
+        await runAcceptanceStep(context, 'I select edge types', {
+          keyword: 'And',
+          text: 'I select edge types',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 14
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:15
+      await test.step('Then the available edge types are Imports, References, Calls, Inherits', async () => {
+        await runAcceptanceStep(context, 'the available edge types are Imports, References, Calls, Inherits', {
+          keyword: 'Then',
+          text: 'the available edge types are Imports, References, Calls, Inherits',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 15
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:16
+      await test.step('And I close the Graph Scope', async () => {
+        await runAcceptanceStep(context, 'I close the Graph Scope', {
+          keyword: 'And',
+          text: 'I close the Graph Scope',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 16
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:18
+      await test.step('When I toggle the Imports edge on', async () => {
+        await runAcceptanceStep(context, 'I toggle the Imports edge on', {
+          keyword: 'When',
+          text: 'I toggle the Imports edge on',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 18
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:19
+      await test.step('Then I can see there are 13 nodes and 7 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 13 nodes and 7 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 13 nodes and 7 connections',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 19
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:20
+      await test.step('And src/index.js points to src/types.js', async () => {
+        await runAcceptanceStep(context, 'src/index.js points to src/types.js', {
+          keyword: 'And',
+          text: 'src/index.js points to src/types.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 20
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:21
+      await test.step('And src/index.js points to src/utils.js', async () => {
+        await runAcceptanceStep(context, 'src/index.js points to src/utils.js', {
+          keyword: 'And',
+          text: 'src/index.js points to src/utils.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 21
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:22
+      await test.step('And src/runner.js points to src/baseRunner.js', async () => {
+        await runAcceptanceStep(context, 'src/runner.js points to src/baseRunner.js', {
+          keyword: 'And',
+          text: 'src/runner.js points to src/baseRunner.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 22
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:23
+      await test.step('And src/runner.js points to src/runnableThing.js', async () => {
+        await runAcceptanceStep(context, 'src/runner.js points to src/runnableThing.js', {
+          keyword: 'And',
+          text: 'src/runner.js points to src/runnableThing.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 23
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:24
+      await test.step('And src/utils.js points to src/depth.js', async () => {
+        await runAcceptanceStep(context, 'src/utils.js points to src/depth.js', {
+          keyword: 'And',
+          text: 'src/utils.js points to src/depth.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 24
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:25
+      await test.step('And src/depth.js points to src/leaf.js', async () => {
+        await runAcceptanceStep(context, 'src/depth.js points to src/leaf.js', {
+          keyword: 'And',
+          text: 'src/depth.js points to src/leaf.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 25
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:27
+      await test.step('And src/orphan.js is an orphan node', async () => {
+        await runAcceptanceStep(context, 'src/orphan.js is an orphan node', {
+          keyword: 'And',
+          text: 'src/orphan.js is an orphan node',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 27
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:28
+      await test.step('And README.md is an orphan node', async () => {
+        await runAcceptanceStep(context, 'README.md is an orphan node', {
+          keyword: 'And',
+          text: 'README.md is an orphan node',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 28
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:29
+      await test.step('And package.json is an orphan node', async () => {
+        await runAcceptanceStep(context, 'package.json is an orphan node', {
+          keyword: 'And',
+          text: 'package.json is an orphan node',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 29
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:30
+      await test.step('And .gitignore is an orphan node', async () => {
+        await runAcceptanceStep(context, '.gitignore is an orphan node', {
+          keyword: 'And',
+          text: '.gitignore is an orphan node',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 30
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:31
+      await test.step('And jsconfig.json is an orphan node', async () => {
+        await runAcceptanceStep(context, 'jsconfig.json is an orphan node', {
+          keyword: 'And',
+          text: 'jsconfig.json is an orphan node',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 31
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:33
+      await test.step('Then I toggle the Imports edge off', async () => {
+        await runAcceptanceStep(context, 'I toggle the Imports edge off', {
+          keyword: 'Then',
+          text: 'I toggle the Imports edge off',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 33
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:34
+      await test.step('And I toggle the Inherits edge on', async () => {
+        await runAcceptanceStep(context, 'I toggle the Inherits edge on', {
+          keyword: 'And',
+          text: 'I toggle the Inherits edge on',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 34
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:35
+      await test.step('Then I can see there are 13 nodes and 1 connection', async () => {
+        await runAcceptanceStep(context, 'I can see there are 13 nodes and 1 connection', {
+          keyword: 'Then',
+          text: 'I can see there are 13 nodes and 1 connection',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 35
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:36
+      await test.step('And src/runner.js points to src/baseRunner.js', async () => {
+        await runAcceptanceStep(context, 'src/runner.js points to src/baseRunner.js', {
+          keyword: 'And',
+          text: 'src/runner.js points to src/baseRunner.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 36
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:38
+      await test.step('Then I toggle the Inherits edge off', async () => {
+        await runAcceptanceStep(context, 'I toggle the Inherits edge off', {
+          keyword: 'Then',
+          text: 'I toggle the Inherits edge off',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 38
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:39
+      await test.step('And I toggle the Calls edge on', async () => {
+        await runAcceptanceStep(context, 'I toggle the Calls edge on', {
+          keyword: 'And',
+          text: 'I toggle the Calls edge on',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 39
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:40
+      await test.step('Then I can see there are 13 nodes and 5 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 13 nodes and 5 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 13 nodes and 5 connections',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 40
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:41
+      await test.step('And src/index.js points to src/types.js', async () => {
+        await runAcceptanceStep(context, 'src/index.js points to src/types.js', {
+          keyword: 'And',
+          text: 'src/index.js points to src/types.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 41
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:42
+      await test.step('And src/index.js points to src/utils.js', async () => {
+        await runAcceptanceStep(context, 'src/index.js points to src/utils.js', {
+          keyword: 'And',
+          text: 'src/index.js points to src/utils.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 42
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:43
+      await test.step('And src/utils.js points to src/types.js', async () => {
+        await runAcceptanceStep(context, 'src/utils.js points to src/types.js', {
+          keyword: 'And',
+          text: 'src/utils.js points to src/types.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 43
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:44
+      await test.step('And src/utils.js points to src/depth.js', async () => {
+        await runAcceptanceStep(context, 'src/utils.js points to src/depth.js', {
+          keyword: 'And',
+          text: 'src/utils.js points to src/depth.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 44
+        });
+      });
+
+      // tests/acceptance/specs/javascript-example.md:45
+      await test.step('And src/depth.js points to src/leaf.js', async () => {
+        await runAcceptanceStep(context, 'src/depth.js points to src/leaf.js', {
+          keyword: 'And',
+          text: 'src/depth.js points to src/leaf.js',
+          sourcePath: 'tests/acceptance/specs/javascript-example.md',
+          line: 45
+        });
+      });
+
+    } finally {
+      await context.cleanup?.();
+    }
+  });
+});
+
 test.describe('Kotlin Example', () => {
   test('Kotlin example renders expected file nodes and import relationships', async ({}, testInfo) => {
     const context = await createAcceptanceContext({


### PR DESCRIPTION
Trello card: https://trello.com/c/fHnNKq5F/157-add-javascript-example-workspace

Adds a JavaScript example workspace modeled on the TypeScript example, with JavaScript-specific acceptance expectations.

What changed:
- Added `examples/example-javascript` with `.js` imports, call relationships, one class inheritance edge, `jsconfig.json`, committed CodeGraphy settings, and README guidance.
- Added a JavaScript acceptance scenario and regenerated the generated Playwright acceptance file.
- Wired JavaScript acceptance runs to install the TypeScript/JavaScript plugin fixture and start with that plugin disabled, like the TypeScript example.
- Updated repo-root example workspace coverage to assert JavaScript edges, symbols, and persisted files.
- Added a patch changeset.

Verification:
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/acceptanceGraphViewPlugins.test.ts tests/acceptanceGraphViewWorkspace.test.ts tests/acceptanceSteps.test.ts`
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/examplesWorkspace.test.ts`
- `pnpm --filter @codegraphy-dev/extension run build:vscode`
- `pnpm --filter @codegraphy-dev/extension exec playwright test --config playwright.vscode.config.ts --grep "JavaScript example"`
- `pnpm --filter @codegraphy-dev/extension run typecheck`
- `pnpm --filter @codegraphy-dev/extension run lint`
- `pnpm run check:acceptance-specs`

Note: the acceptance spec commit used `ALLOW_ACCEPTANCE_SPEC_EDITS=1` because this card explicitly requested the JavaScript acceptance test.