### PR TITLE
Retry Graph Scope acceptance switch settling

### DIFF
--- a/packages/extension/tests/acceptance/graphView/steps.ts
+++ b/packages/extension/tests/acceptance/graphView/steps.ts
@@ -1320,34 +1320,44 @@ async function openGraphScopeSection(
   await frame.getByRole('button', { name: sectionName }).click();
 }
 
-async function setPanelSwitch(
+export async function setPanelSwitch(
   context: GraphAcceptanceContext,
   label: string,
   enabled: boolean,
 ): Promise<void> {
-  const switchInRow = await findPanelSwitch(requireGraphFrame(context), normalizePanelLabel(label));
+  const frame = requireGraphFrame(context);
+  const normalizedLabel = normalizePanelLabel(label);
+  const expected = String(enabled);
+  const switchInRow = await findPanelSwitch(frame, normalizedLabel);
   const current = await switchInRow.getAttribute('aria-checked');
 
-  if (current !== String(enabled)) {
+  if (current !== expected) {
     await switchInRow.click();
   }
 
-  if (!enabled && current !== String(enabled)) {
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      if (!(await switchInRow.isVisible().catch(() => false))) {
+  if (current !== expected) {
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const currentSwitch = await findPanelSwitchIfPresent(frame, normalizedLabel);
+      if (!currentSwitch || !(await currentSwitch.isVisible().catch(() => false))) {
+        if (!enabled) {
+          return;
+        }
+
+        await frame.waitForTimeout(150);
+        continue;
+      }
+
+      const checked = await currentSwitch.getAttribute('aria-checked').catch(() => enabled ? 'false' : expected);
+      if (checked === expected) {
         return;
       }
 
-      if (await switchInRow.getAttribute('aria-checked').catch(() => String(enabled)) === String(enabled)) {
-        return;
-      }
-
-      await switchInRow.click();
-      await requireGraphFrame(context).waitForTimeout(150);
+      await currentSwitch.click();
+      await frame.waitForTimeout(150);
     }
   }
 
-  await expect(switchInRow).toHaveAttribute('aria-checked', String(enabled));
+  await expect(await findPanelSwitch(frame, normalizedLabel)).toHaveAttribute('aria-checked', expected);
 }
 
 async function setPanelSwitchIfPresent(

--- a/packages/extension/tests/acceptance/graphView/steps.ts
+++ b/packages/extension/tests/acceptance/graphView/steps.ts
@@ -1325,72 +1325,64 @@ export async function setPanelSwitch(
   label: string,
   enabled: boolean,
 ): Promise<void> {
-  const frame = requireGraphFrame(context);
-  const normalizedLabel = normalizePanelLabel(label);
-  const expected = String(enabled);
-  const switchInRow = await findPanelSwitch(frame, normalizedLabel);
-  const current = await switchInRow.getAttribute('aria-checked');
-
-  if (current !== expected) {
-    await switchInRow.click();
-  }
-
-  if (current !== expected) {
-    for (let attempt = 0; attempt < 4; attempt += 1) {
-      const currentSwitch = await findPanelSwitchIfPresent(frame, normalizedLabel);
-      if (!currentSwitch || !(await currentSwitch.isVisible().catch(() => false))) {
-        if (!enabled) {
-          return;
-        }
-
-        await frame.waitForTimeout(150);
-        continue;
-      }
-
-      const checked = await currentSwitch.getAttribute('aria-checked').catch(() => enabled ? 'false' : expected);
-      if (checked === expected) {
-        return;
-      }
-
-      await currentSwitch.click();
-      await frame.waitForTimeout(150);
-    }
-  }
-
-  await expect(await findPanelSwitch(frame, normalizedLabel)).toHaveAttribute('aria-checked', expected);
+  await setPanelSwitchState(context, label, enabled, { requirePresent: true });
 }
 
-async function setPanelSwitchIfPresent(
+export async function setPanelSwitchIfPresent(
   context: GraphAcceptanceContext,
   label: string,
   enabled: boolean,
 ): Promise<void> {
+  await setPanelSwitchState(context, label, enabled, { requirePresent: false });
+}
+
+async function setPanelSwitchState(
+  context: GraphAcceptanceContext,
+  label: string,
+  enabled: boolean,
+  options: { requirePresent: boolean },
+): Promise<void> {
   const frame = requireGraphFrame(context);
   const normalizedLabel = normalizePanelLabel(label);
-  const switchInRow = await findPanelSwitchIfPresent(frame, normalizedLabel);
+  const expected = String(enabled);
+  const switchInRow = options.requirePresent
+    ? await findPanelSwitch(frame, normalizedLabel)
+    : await findPanelSwitchIfPresent(frame, normalizedLabel);
+
   if (!switchInRow) {
     return;
   }
 
-  const current = await switchInRow.getAttribute('aria-checked');
-
-  if (current !== String(enabled)) {
-    await switchInRow.click();
-  }
-
-  if (!enabled) {
-    await expect.poll(async () => {
-      const currentSwitch = await findPanelSwitchIfPresent(frame, normalizedLabel);
-      if (!currentSwitch || !(await currentSwitch.isVisible().catch(() => false))) {
-        return 'false';
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const currentSwitch = attempt === 0
+      ? switchInRow
+      : await findPanelSwitchIfPresent(frame, normalizedLabel);
+    if (!currentSwitch || !(await currentSwitch.isVisible().catch(() => false))) {
+      if (!enabled) {
+        return;
       }
 
-      return await currentSwitch.getAttribute('aria-checked') ?? 'false';
-    }).toBe('false');
-    return;
+      await frame.waitForTimeout(150);
+      continue;
+    }
+
+    const checked = await currentSwitch.getAttribute('aria-checked').catch(() => enabled ? 'false' : expected);
+    if (checked === expected) {
+      return;
+    }
+
+    await currentSwitch.click();
+    await frame.waitForTimeout(150);
   }
 
-  await expect(switchInRow).toHaveAttribute('aria-checked', String(enabled));
+  await expect.poll(async () => {
+    const currentSwitch = await findPanelSwitchIfPresent(frame, normalizedLabel);
+    if (!currentSwitch || !(await currentSwitch.isVisible().catch(() => false))) {
+      return enabled ? 'missing' : expected;
+    }
+
+    return await currentSwitch.getAttribute('aria-checked') ?? 'missing';
+  }).toBe(expected);
 }
 
 export async function findPanelSwitchIfPresent(frame: Frame, label: string): Promise<Locator | undefined> {

--- a/packages/extension/tests/acceptanceGraphViewPanelSwitch.test.ts
+++ b/packages/extension/tests/acceptanceGraphViewPanelSwitch.test.ts
@@ -1,6 +1,34 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Frame, Locator } from '@playwright/test';
 
+vi.mock('@playwright/test', () => {
+  const expectLocator = vi.fn((locator: Locator) => ({
+    async toHaveAttribute(name: string, expected: string): Promise<void> {
+      const actual = await locator.getAttribute(name);
+      if (actual !== expected) {
+        throw new Error(`Expected ${name} to be ${expected}, got ${actual}`);
+      }
+    },
+  }));
+
+  return {
+    expect: Object.assign(expectLocator, {
+      poll(callback: () => Promise<string>) {
+        return {
+          async toBe(expected: string): Promise<void> {
+            for (let attempt = 0; attempt < 5; attempt += 1) {
+              if (await callback() === expected) {
+                return;
+              }
+            }
+            throw new Error(`Expected poll to resolve to ${expected}`);
+          },
+        };
+      },
+    }),
+  };
+});
+
 describe('acceptance graph view panel switches', () => {
   it('requires only structural node type switches during pre-index example setup', async () => {
     const { requiresCoreNodeTypeSwitch } = await import('./acceptance/graphView/steps');
@@ -35,6 +63,16 @@ describe('acceptance graph view panel switches', () => {
 
     expect(frame.waitForTimeout).not.toHaveBeenCalled();
   });
+
+  it('retries enabling a present switch until the checked state settles', async () => {
+    const { setPanelSwitch } = await import('./acceptance/graphView/steps');
+    const switchInRow = settlingSwitchLocator({ checkedAfterClicks: 2 });
+    const frame = panelFrameForSwitch(switchInRow);
+
+    await setPanelSwitch({ graphFrame: frame } as never, 'Typedef', true);
+
+    expect(switchInRow.click).toHaveBeenCalledTimes(2);
+  });
 });
 
 function locatorWithCount(count: number): Locator {
@@ -44,4 +82,42 @@ function locatorWithCount(count: number): Locator {
       return this;
     }),
   } as unknown as Locator;
+}
+
+function settlingSwitchLocator({ checkedAfterClicks }: { checkedAfterClicks: number }): Locator {
+  let clicks = 0;
+
+  return {
+    click: vi.fn(async () => {
+      clicks += 1;
+    }),
+    count: vi.fn(async () => 1),
+    first: vi.fn(function first(this: Locator) {
+      return this;
+    }),
+    getAttribute: vi.fn(async (name: string) => {
+      if (name !== 'aria-checked') {
+        return null;
+      }
+
+      return String(clicks >= checkedAfterClicks);
+    }),
+    isVisible: vi.fn(async () => true),
+  } as unknown as Locator;
+}
+
+function panelFrameForSwitch(switchInRow: Locator): Frame {
+  const row = {
+    getByRole: vi.fn(() => switchInRow),
+  };
+
+  return {
+    locator: vi.fn(() => ({
+      filter: vi.fn(() => ({
+        first: vi.fn(() => row),
+      })),
+    })),
+    getByRole: vi.fn(() => locatorWithCount(0)),
+    waitForTimeout: vi.fn(),
+  } as unknown as Frame;
 }

--- a/packages/extension/tests/acceptanceGraphViewPanelSwitch.test.ts
+++ b/packages/extension/tests/acceptanceGraphViewPanelSwitch.test.ts
@@ -73,6 +73,16 @@ describe('acceptance graph view panel switches', () => {
 
     expect(switchInRow.click).toHaveBeenCalledTimes(2);
   });
+
+  it('retries enabling an optional present switch until the checked state settles', async () => {
+    const { setPanelSwitchIfPresent } = await import('./acceptance/graphView/steps');
+    const switchInRow = settlingSwitchLocator({ checkedAfterClicks: 2 });
+    const frame = panelFrameForSwitch(switchInRow);
+
+    await setPanelSwitchIfPresent({ graphFrame: frame } as never, 'Type imports', true);
+
+    expect(switchInRow.click).toHaveBeenCalledTimes(2);
+  });
 });
 
 function locatorWithCount(count: number): Locator {


### PR DESCRIPTION
## Summary
- retry Graph Scope acceptance helper switch updates when enabling rows, not only when disabling them
- re-query the current scope row between retries so panel re-renders do not leave the helper asserting against stale state
- share the same settling behavior with optional-present Graph Scope switches used by broader helper flows
- add focused red tests for present switches whose `aria-checked` state does not settle after the first click

## Failure evidence
- Source failure: PR #261 docs-only CI, run 27298377482, job 80637157114 (`Playwright / Graph interactions`)
- Failing scenario: `tests/playwright-vscode/generated/acceptance.spec.ts:424:7` `C Example › C example exposes symbols when symbol scope is enabled`
- Log symptom: `setPanelSwitch` expected `Toggle Typedef` or `Toggle Union` to have `aria-checked="true"`, but the switch stayed `false` across retries.
- PR #261 passed on a later rerun, which points to flake/timing rather than a docs regression.
- This branch targets the underlying acceptance helper behavior on `main`, not the docs-only PR.

## Verification
- Red first: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/acceptanceGraphViewPanelSwitch.test.ts` failed with `Expected aria-checked to be true, got false` before the retry fix.
- Red follow-up: the optional-present switch test failed the same way before `setPanelSwitchIfPresent` shared the retry/re-query path.
- Green: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/acceptanceGraphViewPanelSwitch.test.ts`
- Green: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/graphScope/Panel.test.tsx tests/webview/graphScope/rows.test.tsx tests/webview/graphScope/messages.test.ts`
- Pre-commit: `pnpm run check:acceptance-specs`, `pnpm run typecheck`, and lint-staged completed while creating the checkpoint commits.
- PR CI: run 27299391186 passed, including `Playwright / Graph interactions` job 80640703571.
- PR CI after optional-present follow-up: run 27300687813 passed, including `Playwright / Graph interactions` job 80645360295 and `Playwright / Language examples` job 80645360316.

## Remote Mac mini note
- Created `/Users/poleski/.codex/worktrees/pr262-graph-interactions` on `codegraphy-mini` for the narrow VS Code Playwright repro.
- Remote local run was blocked before Playwright because the Mac mini login shell uses Node 26.0.0 while the repo requires `>=20.20.0 <23`; native `tree-sitter` failed during install.
- I did not mutate the Mac mini global Node setup from this thread. PR CI supplied the heavy VS Code Playwright verification.

## Notes
- No human-owned acceptance spec Markdown changed.
- No changeset: this is acceptance harness stabilization, not user-facing extension behavior.
