### PR TITLE
Fix Linux tree-sitter native VSIX packaging

### DIFF
--- a/.changeset/tree-sitter-native-vsix.md
+++ b/.changeset/tree-sitter-native-vsix.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Fix Linux VSIX packaging so native Tree-sitter bindings are built and validated for the target platform instead of copying the release host's binary.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,17 @@ jobs:
       - name: Validate VSIX native binaries
         run: pnpm run check:vsix-native-artifacts
 
+      - name: Compile VS Code smoke tests
+        run: pnpm --filter @codegraphy-dev/extension exec tsc -p src/e2e/tsconfig.json
+
+      - name: Smoke installed VSIX activation
+        if: runner.os != 'Linux'
+        run: pnpm run check:vsix-activation
+
+      - name: Smoke installed VSIX activation
+        if: runner.os == 'Linux'
+        run: xvfb-run --auto-servernum pnpm run check:vsix-activation
+
   playwright:
     name: Playwright / ${{ matrix.label }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,21 @@ jobs:
         run: pnpm run test:release
 
   vsix-artifact-tests:
-    runs-on: ubuntu-latest
+    name: VSIX artifacts / ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            os: ubuntu-latest
+          - target: darwin-arm64
+            os: macos-14
+          - target: win32-x64
+            os: windows-latest
+    env:
+      CODEGRAPHY_VSIX_TARGETS: ${{ matrix.target }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
+  release-npm:
+    if: ${{ inputs.target != 'vsce' && inputs.target != 'core' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      VSCE_PAT: ${{ secrets.VSCE_PAT }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     steps:
@@ -57,4 +57,51 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Publish selected target
-        run: pnpm run release:publish ${{ inputs.target }}
+        shell: bash
+        run: |
+          if [[ "${{ inputs.target }}" == "all" ]]; then
+            pnpm run release:publish npm
+          else
+            pnpm run release:publish "${{ inputs.target }}"
+          fi
+
+  release-vsix:
+    if: ${{ inputs.target == 'all' || inputs.target == 'vsce' || inputs.target == 'core' }}
+    name: Release VSIX / ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            os: ubuntu-latest
+          - target: darwin-arm64
+            os: macos-14
+          - target: win32-x64
+            os: windows-latest
+    env:
+      CODEGRAPHY_VSIX_TARGETS: ${{ matrix.target }}
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.0
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish VSIX target
+        run: pnpm run release:publish vsce

--- a/docs/plans/2026-06-09-trello-195-tree-sitter-linux-native-vsix.md
+++ b/docs/plans/2026-06-09-trello-195-tree-sitter-linux-native-vsix.md
@@ -61,14 +61,46 @@ inside the `linux-x64` VSIX.
 
 ## Test-First Plan
 
-1. Add a failing release test for Tree-sitter native binary validation in VSIX
+1. [x] Add a failing release test for Tree-sitter native binary validation in VSIX
    artifacts.
-2. Reproduce the reported mismatch by inspecting the published `5.8.0`
-   `linux-x64` VSIX or by recreating the packaging path locally.
-3. Trace how `tree-sitter` enters `dist/node_modules` during extension build
+2. [x] Reproduce the reported mismatch by recreating the artifact-inspection
+   failure locally with a `linux-x64` VSIX fixture that contains a Mach-O
+   Tree-sitter binding.
+3. [x] Trace how `tree-sitter` enters `dist/node_modules` during extension build
    and VSIX packaging.
-4. Fix the release pipeline so target VSIX artifacts cannot contain host-native
+4. [x] Fix the release pipeline so target VSIX artifacts cannot contain host-native
    Tree-sitter bindings.
-5. Re-run the focused release/native validation tests, then package validation
+5. [x] Re-run the focused release/native validation tests, then package validation
    for supported targets.
 
+## Finding
+
+`tree-sitter@0.25.0` does not publish platform-specific optional native
+packages like `@ladybugdb/core` does. Its npm tarball contains source files and
+an install script that runs `node-gyp-build`; the installed package then has a
+host-built native file at:
+
+```text
+build/Release/tree_sitter_runtime_binding.node
+```
+
+The extension build copies that installed package into `dist/node_modules`.
+`vsce --target linux-x64` labels the VSIX for Linux, but it does not rebuild
+or replace the already-copied Tree-sitter binding. So a macOS arm64 release
+host can create a `linux-x64` VSIX whose Tree-sitter runtime is still a Mach-O
+arm64 binary.
+
+The previous native-artifact validation only inspected
+`@ladybugdb/core/lbugjs.node`, so it missed this second native runtime.
+
+## Fix
+
+- Validate both `@ladybugdb/core/lbugjs.node` and
+  `tree-sitter/build/Release/tree_sitter_runtime_binding.node` inside VSIX
+  artifacts.
+- Make VSIX packaging fail closed when a release host tries to package a VSIX
+  target that does not match its own native runtime platform.
+- Run CI VSIX artifact checks as a Linux/macOS/Windows target matrix so each
+  runner packages and validates the matching native artifact.
+- Split manual release workflow publishing so npm packages publish once, while
+  VSIX publishing runs per target on the matching OS runner.

--- a/docs/plans/2026-06-09-trello-195-tree-sitter-linux-native-vsix.md
+++ b/docs/plans/2026-06-09-trello-195-tree-sitter-linux-native-vsix.md
@@ -1,0 +1,74 @@
+# Trello 195: Linux VSIX Ships Mach-O Tree-sitter Binding
+
+## Report
+
+CodeGraphy `5.8.0` Linux x64 installs with an invalid native Tree-sitter runtime:
+
+```text
+~/.vscode/extensions/codegraphy.codegraphy-5.8.0-linux-x64/dist/node_modules/tree-sitter/build/Release/tree_sitter_runtime_binding.node
+```
+
+Observed with `file`:
+
+```text
+Mach-O 64-bit arm64 bundle
+```
+
+Expected for the `linux-x64` VSIX:
+
+```text
+ELF 64-bit LSB shared object, x86-64
+```
+
+## Tracking
+
+- Trello card: https://trello.com/c/Oy83yMam/195-linux-vsix-ships-mach-o-tree-sitter-native-binding
+- Branch: `codex/195-tree-sitter-linux-native`
+
+## Feedback Loop
+
+Build or inspect target VSIX artifacts and assert that every packaged native
+`.node` binary matches the VSIX target platform. The first failing assertion
+should cover:
+
+```text
+extension/dist/node_modules/tree-sitter/build/Release/tree_sitter_runtime_binding.node
+```
+
+inside the `linux-x64` VSIX.
+
+## Ranked Hypotheses
+
+1. The target-specific VSIX native-artifact validator only inspects
+   `@ladybugdb/core/lbugjs.node`, so the release pipeline still allows
+   Tree-sitter's host-built native binding to be copied into every target.
+   Prediction: extending the validator to inspect Tree-sitter will fail against
+   the current or recreated `linux-x64` artifact.
+2. `syncExtensionRuntimePackages` copies the workspace-installed `tree-sitter`
+   package from the macOS arm64 release host after build, and no target-specific
+   reinstall/rebuild step refreshes that package for `linux-x64`.
+   Prediction: the staged `dist/node_modules/tree-sitter/...node` file matches
+   the release host even when the VSIX target name is `linux-x64`.
+3. `vsce --target linux-x64` labels and filters the VSIX but does not rewrite
+   already-vendored native modules in `dist/node_modules`.
+   Prediction: changing only `vsce` target arguments will not change the
+   binary kind in the vendored Tree-sitter runtime.
+4. `tree-sitter` does not expose the same optional native-package matrix as
+   `@ladybugdb/core`, so the fix may need an explicit target install/rebuild
+   strategy rather than selecting an existing optional package.
+   Prediction: `tree-sitter` package metadata lacks platform-specific optional
+   dependencies for the runtime binding.
+
+## Test-First Plan
+
+1. Add a failing release test for Tree-sitter native binary validation in VSIX
+   artifacts.
+2. Reproduce the reported mismatch by inspecting the published `5.8.0`
+   `linux-x64` VSIX or by recreating the packaging path locally.
+3. Trace how `tree-sitter` enters `dist/node_modules` during extension build
+   and VSIX packaging.
+4. Fix the release pipeline so target VSIX artifacts cannot contain host-native
+   Tree-sitter bindings.
+5. Re-run the focused release/native validation tests, then package validation
+   for supported targets.
+

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"version-packages": "changeset version",
 		"package:vsix": "node scripts/release-core.mjs package",
 		"check:vsix-native-artifacts": "node scripts/validate-vsix-native-artifacts.mjs",
+		"check:vsix-activation": "node scripts/smoke-installed-vsix.mjs",
 		"publish:vsce": "node scripts/release-core.mjs publish",
 		"release:publish": "node scripts/release.mjs publish",
 		"typecheck": "turbo run typecheck",

--- a/scripts/release-core.mjs
+++ b/scripts/release-core.mjs
@@ -12,6 +12,12 @@ export const EXTENSION_VSIX_TARGETS = [
   'win32-x64',
 ];
 
+const EXTENSION_VSIX_HOST_BY_TARGET = {
+  'linux-x64': { platform: 'linux', arch: 'x64' },
+  'darwin-arm64': { platform: 'darwin', arch: 'arm64' },
+  'win32-x64': { platform: 'win32', arch: 'x64' },
+};
+
 const LADYBUG_NATIVE_PACKAGE_BY_TARGET = {
   'linux-x64': '@ladybugdb/core-linux-x64',
   'darwin-arm64': '@ladybugdb/core-darwin-arm64',
@@ -134,6 +140,64 @@ export function createCoreVsceInvocations({
       ],
     };
   });
+}
+
+export function resolveHostVsixTarget({
+  platform = process.platform,
+  arch = process.arch,
+} = {}) {
+  const hostTarget = EXTENSION_VSIX_TARGETS.find((target) => {
+    const host = EXTENSION_VSIX_HOST_BY_TARGET[target];
+    return host.platform === platform && host.arch === arch;
+  });
+
+  if (!hostTarget) {
+    throw new Error(
+      `Unsupported VSIX native build host: ${platform}-${arch}. `
+      + `Supported hosts are ${EXTENSION_VSIX_TARGETS.join(', ')}.`,
+    );
+  }
+
+  return hostTarget;
+}
+
+export function parseRequestedVsixTargets(value) {
+  if (!value) {
+    return undefined;
+  }
+
+  return value
+    .split(',')
+    .map(target => target.trim())
+    .filter(Boolean);
+}
+
+export function resolveCoreVsixTargets({
+  requestedTargets,
+  platform = process.platform,
+  arch = process.arch,
+} = {}) {
+  const hostTarget = resolveHostVsixTarget({ platform, arch });
+  const targets = requestedTargets ?? [hostTarget];
+  const unsupportedTarget = targets.find(target => !EXTENSION_VSIX_TARGETS.includes(target));
+
+  if (unsupportedTarget) {
+    throw new Error(
+      `Unsupported CodeGraphy VSIX target: ${unsupportedTarget}. `
+      + `Supported targets are ${EXTENSION_VSIX_TARGETS.join(', ')}.`,
+    );
+  }
+
+  for (const target of targets) {
+    if (target !== hostTarget) {
+      throw new Error(
+        `Cannot package ${hostTarget} host-built native runtime for ${target} VSIX. `
+        + 'Run this target on its matching release runner so Tree-sitter native bindings are built for the target platform.',
+      );
+    }
+  }
+
+  return targets;
 }
 
 function getStagedLadybugNativeBinaryPath(stageDir) {
@@ -310,6 +374,9 @@ export function runCoreRelease(mode, baseDir = repoRoot) {
     process.exit(1);
   }
 
+  const targets = resolveCoreVsixTargets({
+    requestedTargets: parseRequestedVsixTargets(process.env.CODEGRAPHY_VSIX_TARGETS),
+  });
   prepareCoreReleaseBase(baseDir);
   const { stageDir, version } = createCoreReleaseStage(baseDir);
   const nativeCacheDir = mkdtempSync(path.join(tmpdir(), 'codegraphy-ladybug-native-'));
@@ -322,7 +389,7 @@ export function runCoreRelease(mode, baseDir = repoRoot) {
   mkdirSync(artifactsDir, { recursive: true });
 
   try {
-    for (const invocation of createCoreVsceInvocations({ mode, version, artifactsDir })) {
+    for (const invocation of createCoreVsceInvocations({ mode, version, artifactsDir, targets })) {
       stageTargetLadybugNativeBinary({
         stageDir,
         target: invocation.target,

--- a/scripts/smoke-installed-vsix.mjs
+++ b/scripts/smoke-installed-vsix.mjs
@@ -89,7 +89,7 @@ async function smokeInstalledVsix({ target, vsixPath }) {
       extensionTestsPath,
       extensionTestsEnv: {
         CODEGRAPHY_E2E_SCENARIO: 'typescript',
-        CODEGRAPHY_E2E_GREP: 'extension activates without error|all commands are registered',
+        CODEGRAPHY_E2E_GREP: 'extension activates without error|all commands are registered|manual graph indexing creates scenario edges',
       },
       launchArgs: [
         workspacePath,

--- a/scripts/smoke-installed-vsix.mjs
+++ b/scripts/smoke-installed-vsix.mjs
@@ -1,0 +1,152 @@
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const requireFromExtension = createRequire(
+  path.join(repoRoot, 'packages', 'extension', 'package.json'),
+);
+const { runTests, runVSCodeCommand } = requireFromExtension('@vscode/test-electron');
+
+const hostTargetByPlatform = {
+  linux: {
+    x64: 'linux-x64',
+  },
+  darwin: {
+    arm64: 'darwin-arm64',
+  },
+  win32: {
+    x64: 'win32-x64',
+  },
+};
+
+function readExtensionVersion() {
+  const manifestPath = path.join(repoRoot, 'packages', 'extension', 'package.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  return manifest.version;
+}
+
+function parseRequestedTargets(value) {
+  if (!value) {
+    return [hostTargetByPlatform[process.platform]?.[process.arch]].filter(Boolean);
+  }
+
+  return value
+    .split(',')
+    .map(target => target.trim())
+    .filter(Boolean);
+}
+
+function findVsixForTarget({ artifactsDir, version, target }) {
+  const expectedName = `codegraphy.codegraphy-${version}-${target}.vsix`;
+  const expectedPath = path.join(artifactsDir, expectedName);
+
+  if (existsSync(expectedPath)) {
+    return expectedPath;
+  }
+
+  return readdirSync(artifactsDir)
+    .filter(fileName => fileName.endsWith(`-${target}.vsix`))
+    .map(fileName => path.join(artifactsDir, fileName))
+    .at(0);
+}
+
+async function smokeInstalledVsix({ target, vsixPath }) {
+  const profilePath = mkdtempSync(path.join(tmpdir(), 'cg-vsix-'));
+  const harnessPath = path.join(profilePath, 'harness');
+  const userDataDir = path.join(profilePath, 'user-data');
+  const extensionsDir = path.join(profilePath, 'extensions');
+  const workspacePath = path.join(repoRoot, 'examples', 'example-typescript');
+  const extensionTestsPath = path.join(
+    repoRoot,
+    'packages',
+    'extension',
+    'dist-e2e',
+    'extension',
+    'src',
+    'e2e',
+    'suite',
+    'run',
+  );
+  const profileArgs = [
+    `--user-data-dir=${userDataDir}`,
+    `--extensions-dir=${extensionsDir}`,
+  ];
+
+  try {
+    await writeHarnessExtension(harnessPath);
+    await runVSCodeCommand([
+      ...profileArgs,
+      '--install-extension',
+      vsixPath,
+      '--force',
+    ]);
+
+    await runTests({
+      extensionDevelopmentPath: harnessPath,
+      extensionTestsPath,
+      extensionTestsEnv: {
+        CODEGRAPHY_E2E_SCENARIO: 'typescript',
+        CODEGRAPHY_E2E_GREP: 'extension activates without error|all commands are registered',
+      },
+      launchArgs: [
+        workspacePath,
+        ...profileArgs,
+        '--use-inmemory-secretstorage',
+        '--sync',
+        'off',
+        '--disable-telemetry',
+        '--disable-updates',
+        '--disable-workspace-trust',
+        '--skip-welcome',
+        '--skip-release-notes',
+      ],
+    });
+
+    console.log(`${path.basename(vsixPath)} installed and activated in VS Code on ${target}`);
+  } finally {
+    rmSync(profilePath, { recursive: true, force: true });
+  }
+}
+
+async function writeHarnessExtension(harnessPath) {
+  const { mkdir, writeFile } = await import('node:fs/promises');
+
+  await mkdir(harnessPath, { recursive: true });
+  await writeFile(
+    path.join(harnessPath, 'package.json'),
+    `${JSON.stringify({
+      name: 'codegraphy-vsix-smoke-harness',
+      publisher: 'codegraphy',
+      version: '0.0.0',
+      engines: {
+        vscode: '^1.85.0',
+      },
+      activationEvents: [],
+      main: './extension.js',
+    }, null, 2)}\n`,
+  );
+  await writeFile(path.join(harnessPath, 'extension.js'), 'module.exports = {};\n');
+}
+
+const artifactsDir = path.join(repoRoot, 'artifacts', 'vsix');
+const version = readExtensionVersion();
+const targets = parseRequestedTargets(process.env.CODEGRAPHY_VSIX_TARGETS);
+
+if (targets.length === 0) {
+  throw new Error(
+    `Unsupported VSIX activation smoke host: ${process.platform}-${process.arch}. `
+    + 'Set CODEGRAPHY_VSIX_TARGETS to a supported target.',
+  );
+}
+
+for (const target of targets) {
+  const vsixPath = findVsixForTarget({ artifactsDir, version, target });
+  if (!vsixPath) {
+    throw new Error(`Missing VSIX artifact for ${target} in ${artifactsDir}.`);
+  }
+
+  await smokeInstalledVsix({ target, vsixPath });
+}

--- a/scripts/validate-vsix-native-artifacts.mjs
+++ b/scripts/validate-vsix-native-artifacts.mjs
@@ -4,13 +4,28 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const nativeBinaryPath = 'extension/dist/node_modules/@ladybugdb/core/lbugjs.node';
 
 const expectedNativeBinaryByTarget = {
   'linux-x64': 'ELF x86-64',
   'darwin-arm64': 'Mach-O arm64',
   'win32-x64': 'PE32+ x86-64',
 };
+
+const nativeBinaryPaths = [
+  'extension/dist/node_modules/@ladybugdb/core/lbugjs.node',
+  'extension/dist/node_modules/tree-sitter/build/Release/tree_sitter_runtime_binding.node',
+];
+
+function parseRequestedTargets(value) {
+  if (!value) {
+    return Object.keys(expectedNativeBinaryByTarget);
+  }
+
+  return value
+    .split(',')
+    .map(target => target.trim())
+    .filter(Boolean);
+}
 
 function hasPrefix(binary, bytes) {
   return bytes.every((byte, index) => binary[index] === byte);
@@ -92,7 +107,7 @@ function findVsixForTarget({ artifactsDir, version, target }) {
     .at(0);
 }
 
-function extractNativeBinaryFromVsix(vsixPath) {
+function extractNativeBinaryFromVsix(vsixPath, nativeBinaryPath) {
   const result = spawnSync('unzip', ['-p', vsixPath, nativeBinaryPath], {
     encoding: 'buffer',
     maxBuffer: 64 * 1024 * 1024,
@@ -115,23 +130,34 @@ export function validateVsixNativeArtifacts({
   baseDir = repoRoot,
   artifactsDir = path.join(baseDir, 'artifacts', 'vsix'),
   version = readExtensionVersion(baseDir),
+  targets = parseRequestedTargets(process.env.CODEGRAPHY_VSIX_TARGETS),
 } = {}) {
-  for (const [target, expectedKind] of Object.entries(expectedNativeBinaryByTarget)) {
+  for (const target of targets) {
+    const expectedKind = expectedNativeBinaryByTarget[target];
+    if (!expectedKind) {
+      throw new Error(
+        `Unsupported CodeGraphy VSIX target: ${target}. `
+        + `Supported targets are ${Object.keys(expectedNativeBinaryByTarget).join(', ')}.`,
+      );
+    }
+
     const vsixPath = findVsixForTarget({ artifactsDir, version, target });
     if (!vsixPath) {
       throw new Error(`Missing VSIX artifact for ${target} in ${artifactsDir}.`);
     }
 
-    const binary = extractNativeBinaryFromVsix(vsixPath);
-    const actualKind = identifyNativeBinary(binary);
+    for (const nativeBinaryPath of nativeBinaryPaths) {
+      const binary = extractNativeBinaryFromVsix(vsixPath, nativeBinaryPath);
+      const actualKind = identifyNativeBinary(binary);
 
-    if (actualKind !== expectedKind) {
-      throw new Error(
-        `${path.basename(vsixPath)} contains ${actualKind} at ${nativeBinaryPath}; expected ${expectedKind}.`,
-      );
+      if (actualKind !== expectedKind) {
+        throw new Error(
+          `${path.basename(vsixPath)} contains ${actualKind} at ${nativeBinaryPath}; expected ${expectedKind}.`,
+        );
+      }
+
+      console.log(`${path.basename(vsixPath)}: ${nativeBinaryPath} is ${actualKind}`);
     }
-
-    console.log(`${path.basename(vsixPath)}: ${nativeBinaryPath} is ${actualKind}`);
   }
 }
 

--- a/tests/release/releaseCore.test.mjs
+++ b/tests/release/releaseCore.test.mjs
@@ -71,6 +71,43 @@ test('publish mode publishes every target-specific VSIX target', () => {
   );
 });
 
+test('resolves the VSIX target that matches the host native runtime', () => {
+  assert.equal(
+    releaseCore.resolveHostVsixTarget({ platform: 'linux', arch: 'x64' }),
+    'linux-x64',
+  );
+  assert.equal(
+    releaseCore.resolveHostVsixTarget({ platform: 'darwin', arch: 'arm64' }),
+    'darwin-arm64',
+  );
+  assert.equal(
+    releaseCore.resolveHostVsixTarget({ platform: 'win32', arch: 'x64' }),
+    'win32-x64',
+  );
+});
+
+test('rejects cross-target VSIX packaging for host-built Tree-sitter bindings', () => {
+  assert.throws(
+    () => releaseCore.resolveCoreVsixTargets({
+      requestedTargets: ['linux-x64', 'darwin-arm64'],
+      platform: 'darwin',
+      arch: 'arm64',
+    }),
+    /Cannot package darwin-arm64 host-built native runtime for linux-x64 VSIX/,
+  );
+});
+
+test('allows one explicitly requested target when it matches the host native runtime', () => {
+  assert.deepEqual(
+    releaseCore.resolveCoreVsixTargets({
+      requestedTargets: ['linux-x64'],
+      platform: 'linux',
+      arch: 'x64',
+    }),
+    ['linux-x64'],
+  );
+});
+
 test('stages the target LadybugDB native binary before packaging a target VSIX', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraphy-release-native-'));
   const stageDir = path.join(tempDir, 'stage');

--- a/tests/release/vsixNativeArtifacts.test.mjs
+++ b/tests/release/vsixNativeArtifacts.test.mjs
@@ -1,7 +1,14 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
-import { identifyNativeBinary } from '../../scripts/validate-vsix-native-artifacts.mjs';
+import {
+  identifyNativeBinary,
+  validateVsixNativeArtifacts,
+} from '../../scripts/validate-vsix-native-artifacts.mjs';
 
 test('identifies Linux x64 native binaries from ELF headers', () => {
   const binary = Buffer.alloc(20);
@@ -29,3 +36,115 @@ test('identifies Windows x64 native binaries from PE headers', () => {
 
   assert.equal(identifyNativeBinary(binary), 'PE32+ x86-64');
 });
+
+test('rejects a linux x64 VSIX with a macOS Apple Silicon Tree-sitter binding', () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'codegraphy-vsix-native-artifacts-'));
+  const artifactsDir = path.join(tempDir, 'artifacts');
+  const version = '5.8.0';
+
+  writeVsixFixture({
+    artifactsDir,
+    version,
+    target: 'linux-x64',
+    ladybugBinary: createElfX64Binary(),
+    treeSitterBinary: createMachOArm64Binary(),
+  });
+  writeVsixFixture({
+    artifactsDir,
+    version,
+    target: 'darwin-arm64',
+    ladybugBinary: createMachOArm64Binary(),
+    treeSitterBinary: createMachOArm64Binary(),
+  });
+  writeVsixFixture({
+    artifactsDir,
+    version,
+    target: 'win32-x64',
+    ladybugBinary: createPe32PlusX64Binary(),
+    treeSitterBinary: createPe32PlusX64Binary(),
+  });
+
+  assert.throws(
+    () => validateVsixNativeArtifacts({ artifactsDir, version }),
+    /linux-x64\.vsix contains Mach-O arm64 at extension\/dist\/node_modules\/tree-sitter\/build\/Release\/tree_sitter_runtime_binding\.node; expected ELF x86-64\./,
+  );
+});
+
+test('validates only the requested VSIX artifact targets', () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'codegraphy-vsix-native-artifacts-target-'));
+  const artifactsDir = path.join(tempDir, 'artifacts');
+  const version = '5.8.0';
+
+  writeVsixFixture({
+    artifactsDir,
+    version,
+    target: 'linux-x64',
+    ladybugBinary: createElfX64Binary(),
+    treeSitterBinary: createElfX64Binary(),
+  });
+
+  assert.doesNotThrow(
+    () => validateVsixNativeArtifacts({ artifactsDir, version, targets: ['linux-x64'] }),
+  );
+});
+
+function writeVsixFixture({
+  artifactsDir,
+  version,
+  target,
+  ladybugBinary,
+  treeSitterBinary,
+}) {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), `codegraphy-vsix-${target}-`));
+  writeFixtureBinary(
+    fixtureRoot,
+    'extension/dist/node_modules/@ladybugdb/core/lbugjs.node',
+    ladybugBinary,
+  );
+  writeFixtureBinary(
+    fixtureRoot,
+    'extension/dist/node_modules/tree-sitter/build/Release/tree_sitter_runtime_binding.node',
+    treeSitterBinary,
+  );
+
+  mkdirSync(artifactsDir, { recursive: true });
+  const vsixPath = path.join(artifactsDir, `codegraphy.codegraphy-${version}-${target}.vsix`);
+  const zipResult = spawnSync('zip', ['-qr', vsixPath, 'extension'], {
+    cwd: fixtureRoot,
+    encoding: 'utf8',
+  });
+
+  if (zipResult.status !== 0) {
+    throw new Error(`Unable to create VSIX fixture for ${target}.\n${zipResult.stderr}`);
+  }
+}
+
+function writeFixtureBinary(rootDir, relativePath, binary) {
+  const filePath = path.join(rootDir, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, binary);
+}
+
+function createElfX64Binary() {
+  const binary = Buffer.alloc(20);
+  binary.set([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00], 0);
+  binary.writeUInt16LE(0x3e, 18);
+  return binary;
+}
+
+function createMachOArm64Binary() {
+  const binary = Buffer.alloc(8);
+  binary.writeUInt32LE(0xfeedfacf, 0);
+  binary.writeInt32LE(0x0100000c, 4);
+  return binary;
+}
+
+function createPe32PlusX64Binary() {
+  const binary = Buffer.alloc(160);
+  binary.write('MZ', 0, 'ascii');
+  binary.writeUInt32LE(0x80, 0x3c);
+  binary.write('PE\0\0', 0x80, 'ascii');
+  binary.writeUInt16LE(0x8664, 0x84);
+  binary.writeUInt16LE(0x20b, 0x98);
+  return binary;
+}


### PR DESCRIPTION
## Summary

Fixes Trello #195: CodeGraphy 5.8.0 linux-x64 VSIX could include a macOS arm64 Tree-sitter native binding at:

```text
extension/dist/node_modules/tree-sitter/build/Release/tree_sitter_runtime_binding.node
```

## Root cause

The earlier target-specific VSIX hardening correctly swapped LadybugDB native binaries, but the validator only inspected `@ladybugdb/core/lbugjs.node`. Tree-sitter is different: `tree-sitter@0.25.0` ships source and builds `build/Release/tree_sitter_runtime_binding.node` during install on the release host. The extension build then copies that installed package into `dist/node_modules`.

`vsce --target linux-x64` labels the VSIX for Linux, but it does not rebuild or replace the copied Tree-sitter native binding. So a macOS arm64 release host could publish a Linux-targeted VSIX with a Mach-O arm64 Tree-sitter runtime.

## Changes

- Add VSIX artifact validation for Tree-sitter's native runtime in addition to LadybugDB.
- Make release-core resolve the host-native VSIX target and reject cross-target packaging for host-built native runtimes.
- Let CI/release jobs pass `CODEGRAPHY_VSIX_TARGETS` so each OS runner packages and validates only its matching VSIX.
- Change VSIX artifact CI to a linux-x64 / darwin-arm64 / win32-x64 matrix.
- Add an installed-VSIX smoke test: CI installs the freshly packaged VSIX into a clean VS Code profile on the target OS, activates CodeGraphy, and runs a real TypeScript workspace indexing path.
- Split manual release publishing so npm packages publish once, while VSIX publishing runs per target on the matching OS runner.
- Add a patch changeset and written investigation notes.

## Validation

- Red reproduced: new VSIX fixture test initially failed because the validator missed a Mach-O Tree-sitter binding inside a linux-x64 VSIX.
- `pnpm run test:release`
- Local package/validate/smoke on darwin-arm64:
  - `pnpm run package:vsix` produced `codegraphy.codegraphy-5.8.0-darwin-arm64.vsix`
  - `CODEGRAPHY_VSIX_TARGETS=darwin-arm64 pnpm run check:vsix-native-artifacts` verified LadybugDB and Tree-sitter are both Mach-O arm64
  - `CODEGRAPHY_VSIX_TARGETS=darwin-arm64 pnpm run check:vsix-activation` installed that VSIX into a clean VS Code profile, activated CodeGraphy, and passed `manual graph indexing creates scenario edges`, `extension activates without error`, and `all commands are registered`
- Linux GitHub Actions proof on run `27224392380`, job `VSIX artifacts / linux-x64`:
  - Packaged `codegraphy.codegraphy-5.8.0-linux-x64.vsix`
  - Validator reported `@ladybugdb/core/lbugjs.node is ELF x86-64`
  - Validator reported `tree-sitter/build/Release/tree_sitter_runtime_binding.node is ELF x86-64`
  - Installed the linux-x64 VSIX into VS Code `1.123.1` on the Linux runner under `xvfb-run`
  - Indexed the TypeScript scenario: `Discovered 14 files`, `Analysis: 0 cache hits, 14 misses`, `Graph built: 15 nodes, 17 edges`
  - Passed `manual graph indexing creates scenario edges`, `extension activates without error`, and `all commands are registered`
- Negative guard check on this Mac:
  - `CODEGRAPHY_VSIX_TARGETS=linux-x64 node scripts/release-core.mjs package` fails before build with the cross-target native-runtime error.
- Pre-commit acceptance guard and full `pnpm run typecheck` passed.