### PR TITLE
[codex] Fix npm release dependency builds

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -228,17 +228,17 @@ function runCoreRelease(mode, baseDir, runCommand) {
 }
 
 function runNpmRelease(mode, target, baseDir, runCommand) {
-  if (mode === 'publish' && npmVersionExists(target, baseDir, runCommand)) {
-    console.log(`${target.packageName}@${target.version} already exists on npm; skipping.`);
-    return { status: 0 };
-  }
-
   const buildResult = target.hasBuildScript
     ? runCommand('pnpm', ['--filter', target.packageName, 'run', 'build'], { cwd: baseDir })
     : { status: 0 };
 
   if (buildResult.status !== 0) {
     return buildResult;
+  }
+
+  if (mode === 'publish' && npmVersionExists(target, baseDir, runCommand)) {
+    console.log(`${target.packageName}@${target.version} already exists on npm; skipping.`);
+    return { status: 0 };
   }
 
   if (mode === 'package') {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
-import { collectReleaseTargets, resolveReleaseTargets } from './release.mjs';
+import { collectReleaseTargets, resolveReleaseTargets, runRelease } from './release.mjs';
 
 test('language plugin release targets resolve by short language name', () => {
   const repoRoot = createReleaseFixture({
@@ -57,6 +57,41 @@ test('release target list exposes plugin and short aliases', () => {
   });
 });
 
+test('already-published workspace dependencies still build before dependent npm targets publish', () => {
+  const repoRoot = createReleaseFixture({
+    'packages/plugin-api/package.json': packageManifest('@codegraphy-dev/plugin-api', {
+      scripts: {},
+    }),
+    'packages/plugin-markdown/package.json': packageManifest('@codegraphy-dev/plugin-markdown', {
+      dependencies: {
+        '@codegraphy-dev/plugin-api': 'workspace:*',
+      },
+    }),
+    'packages/core/package.json': packageManifest('@codegraphy-dev/core', {
+      dependencies: {
+        '@codegraphy-dev/plugin-markdown': 'workspace:*',
+      },
+    }),
+  });
+  const commands = [];
+
+  runRelease('publish', 'npm', repoRoot, (command, args) => {
+    commands.push([command, ...args]);
+
+    if (command === 'npm' && args[0] === 'view') {
+      return { status: args[1] === '@codegraphy-dev/core@1.0.0' ? 1 : 0 };
+    }
+
+    return { status: 0 };
+  });
+
+  assert.deepEqual(commands.filter(command => command[0] === 'pnpm'), [
+    ['pnpm', '--filter', '@codegraphy-dev/plugin-markdown', 'run', 'build'],
+    ['pnpm', '--filter', '@codegraphy-dev/core', 'run', 'build'],
+    ['pnpm', '--filter', '@codegraphy-dev/core', 'publish', '--access', 'public', '--no-git-checks'],
+  ]);
+});
+
 function createReleaseFixture(files) {
   const repoRoot = mkdtempSync(path.join(tmpdir(), 'codegraphy-release-test-'));
   writeFile(repoRoot, 'package.json', {
@@ -76,11 +111,12 @@ function writeFile(repoRoot, relativePath, contents) {
   writeFileSync(absolutePath, `${JSON.stringify(contents, null, 2)}\n`);
 }
 
-function packageManifest(name) {
+function packageManifest(name, overrides = {}) {
   return {
     name,
     version: '1.0.0',
     publishConfig: { access: 'public' },
     scripts: { build: 'echo build' },
+    ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fixes the npm release workflow failure where already-published workspace packages were skipped before their build outputs were generated.

## Root Cause

`release:publish npm` checked npm for an existing package version before running that package's build. On a clean GitHub Actions runner, packages such as `@codegraphy-dev/plugin-markdown` can already exist on npm while still needing their local `dist` outputs so later workspace packages, such as `@codegraphy-dev/core`, can resolve package exports during build.

## Changes

- Build npm release targets before checking whether the exact version already exists on npm.
- Keep duplicate-safe publishing behavior by skipping only the publish step after a successful build.
- Add a release regression test for an already-published workspace dependency required by a dependent npm target.

## Validation

- `pnpm exec node --test scripts/release.test.mjs`
- `pnpm run test:release`
- `pnpm --filter @codegraphy-dev/plugin-markdown run build && pnpm --filter @codegraphy-dev/core run build`
- `pnpm run lint` (passes with existing generated Playwright spacing warnings)
- pre-commit: `pnpm run check:acceptance-specs`
- pre-commit: `pnpm run typecheck`