### PR TITLE
Docs: keep loop role work in orchestrator thread

### DIFF
--- a/docs/agents/codegraphy-loop.md
+++ b/docs/agents/codegraphy-loop.md
@@ -4,9 +4,10 @@ The CodeGraphy Loop is a role-based workflow for taking one Trello card, bug
 report, or explicit user request from informal intent to a PR that is ready for
 human review.
 
-The loop is orchestrated by one main Codex thread. Role agents do focused work,
-write the substantive handoff entries at role boundaries, and return control to
-the Orchestrator.
+The loop is orchestrated by one main Codex thread. The Orchestrator runs each
+role as a bounded role pass, writes substantive handoff entries at role
+boundaries, and uses those entries as the continuity record when a later pass
+returns to the same role.
 
 ## Roles
 
@@ -21,6 +22,10 @@ CodeGraphy uses one Orchestrator and four role agents:
   CI readiness.
 
 Each role has its own loop contract under `docs/agents/loops/`.
+
+The Orchestrator is the visible control surface for the loop. Alternative
+execution models need explicit user approval for that loop and should still use
+the same handoff file as the shared state record.
 
 ## Heavy Work
 

--- a/docs/agents/loops/architect.md
+++ b/docs/agents/loops/architect.md
@@ -89,8 +89,8 @@ Mutation survivor fixes often split files, add tests, or move helpers. After
 the mutation site and survivor loops pass, check whether the changed production
 areas still satisfy the organization tool.
 
-If organization output is dirty, do not start a Refactorer cleanup inside the
-Architect thread. Return to the Orchestrator with the affected paths and output
+If organization output is dirty, do not start a Refactorer cleanup during the
+Architect pass. Return to the Orchestrator with the affected paths and output
 summary. The Orchestrator routes Refactorer, then routes Architect again because
 Refactorer changes make the downstream mutation and architecture checks stale.
 

--- a/docs/agents/loops/coder.md
+++ b/docs/agents/loops/coder.md
@@ -45,7 +45,7 @@ flowchart TD
     Commit --> Done["Return handoff to orchestrator"]
 ```
 
-The Coder does not need to check PR CI in V0. It must not hand off until its
+The Coder does not need to check PR CI. It must not hand off until its
 focused unit tests, generated acceptance tests, lint, and typecheck pass.
 
 If generated acceptance or focused behavior reds point back to human-owned

--- a/docs/agents/loops/orchestrator.md
+++ b/docs/agents/loops/orchestrator.md
@@ -20,7 +20,7 @@ belongs to the Specifier, Coder, Refactorer, or Architect.
 - working on exactly one card, bug report, or request
 - creating a dedicated `codex/` branch, isolated worktree, and draft PR
 - keeping one shared PR worktree and one handoff file for the loop
-- dispatching one reusable thread per role with a bounded task and current state
+- running each role as a bounded role pass inside the Orchestrator thread
 - reading each role handoff before choosing the next state
 - preparing the remote Mac mini only when a role needs heavy checks
 - enforcing human gates
@@ -34,8 +34,7 @@ belongs to the Specifier, Coder, Refactorer, or Architect.
 - implementing accepted behavior
 - running role-owned quality or mutation loops
 - bypassing a role because the next step seems obvious
-- closing an addressable role thread while that role may still need follow-up
-  work in the current loop
+- changing the loop execution model without explicit user approval
 - marking work done before human review accepts it
 - writing role evidence that belongs to the active role agent
 
@@ -51,7 +50,7 @@ flowchart TD
     Decide --> Human{"Human gate active?"}
     Human -->|Yes| Wait["Move to Review and wait for human input"]
     Wait --> Read
-    Human -->|No| Dispatch["Dispatch one role agent"]
+    Human -->|No| Dispatch["Run one bounded role pass"]
     Dispatch --> Return["Role returns handoff entry"]
     Return --> Record["Record role boundary state"]
     Record --> Ready{"All role conditions and CI green?"}
@@ -76,11 +75,11 @@ shows a reason to move elsewhere.
 
 When the Orchestrator routes backward, every downstream role state becomes
 stale. Route forward again from that point before returning to human review.
-Use at most one reusable thread per role during the active loop so the same
-Specifier, Coder, Refactorer, or Architect can continue with the updated context
-when the loop returns to that role. If an earlier role thread is no longer
-addressable, spawn one replacement for that role and use it as the active thread
-for that role.
+
+Run role passes inside the Orchestrator thread. Keep continuity through the
+handoff file: when the loop returns to a role, read the prior handoff entries
+for that role, run the next bounded pass, and append the new result. Alternative
+execution models need explicit user approval for the current loop.
 
 Before dispatching a role, verify that the shared worktree is clean or that any
 dirty files are intentionally owned by the target role or an active human gate.
@@ -179,7 +178,7 @@ The Orchestrator pauses the loop when:
 While paused, Trello should move to `Review`. When the user responds, the
 Orchestrator records the decision and routes the loop back to the correct role.
 
-The current V0 Trello model is:
+The current Trello model is:
 
 - existing `In Progress` state means the loop is running
 - `Review` means the loop is waiting for human acceptance review or final


### PR DESCRIPTION
## Summary
- define the Orchestrator as the visible control surface for a loop
- describe Specifier, Coder, Refactorer, and Architect work as bounded role passes inside the Orchestrator thread
- make the handoff file the continuity record when a later pass returns to the same role
- keep alternate execution models behind explicit user approval for that loop

## Cleanup context
- discarded the first C# loop attempt because the loop contract was ambiguous about role execution
- closed PR #271 and removed the C# branch/worktree
- moved the C# Trello card back to Todo with a note

## Checks
- rg scan for stale role-thread wording and V0 wording
- git diff --check