### PR TITLE
C# Upgrade

### DIFF
--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -1,0 +1,82 @@
+# Trello 201: C# Upgrade
+
+## Current State
+
+- State: setup complete, pre-role alignment pending.
+- Trello: [C# Upgrade](https://trello.com/c/rSYGlC3d), moved to In Progress on 2026-06-12.
+- Branch: `codex/201-csharp-upgrade`
+- Worktree: `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4`
+- PR: pending initial setup push.
+- Next route: alignment gate, then likely Specifier.
+
+## Human Gates
+
+- Human-owned acceptance spec Markdown under `packages/extension/tests/acceptance/specs/` must not be edited, created, renamed, deleted, or committed without explicit approval.
+- This card asks to add or update the C# example acceptance spec only after the support contract is clear, so Specifier should prepare the acceptance shape and pause for approval before any spec Markdown change.
+- VS Code Playwright acceptance and mutation work should run on `codegraphy-mini` unless the human explicitly approves local focus-stealing runs.
+
+## Request
+
+Start Trello card `https://trello.com/c/rSYGlC3d/201-c-upgrade`, then follow `docs/agents/codegraphy-loop.md`.
+
+## Trello Card Summary
+
+Goal: upgrade `examples/example-csharp` so C# feels like a real, focused CodeGraphy demo project and has acceptance coverage that proves visible graph behavior.
+
+Important card requirements:
+
+- Treat this as a support audit before fixture polish.
+- Review official C# docs and the C# parser/plugin surface currently in use.
+- Inventory current C# symbols, variables, and edges emitted by CodeGraphy.
+- Compare that inventory to Graph Scope when opening `examples/example-csharp`.
+- Separate capability gaps by generic Core Tree-sitter behavior, plugin-owned behavior, and out-of-scope language-specific semantics.
+- Make `examples/example-csharp` a believable small project that intentionally demonstrates every visible supported C# node and edge toggle.
+- Keep README/settings honest about current support and known limitations.
+- Follow the C and C++ acceptance pattern, including toggle behavior and stable node/connection counts.
+- Run focused analyzer/plugin tests, focused generated VS Code acceptance for `examples/example-csharp`, mutation for touched production files when required, and organize/typecheck/lint gates before review.
+
+## Setup Context Read
+
+- `AGENTS.md`
+- `CONTEXT.md`
+- `docs/agents/codegraphy-loop.md`
+- `docs/agents/loops/orchestrator.md`
+- `docs/agents/loops/specifier.md`
+- `docs/agents/loops/coder.md`
+- `docs/agents/loops/refactorer.md`
+- `docs/agents/loops/architect.md`
+- `docs/agents/acceptance-specs.md`
+- `docs/agents/issue-tracker.md`
+- `docs/agents/triage-labels.md`
+- `docs/agents/domain.md`
+- `packages/extension/tests/acceptance/README.md`
+- `packages/extension/tests/acceptance/specs/csharp-example.md`
+- `packages/extension/tests/acceptance/specs/c-example.md`
+- `packages/extension/tests/acceptance/specs/cpp-example.md`
+- `examples/example-csharp/README.md`
+- `examples/example-csharp/src/**/*.cs`
+- `packages/plugin-csharp/src/plugin.ts`
+- `packages/plugin-csharp/tests/plugin.test.ts`
+- `packages/plugin-csharp/codegraphy.json`
+- `packages/plugin-csharp/README.md`
+- repo search for C# analyzer and acceptance references
+
+## Initial Observations
+
+- The C# plugin is currently metadata-only: it contributes supported extensions, C# ecosystem default filters, and empty file colors. Core Tree-sitter Analysis owns baseline C# analysis.
+- Core C# analysis lives under `packages/core/src/treeSitter/runtime/analyzeCSharp` with a C# workspace index under `packages/core/src/treeSitter/runtime/csharpIndex`.
+- Existing C# acceptance coverage checks file nodes and file-level Imports, References, Inherits, and Calls edge toggles.
+- The newer C and C++ acceptance specs include deeper Graph Scope coverage for language node types, Contains edges, symbol nodes, and stable counts. The current C# spec does not yet follow that richer shape.
+- The current C# example README describes a small namespace/type-usage workspace and a symbol node demo, but the acceptance spec does not yet prove the symbol-node behavior described there.
+- The protected main checkout had an existing modified generated acceptance file before this worktree was created. It was not touched by this loop setup.
+
+## Event Log
+
+### 2026-06-12T20:51:39Z - Orchestrator Setup
+
+- Read loop, tracker, role, acceptance, domain, example, plugin, and nearby acceptance context.
+- Fetched the Trello card and confirmed it had no comments.
+- Moved the Trello card from Todo to In Progress.
+- Created isolated worktree `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4` on branch `codex/201-csharp-upgrade` from `origin/main`.
+- Recorded setup context and human gates.
+- Current blocker before first role dispatch: pre-role alignment is required because the card is language-support, acceptance-spec, and support-audit sensitive.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -98,3 +98,38 @@ Important card requirements:
 - Dispatching Specifier with the clarified scope.
 - Relevant current C# Core surface: `packages/core/src/treeSitter/runtime/analyzeCSharp` emits `class`, `interface`, `enum`, and `method` symbols plus Imports, References, Calls, and Inherits relations. The C# plugin is metadata-only.
 - Specifier stopping condition: return an acceptance contract and example-shape plan, including whether human-owned `packages/extension/tests/acceptance/specs/csharp-example.md` needs an approved edit before Coder runs.
+
+### 2026-06-12T21:40:00Z - Specifier Inventory And Contract
+
+- Result: needs human acceptance before spec Markdown edits.
+- Plan path: `docs/plans/201-csharp-upgrade-specifier-plan.md`.
+- Inventory result:
+  - Core Tree-sitter C# owns C# analysis; `packages/plugin-csharp` is metadata-only and contributes supported extension/default-filter settings only.
+  - Current C# edge capability metadata advertises `Imports`, `References`, `Calls`, and `Inherits`.
+  - Current C# symbol node capability metadata advertises `Function`, `Class`, `Interface`, `Struct`, and `Enum`.
+  - C# method declarations are emitted with symbol kind `method`, but the product Graph Scope row for C# is `Function` because `symbol:function` matches both `function` and `method`. C# does not currently advertise the narrower `Method` node type.
+  - Analyzer tests prove C# can emit class/interface/struct/enum/method symbols, resolved namespace `Imports`, uppercase type `References`, object/static/inherited `Calls`, and base-list `Inherits`.
+- Example-shape plan:
+  - Keep all C# upgrade work in this loop.
+  - Reshape `examples/example-csharp` into a small file-scoped-namespace task-runner/service demo.
+  - Add explicit struct and enum source files, likely `src/Models/RunRequest.cs` and `src/Models/RunStatus.cs`, so every advertised C# symbol node type is visible.
+  - Keep representative classes/interfaces/methods: `Program`, `Config`, `ApiService`, `BaseService`, `IRunner`, `Helpers`, `Formatter`, and one intentional orphan class.
+  - Keep file relationships deliberate: Program resolves/calls Config, ApiService, RunRequest/RunStatus, and Helpers; ApiService inherits BaseService and implements IRunner; Helpers calls Formatter; ApiService calls an inherited BaseService method.
+  - Update README/settings honestly around Core Tree-sitter C# support and the metadata-only C# plugin.
+- Acceptance contract:
+  - Update `packages/extension/tests/acceptance/specs/csharp-example.md` only after human approval.
+  - Follow the C/C++ pattern with one file-relationship scenario and one symbol-node scenario.
+  - File scenario should assert available C# edge types, stable no-edge and per-edge counts, and representative file edges for Imports, References, Inherits, and Calls.
+  - Symbol scenario should assert available C# node types are only Function, Class, Interface, Struct, and Enum; Method and Type should not be available for this C# example.
+  - Symbol scenario should prove each supported C# symbol node type with visible graph assertions and use `Contains` to prove file-to-symbol projection.
+  - Red-first gap to verify: if `Contains` is unavailable for the upgraded C# symbol scenario, Coder should add the smallest Core capability test/fix that exposes `Contains` consistently with C# symbol nodes.
+- Acceptance impact scan:
+  - Directly affected human-owned spec: `packages/extension/tests/acceptance/specs/csharp-example.md`.
+  - Likely generated/tooling after approval: `packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts`.
+  - Potential fixture/docs edits: `examples/example-csharp/README.md`, `examples/example-csharp/src/**/*.cs`, `examples/example-csharp/.codegraphy/settings.json`, and `examples/README.md`.
+  - Intentionally unaffected specs: `c-example.md`, `cpp-example.md`, and generic Graph Scope specs unless Coder changes shared Graph Scope capability behavior for `Contains`.
+- Human approval status: required before editing human-owned acceptance spec Markdown.
+- Open questions:
+  - Should Orchestrator treat the approval already given in this thread ("then we make sure the acceptance tests match the expected example") as permission to edit `packages/extension/tests/acceptance/specs/csharp-example.md`, or pause for an explicit spec-Markdown approval because the loop docs require it?
+  - Should Coder make the example source update first and return measured counts before the spec Markdown is edited, or should the approved spec draft lead with expected names and allow Coder to fill counts after the example is implemented?
+- Exact files inspected are listed in `docs/plans/201-csharp-upgrade-specifier-plan.md`.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -2,12 +2,12 @@
 
 ## Current State
 
-- State: dispatching Specifier.
+- State: dispatching Coder for example/source and red-first Core gap work.
 - Trello: [C# Upgrade](https://trello.com/c/rSYGlC3d), moved to In Progress on 2026-06-12.
 - Branch: `codex/201-csharp-upgrade`
 - Worktree: `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4`
 - PR: [#276](https://github.com/joesobo/CodeGraphyV4/pull/276) draft.
-- Next route: alignment gate, then likely Specifier.
+- Next route: Coder.
 
 ## Human Gates
 
@@ -133,3 +133,13 @@ Important card requirements:
   - Should Orchestrator treat the approval already given in this thread ("then we make sure the acceptance tests match the expected example") as permission to edit `packages/extension/tests/acceptance/specs/csharp-example.md`, or pause for an explicit spec-Markdown approval because the loop docs require it?
   - Should Coder make the example source update first and return measured counts before the spec Markdown is edited, or should the approved spec draft lead with expected names and allow Coder to fill counts after the example is implemented?
 - Exact files inspected are listed in `docs/plans/201-csharp-upgrade-specifier-plan.md`.
+
+### 2026-06-12T21:55:00Z - Orchestrator Receives Specifier
+
+- Verified Specifier commit `53c72492` on `origin/codex/201-csharp-upgrade`.
+- Closed completed Specifier subagent.
+- Routing to Coder for the first implementation slice:
+  - update `examples/example-csharp` source/README/settings so the example visibly demonstrates expected current C# Tree-sitter-supported nodes and edges;
+  - verify the red-first `Contains` capability gap and add the smallest Core test/fix if needed;
+  - measure expected node/edge counts for the upgraded example.
+- Human-owned acceptance spec Markdown remains gated until the upgraded example is measured and the proposed spec update is concrete.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- State: setup complete, pre-role alignment pending.
+- State: dispatching Specifier.
 - Trello: [C# Upgrade](https://trello.com/c/rSYGlC3d), moved to In Progress on 2026-06-12.
 - Branch: `codex/201-csharp-upgrade`
 - Worktree: `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4`
@@ -86,3 +86,15 @@ Important card requirements:
 - Pushed branch `codex/201-csharp-upgrade`.
 - Opened draft PR [#276](https://github.com/joesobo/CodeGraphyV4/pull/276).
 - Next action remains the pre-role alignment gate before dispatching Specifier.
+
+### 2026-06-12T21:02:00Z - Alignment Scope Clarified
+
+- Human decision: keep all C# upgrade work in this loop rather than spinning off the main C# support upgrades immediately.
+- Ordered scope: first make `examples/example-csharp` look like expected C# support, matching expected Tree-sitter-supported nodes and edges; then make acceptance tests match that expected example.
+- Implication for first route: Specifier should inventory the expected C# Tree-sitter node and edge capabilities, compare those to the current example, and draft the acceptance contract around the upgraded example shape before any human-owned spec Markdown is edited.
+
+### 2026-06-12T21:08:00Z - Specifier Dispatch
+
+- Dispatching Specifier with the clarified scope.
+- Relevant current C# Core surface: `packages/core/src/treeSitter/runtime/analyzeCSharp` emits `class`, `interface`, `enum`, and `method` symbols plus Imports, References, Calls, and Inherits relations. The C# plugin is metadata-only.
+- Specifier stopping condition: return an acceptance contract and example-shape plan, including whether human-owned `packages/extension/tests/acceptance/specs/csharp-example.md` needs an approved edit before Coder runs.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -2,12 +2,12 @@
 
 ## Current State
 
-- State: pre-role alignment grill incomplete; downstream role state stale.
+- State: pre-role alignment complete; dispatching Specifier for approved example and acceptance spec updates.
 - Trello: [C# Upgrade](https://trello.com/c/rSYGlC3d), moved to In Progress on 2026-06-12.
 - Branch: `codex/201-csharp-upgrade`
 - Worktree: `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4`
 - PR: [#276](https://github.com/joesobo/CodeGraphyV4/pull/276) draft.
-- Next route: finish `grill-with-docs` alignment, then dispatch Specifier only after the alignment gate passes.
+- Next route: Specifier.
 
 ## Human Gates
 
@@ -227,3 +227,17 @@ Important card requirements:
 - Aligned baseline: C# should cover `Field`, `Parameter`, and `Local` if Core can emit them cleanly from Tree-sitter.
 - Human decision: C# should include `Constant` in this loop, but narrowly for explicit C# `const` declarations that Tree-sitter can identify cleanly.
 - Human decision: keep `Global` out of C# for now because C# does not have the same clean global-variable model as C/C++.
+
+### 2026-06-15T00:00:00Z - Alignment Gate Complete
+
+- Human decision: alignment gate is complete.
+- Approved Specifier scope:
+  - update `examples/example-csharp` based on the grill decisions;
+  - update `packages/extension/tests/acceptance/specs/csharp-example.md` to test all agreed C# Tree-sitter features using the example as the base;
+  - shape the acceptance spec as one C++-style scenario;
+  - cover C# symbols `Function`, `Class`, `Interface`, `Struct`, `Enum`;
+  - cover C# variables `Field`, `Parameter`, `Local`, and narrow `Constant`;
+  - cover C# edges `Imports`, `References`, `Calls`, `Contains`, `Inherits`;
+  - keep `Global` out of C#.
+- Human review gate after Specifier: the human will review and approve the example plus acceptance-test modifications before Orchestrator routes to Coder.
+- Existing premature Specifier/Coder commits may be reused as evidence or revised by the new Specifier pass, but downstream role approval remains stale until this proper Specifier pass completes and receives human review.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -2,12 +2,12 @@
 
 ## Current State
 
-- State: human review gate for Specifier acceptance contract approval.
+- State: pre-role alignment grill incomplete; downstream role state stale.
 - Trello: [C# Upgrade](https://trello.com/c/rSYGlC3d), moved to In Progress on 2026-06-12.
 - Branch: `codex/201-csharp-upgrade`
 - Worktree: `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4`
 - PR: [#276](https://github.com/joesobo/CodeGraphyV4/pull/276) draft.
-- Next route: Specifier after human approval, to apply the approved acceptance spec Markdown contract.
+- Next route: finish `grill-with-docs` alignment, then dispatch Specifier only after the alignment gate passes.
 
 ## Human Gates
 
@@ -199,3 +199,16 @@ Important card requirements:
 - The acceptance spec Markdown has not been edited yet. The Coder example/Core pass is premature downstream work and should be treated as available evidence, not as permission to skip the Specifier approval gate.
 - No further Coder, Refactorer, or Architect routing should happen until the human approves or revises the Specifier acceptance contract.
 - After approval, route back to Specifier to apply the approved acceptance spec Markdown change, then route forward through Coder again because downstream Coder state is stale relative to the approved acceptance contract.
+
+### 2026-06-13T00:10:00Z - Orchestrator Process Correction 2
+
+- Human correction: the loop requires completing `grill-with-docs` before the first role dispatch.
+- Reread `docs/agents/codegraphy-loop.md`, `docs/agents/loops/orchestrator.md`, `docs/agents/loops/specifier.md`, and `docs/agents/acceptance-specs.md`.
+- Correct current state: the pre-role alignment gate was not completed. The loop is not at Specifier human review yet.
+- Correct sequence from here:
+  1. Orchestrator finishes the docs-backed alignment grill, one question at a time, until scope, acceptance shape, human gates, and first route are clear.
+  2. After the alignment gate passes, Orchestrator dispatches Specifier.
+  3. Specifier owns drafting and applying approved acceptance spec Markdown changes when the human has explicitly approved that exact spec change during/after alignment.
+  4. Human reviews the Specifier acceptance-test modifications.
+  5. Only after that review passes does Orchestrator route to Coder.
+- Existing Specifier and Coder commits are downstream artifacts from premature routing. Treat them as stale evidence until the proper alignment and Specifier pass decide whether to keep, revise, or replace them.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -6,7 +6,7 @@
 - Trello: [C# Upgrade](https://trello.com/c/rSYGlC3d), moved to In Progress on 2026-06-12.
 - Branch: `codex/201-csharp-upgrade`
 - Worktree: `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4`
-- PR: pending initial setup push.
+- PR: [#276](https://github.com/joesobo/CodeGraphyV4/pull/276) draft.
 - Next route: alignment gate, then likely Specifier.
 
 ## Human Gates
@@ -80,3 +80,9 @@ Important card requirements:
 - Created isolated worktree `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4` on branch `codex/201-csharp-upgrade` from `origin/main`.
 - Recorded setup context and human gates.
 - Current blocker before first role dispatch: pre-role alignment is required because the card is language-support, acceptance-spec, and support-audit sensitive.
+
+### 2026-06-12T20:55:00Z - Draft PR Published
+
+- Pushed branch `codex/201-csharp-upgrade`.
+- Opened draft PR [#276](https://github.com/joesobo/CodeGraphyV4/pull/276).
+- Next action remains the pre-role alignment gate before dispatching Specifier.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -220,3 +220,10 @@ Important card requirements:
 - Example-shape decision: `examples/example-csharp` should be built as a clean demo for every feature the C# Tree-sitter support covers, not a syntax museum.
 - Orchestrator read `packages/extension/tests/acceptance/specs/cpp-example.md` to ground the shape. The C++ pattern is one scenario that checks available edge rows, available node/variable rows, individual row counts, combined symbol graph counts, and representative edge assertions.
 - Current uncertainty for the next grill question: existing C# capability metadata advertises symbols (`Function`, `Class`, `Interface`, `Struct`, `Enum`) and edges (`Imports`, `References`, `Calls`, `Contains`, `Inherits` after the premature Coder pass), but it does not currently advertise variable rows such as `Field`, `Parameter`, `Local`, `Global`, or `Constant`.
+
+### 2026-06-13T00:28:00Z - Alignment Grill: C# Variable Scope
+
+- Human decision: this loop should include C# Tree-sitter variable node support so the C# acceptance scenario covers variables as well as symbols and edges, following the C++ acceptance style.
+- Aligned baseline: C# should cover `Field`, `Parameter`, and `Local` if Core can emit them cleanly from Tree-sitter.
+- Orchestrator recommendation pending confirmation: keep `Global` out of C# unless a clean C# top-level/global construct is intentionally supported.
+- Open alignment question: whether C# should include `Constant` in this loop through `const` fields/local constants, or defer constants until the analyzer can model them without ambiguity.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -2,12 +2,12 @@
 
 ## Current State
 
-- State: human gate for C# acceptance spec Markdown approval.
+- State: human review gate for Specifier acceptance contract approval.
 - Trello: [C# Upgrade](https://trello.com/c/rSYGlC3d), moved to In Progress on 2026-06-12.
 - Branch: `codex/201-csharp-upgrade`
 - Worktree: `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4`
 - PR: [#276](https://github.com/joesobo/CodeGraphyV4/pull/276) draft.
-- Next route: Coder for acceptance Markdown/generated acceptance update after approval.
+- Next route: Specifier after human approval, to apply the approved acceptance spec Markdown contract.
 
 ## Human Gates
 
@@ -191,3 +191,11 @@ Important card requirements:
 - Closed completed Coder subagent.
 - Moved Trello card to Review while waiting for human approval to edit human-owned acceptance spec Markdown.
 - Approval needed: edit `packages/extension/tests/acceptance/specs/csharp-example.md` so the C# acceptance spec matches the upgraded `examples/example-csharp` example and the measured counts recorded above, then regenerate generated acceptance output.
+
+### 2026-06-13T00:00:00Z - Orchestrator Process Correction
+
+- Human correction: the Orchestrator routed to Coder too early. The loop contract should be executed as a contract, not treated as guidance.
+- Correct current state: human review is for the Specifier acceptance contract and proposed `packages/extension/tests/acceptance/specs/csharp-example.md` modifications.
+- The acceptance spec Markdown has not been edited yet. The Coder example/Core pass is premature downstream work and should be treated as available evidence, not as permission to skip the Specifier approval gate.
+- No further Coder, Refactorer, or Architect routing should happen until the human approves or revises the Specifier acceptance contract.
+- After approval, route back to Specifier to apply the approved acceptance spec Markdown change, then route forward through Coder again because downstream Coder state is stale relative to the approved acceptance contract.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -2,12 +2,12 @@
 
 ## Current State
 
-- State: dispatching Coder for example/source and red-first Core gap work.
+- State: human gate for C# acceptance spec Markdown approval.
 - Trello: [C# Upgrade](https://trello.com/c/rSYGlC3d), moved to In Progress on 2026-06-12.
 - Branch: `codex/201-csharp-upgrade`
 - Worktree: `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4`
 - PR: [#276](https://github.com/joesobo/CodeGraphyV4/pull/276) draft.
-- Next route: Coder.
+- Next route: Coder for acceptance Markdown/generated acceptance update after approval.
 
 ## Human Gates
 
@@ -184,3 +184,10 @@ Important card requirements:
 - Notes for Orchestrator:
   - Acceptance Markdown is still gated by the human-owned spec rule. The next acceptance update should use the measured file counts for file-edge scenarios and measured symbol-projected counts for symbol/Contains scenarios.
   - This pass changes user-facing Core Graph Scope capability behavior for C# by advertising `Contains`; a changeset may be needed in a later loop role if release policy applies to this PR.
+
+### 2026-06-12T22:48:00Z - Orchestrator Receives Coder And Enters Human Gate
+
+- Verified Coder commit `e1ea6b0c` on `origin/codex/201-csharp-upgrade`.
+- Closed completed Coder subagent.
+- Moved Trello card to Review while waiting for human approval to edit human-owned acceptance spec Markdown.
+- Approval needed: edit `packages/extension/tests/acceptance/specs/csharp-example.md` so the C# acceptance spec matches the upgraded `examples/example-csharp` example and the measured counts recorded above, then regenerate generated acceptance output.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -225,5 +225,5 @@ Important card requirements:
 
 - Human decision: this loop should include C# Tree-sitter variable node support so the C# acceptance scenario covers variables as well as symbols and edges, following the C++ acceptance style.
 - Aligned baseline: C# should cover `Field`, `Parameter`, and `Local` if Core can emit them cleanly from Tree-sitter.
-- Orchestrator recommendation pending confirmation: keep `Global` out of C# unless a clean C# top-level/global construct is intentionally supported.
-- Open alignment question: whether C# should include `Constant` in this loop through `const` fields/local constants, or defer constants until the analyzer can model them without ambiguity.
+- Human decision: C# should include `Constant` in this loop, but narrowly for explicit C# `const` declarations that Tree-sitter can identify cleanly.
+- Human decision: keep `Global` out of C# for now because C# does not have the same clean global-variable model as C/C++.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -241,3 +241,48 @@ Important card requirements:
   - keep `Global` out of C#.
 - Human review gate after Specifier: the human will review and approve the example plus acceptance-test modifications before Orchestrator routes to Coder.
 - Existing premature Specifier/Coder commits may be reused as evidence or revised by the new Specifier pass, but downstream role approval remains stale until this proper Specifier pass completes and receives human review.
+
+### 2026-06-15T16:02:49Z - Specifier Acceptance Contract Applied
+
+- Result: acceptance contract ready for human review.
+- Human approval status: the human explicitly approved this Specifier pass to update `examples/example-csharp` and the human-owned `packages/extension/tests/acceptance/specs/csharp-example.md`; the updated example/spec now need human review before routing to Coder.
+- Official C# docs grounding:
+  - Microsoft Learn documents fields as variables declared directly in a class or struct.
+  - Microsoft Learn documents `const` as the marker for constant fields or local constants.
+  - Microsoft Learn declaration statements document local variable and local constant declarations.
+- Example source changes:
+  - Kept the C# task-runner/service shape from the earlier stale Coder evidence and revised it for the approved variable scope.
+  - Added explicit C# constant targets: `Config.DefaultMaxItems` and `RunRequest.DefaultName`.
+  - Added explicit C# field targets: `RunRequest.Name`, `RunRequest.MaxItems`, and `ApiService.serviceName`.
+  - Kept explicit C# parameter targets: `IRunner.Run(request)`, `RunRequest(name, maxItems)`, `ApiService.Run(request)`, `Helpers.IsRunnable(request, currentStatus)`, `Helpers.FormatStatus(status)`, and `Formatter.FormatOutput(status)`.
+  - Kept explicit C# local targets: `settings`, `service`, `request`, `status`, `output`, `currentStatus`, and `isRunnable`.
+  - Updated `examples/example-csharp/README.md` and `examples/README.md` so the example honestly describes Symbol plus Variable coverage.
+- Approved acceptance spec changes:
+  - Replaced the old C# file-edge-only scenario with one C++-style scenario, `C# example covers Task Runner graph scope`.
+  - File graph baseline: `13 nodes / 0 connections`.
+  - Available edge rows: `Imports`, `References`, `Calls`, `Contains`, `Inherits`.
+  - Available C# node rows: `Function`, `Class`, `Interface`, `Struct`, `Enum`, `Constant`, `Field`, `Parameter`, `Local`.
+  - Explicitly unavailable rows for this C# example: `Method`, `Type`, and `Global`.
+  - File edge counts: Imports `6`, References `7`, Inherits `2`, Calls `7`.
+  - Per-row Contains counts: Class `7`, Interface `1`, Struct `1`, Enum `1`, Function `9`, Constant `2`, Field `3`, Parameter `8`, Local `7`.
+  - Combined File plus supported C# Symbol/Variable rows: `52 nodes / 0 connections`; with Contains enabled: `52 nodes / 39 connections`.
+  - Combined graph edge counts: Calls `7`, Inherits `2`, Imports `6`, References `7`.
+- Acceptance impact scan:
+  - Directly changed human-owned spec: `packages/extension/tests/acceptance/specs/csharp-example.md`.
+  - Regenerated review artifact: `packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts`.
+  - Direct example/docs changes: `examples/example-csharp/src/**/*.cs`, `examples/example-csharp/README.md`, and `examples/README.md`.
+  - Intentionally unaffected human-owned specs: `packages/extension/tests/acceptance/specs/c-example.md`, `packages/extension/tests/acceptance/specs/cpp-example.md`, and `packages/extension/tests/acceptance/specs/graph-scope-node-types.md`.
+  - Coder should update step bindings because current acceptance steps have a C++-specific available-node-types phrase and C++-specific unavailable-node-type phrase; the new C# spec intentionally uses C# variants.
+- Coder requirements after human review:
+  - Add red-first Core tests for C# variable extraction and capability metadata for `symbol:constant`, `symbol:field`, `symbol:parameter`, and `symbol:local`.
+  - Keep C# `Constant` narrow to explicit `const` declarations and do not advertise or emit `Global` for C#.
+  - Ensure properties such as `Config.ApiUrl`, `Config.MaxItems`, and `Config.Debug` do not accidentally inflate the Field count unless the human expands C# Field semantics later.
+  - Preserve the already identified C# `Contains` capability requirement if it remains on the branch.
+  - Add or generalize acceptance step bindings for C# node-row availability and unavailable-row assertions.
+  - Run focused analyzer tests, acceptance generation/checks, and the generated C# VS Code acceptance scenario on `codegraphy-mini` unless the human approves a local focus-stealing run.
+- Commands run:
+  - `pnpm --filter @codegraphy-dev/extension run generate:acceptance`: passed.
+  - `pnpm run check:acceptance-specs`: passed.
+  - `git diff --check`: passed.
+- Open questions:
+  - None for Specifier. Next route should be human review of this Specifier commit, not Coder, until the human approves the example/spec contract.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -143,3 +143,44 @@ Important card requirements:
   - verify the red-first `Contains` capability gap and add the smallest Core test/fix if needed;
   - measure expected node/edge counts for the upgraded example.
 - Human-owned acceptance spec Markdown remains gated until the upgraded example is measured and the proposed spec update is concrete.
+
+### 2026-06-12T22:42:00Z - Coder Example And Core Capability Pass
+
+- Result: behavior green for the Coder slice; ready for Orchestrator to approve or route the acceptance Markdown update.
+- Updated `examples/example-csharp` into a small task-runner/service demo:
+  - `Program.cs` calls `Config.LoadConfig()`, creates `ApiService`, creates a `RunRequest` struct, and formats the returned status through `Helpers`.
+  - `ApiService.cs` inherits `BaseService`, implements `IRunner`, calls inherited `Status()`, calls `Helpers.IsRunnable(...)`, and references `RunStatus`.
+  - Added `src/Models/RunRequest.cs` as the C# Struct target and `src/Models/RunStatus.cs` as the C# Enum target.
+  - Kept `Orphan.cs` as an intentionally unrelated class.
+  - Updated `examples/example-csharp/README.md` and `examples/README.md` to describe current Core Tree-sitter C# behavior and the metadata-only C# plugin boundary.
+- Verified the red-first Core gap:
+  - Added a focused failing test proving C# should advertise `Contains` when C# symbol node capabilities are available.
+  - Red evidence before the fix: `packages/core/tests/treeSitter/capabilities.test.ts` failed because C# edge capabilities were `import`, `reference`, `call`, `inherit` and missed `contains`.
+  - Smallest fix: added `contains` to the C# entry in `packages/core/src/treeSitter/runtime/capabilities.ts`.
+- Measured upgraded example using local Core source APIs:
+  - Default file graph after indexing `examples/example-csharp`: `13 files`, `13 nodes`, `22 edges`.
+  - File-only Graph Scope slices with package/folder disabled:
+    - no edges: `13 nodes / 0 edges`
+    - Imports: `13 nodes / 6 edges`
+    - References: `13 nodes / 7 edges`
+    - Calls: `13 nodes / 7 edges`
+    - Inherits: `13 nodes / 2 edges`
+    - Contains: `13 nodes / 0 edges`
+  - Representative file edges:
+    - Imports: `Program.cs -> Models/RunRequest.cs`, `Program.cs -> Services/ApiService.cs`, `Program.cs -> Utils/Helpers.cs`, `ApiService.cs -> Contracts/IRunner.cs`, `ApiService.cs -> Models/RunStatus.cs`, `ApiService.cs -> Utils/Helpers.cs`.
+    - References: `Program.cs -> Config.cs`, `Program.cs -> Models/RunRequest.cs`, `Program.cs -> Services/ApiService.cs`, `Program.cs -> Utils/Helpers.cs`, `ApiService.cs -> Models/RunStatus.cs`, `ApiService.cs -> Utils/Helpers.cs`, `Helpers.cs -> Formatter.cs`.
+    - Calls: `Program.cs -> Config.cs`, `Program.cs -> Models/RunRequest.cs`, `Program.cs -> Services/ApiService.cs`, `Program.cs -> Utils/Helpers.cs`, `ApiService.cs -> Services/BaseService.cs`, `ApiService.cs -> Utils/Helpers.cs`, `Helpers.cs -> Formatter.cs`.
+    - Inherits: `ApiService.cs -> Contracts/IRunner.cs`, `ApiService.cs -> Services/BaseService.cs`.
+  - Symbol-projected graph with File plus C# Function/Class/Interface/Struct/Enum enabled: `32 nodes`, `41 edges`.
+    - Symbols visible with no edges: `19` total, grouped as `7 class`, `9 method` under Function, `1 interface`, `1 struct`, `1 enum`.
+    - Contains slice: `32 nodes / 19 edges`; representative edges include `Models/RunRequest.cs -> Models/RunRequest.cs#RunRequest:struct`, `Models/RunStatus.cs -> Models/RunStatus.cs#RunStatus:enum`, `Program.cs -> Program.cs#Main:method`, and `Services/ApiService.cs -> Services/ApiService.cs#Run:method`.
+    - Calls slice with symbols enabled: `32 nodes / 7 edges`; representative symbol edges include `Program.cs#Main:method -> Config.cs#LoadConfig:method`, `Program.cs#Main:method -> Models/RunRequest.cs#RunRequest:struct`, `ApiService.cs#Run:method -> Services/BaseService.cs#Status:method`, and `Helpers.cs#FormatStatus:method -> Formatter.cs#FormatOutput:method`.
+- Verification:
+  - `pnpm test tests/treeSitter/csharp/analyze.test.ts tests/treeSitter/csharpIndex.test.ts tests/treeSitter/capabilities.test.ts` from `packages/core`: passed, `18 tests`.
+  - `pnpm --filter @codegraphy-dev/core lint`: passed.
+  - `pnpm --filter @codegraphy-dev/core typecheck`: passed.
+  - `pnpm run check:acceptance-specs`: passed; no human-owned acceptance spec Markdown edited.
+  - `git diff --check`: passed.
+- Notes for Orchestrator:
+  - Acceptance Markdown is still gated by the human-owned spec rule. The next acceptance update should use the measured file counts for file-edge scenarios and measured symbol-projected counts for symbol/Contains scenarios.
+  - This pass changes user-facing Core Graph Scope capability behavior for C# by advertising `Contains`; a changeset may be needed in a later loop role if release policy applies to this PR.

--- a/docs/handoff/201-csharp-upgrade.md
+++ b/docs/handoff/201-csharp-upgrade.md
@@ -212,3 +212,11 @@ Important card requirements:
   4. Human reviews the Specifier acceptance-test modifications.
   5. Only after that review passes does Orchestrator route to Coder.
 - Existing Specifier and Coder commits are downstream artifacts from premature routing. Treat them as stale evidence until the proper alignment and Specifier pass decide whether to keep, revise, or replace them.
+
+### 2026-06-13T00:20:00Z - Alignment Grill: Acceptance Scenario Shape
+
+- Human decision: C# should use one acceptance scenario, matching the C++ acceptance-test style, rather than separate file and symbol scenarios.
+- Acceptance scope should cover everything expected for C# with Tree-sitter in one scenario: all supported symbols, variables, and edges.
+- Example-shape decision: `examples/example-csharp` should be built as a clean demo for every feature the C# Tree-sitter support covers, not a syntax museum.
+- Orchestrator read `packages/extension/tests/acceptance/specs/cpp-example.md` to ground the shape. The C++ pattern is one scenario that checks available edge rows, available node/variable rows, individual row counts, combined symbol graph counts, and representative edge assertions.
+- Current uncertainty for the next grill question: existing C# capability metadata advertises symbols (`Function`, `Class`, `Interface`, `Struct`, `Enum`) and edges (`Imports`, `References`, `Calls`, `Contains`, `Inherits` after the premature Coder pass), but it does not currently advertise variable rows such as `Field`, `Parameter`, `Local`, `Global`, or `Constant`.

--- a/docs/plans/201-csharp-upgrade-specifier-plan.md
+++ b/docs/plans/201-csharp-upgrade-specifier-plan.md
@@ -1,0 +1,210 @@
+# C# Upgrade Specifier Plan
+
+## Result
+
+The C# upgrade should stay in this loop. The next role should first reshape
+`examples/example-csharp` into the expected C# support demo, then update the
+generated/executable acceptance work to match the approved human Markdown
+contract.
+
+Human-owned acceptance Markdown still needs approval before
+`packages/extension/tests/acceptance/specs/csharp-example.md` is edited.
+
+## Supported C# Inventory
+
+Current Core Tree-sitter C# support is owned by
+`packages/core/src/treeSitter/runtime/analyzeCSharp` and
+`packages/core/src/treeSitter/runtime/csharpIndex`. The C# plugin is
+metadata-only.
+
+Supported edge capabilities from current Core capability metadata:
+
+- `Imports`
+- `References`
+- `Calls`
+- `Inherits`
+
+Supported C# symbol node capabilities from current Core capability metadata:
+
+- `Function`
+- `Class`
+- `Interface`
+- `Struct`
+- `Enum`
+
+Important product-label detail: C# method declarations are emitted as symbol
+kind `method`, but the C# capability row is `symbol:function`; the core
+Function node type matches both `function` and `method`. The C# example should
+therefore use the Graph Scope label `Function`, not `Method`.
+
+Current C# analyzer behavior proven by tests:
+
+- class, interface, struct, enum, and method symbols can be emitted.
+- `using` directives become `Imports`, unresolved for external namespaces and
+resolved when referenced namespace types exist in the workspace index.
+- member access and object creation of uppercase type names become
+`References` when the type resolves through current namespace or using
+namespaces.
+- object creation and static member access become `Calls` when the target type
+resolves.
+- unqualified method invocation can become a `Calls` edge to the single
+resolved base class for the containing type.
+- base-list entries become `Inherits` edges; only class base types are carried
+forward for inherited method-call resolution.
+
+Likely Core gap to verify red-first: the C# capability metadata does not list
+`contains`, even though symbol node examples need `Contains` to prove file-to-
+symbol projection. If the upgraded C# symbol acceptance cannot see the Contains
+edge row after indexing with symbol node types, Coder should add the smallest
+Core capability test/fix that makes C# expose `Contains` consistently with the
+symbol-node contract.
+
+## Example Shape
+
+Keep the example small, readable, and C#-natural. Prefer file-scoped namespaces
+to reduce fixture noise, matching current Microsoft C# guidance that namespaces
+organize types and file-scoped namespaces are recommended for new code.
+
+Upgrade `examples/example-csharp/src` around a simple task-runner/service demo:
+
+- `Program.cs`: entry point that loads `Config`, creates an `ApiService`, builds
+  a `RunRequest` struct value, calls the service, and formats output through
+  `Helpers`.
+- `Config.cs`: class with `LoadConfig()` static call target.
+- `Contracts/IRunner.cs`: interface implemented by the service.
+- `Services/BaseService.cs`: class with an inherited method target such as
+  `Status()`.
+- `Services/ApiService.cs`: class inheriting `BaseService` and implementing
+  `IRunner`; it should reference/call `Helpers`, `RunRequest`, and `RunStatus`,
+  and call the inherited base method.
+- `Models/RunRequest.cs`: struct used from `Program.cs` and `ApiService.cs`.
+- `Models/RunStatus.cs`: enum used from `ApiService.cs` and/or `Program.cs`.
+- `Utils/Helpers.cs`: static helper class that calls `Formatter`.
+- `Utils/Formatter.cs`: class/static helper called by `Helpers`.
+- `Orphan.cs`: keep one intentionally unrelated class so file-orphan behavior
+  remains easy to see.
+
+The README should describe only current Tree-sitter/Core behavior:
+
+- C# plugin contributes ecosystem defaults only.
+- Core Tree-sitter owns C# Imports, References, Calls, Inherits, and symbols.
+- Mention known limits only as current Core limits, not plugin gaps.
+
+## Proposed Acceptance Contract
+
+After the example source is updated and measured, `csharp-example.md` should
+follow the C/C++ pattern with two scenarios.
+
+Scenario 1: file relationships
+
+- Open `examples/example-csharp`, index, show no edge types.
+- Assert the expected file-node count and file list.
+- Graph Scope edge types should be only the C#-relevant rows: `Imports`,
+  `References`, `Calls`, `Inherits`, plus `Contains` if the symbol-node contract
+  requires it to be available from current Core behavior.
+- Toggle `Imports`, `References`, `Inherits`, and `Calls` independently.
+- Assert stable counts and representative file edges:
+  - `Program.cs` to `Config.cs`, `Services/ApiService.cs`,
+    `Models/RunRequest.cs`, `Models/RunStatus.cs`, and/or `Utils/Helpers.cs`
+    according to the final source.
+  - `Services/ApiService.cs` to `Services/BaseService.cs` and
+    `Contracts/IRunner.cs`.
+  - `Utils/Helpers.cs` to `Utils/Formatter.cs`.
+  - one intentionally unrelated file remains orphaned when only file-level
+    relationship edges are enabled.
+
+Scenario 2: C# symbol node scope
+
+- Open `examples/example-csharp`, index, show no edge types.
+- Select Graph Scope node types and assert available C# node types are only
+  `Function`, `Class`, `Interface`, `Struct`, and `Enum`.
+- Assert `Method`, `Type`, and C/C++-only rows are not available for the C#
+  example.
+- Show only File plus each C# symbol node type and assert stable counts plus
+  representative symbols:
+  - Class: `Program`, `Config`, `ApiService`, `BaseService`, `Helpers`,
+    `Formatter`, `Orphan`.
+  - Interface: `IRunner`.
+  - Struct: `RunRequest`.
+  - Enum: `RunStatus`.
+  - Function: representative C# methods such as `Main`, `LoadConfig`, `Run`,
+    `Status`, `Process`, or `FormatOutput`.
+- Toggle `Contains` with all C# symbol node types enabled and assert file-to-
+  symbol edges such as `src/Models/RunRequest.cs` to
+  `src/Models/RunRequest.cs#RunRequest:struct`.
+- Show only `Calls` with symbol node types enabled and assert representative
+  symbol-level calls where current Core supports them. If C# only reliably
+  exposes file-level Calls for a case, keep the contract at the file edge level
+  and record the unsupported symbol-call expectation as a follow-up note.
+
+## Acceptance Impact Scan
+
+Directly affected human-owned spec:
+
+- `packages/extension/tests/acceptance/specs/csharp-example.md`
+
+Likely generated/tooling files after approval:
+
+- `packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts`
+
+Potential fixture/source/docs files:
+
+- `examples/example-csharp/README.md`
+- `examples/example-csharp/src/**/*.cs`
+- `examples/example-csharp/.codegraphy/settings.json`
+- `examples/README.md`
+
+Intentionally unaffected specs:
+
+- `packages/extension/tests/acceptance/specs/c-example.md`
+- `packages/extension/tests/acceptance/specs/cpp-example.md`
+- generic Graph Scope specs, unless Coder changes shared Graph Scope capability
+  behavior for `Contains`.
+
+## Files Inspected
+
+- `AGENTS.md`
+- `CONTEXT.md`
+- `docs/agents/codegraphy-loop.md`
+- `docs/agents/loops/specifier.md`
+- `docs/agents/acceptance-specs.md`
+- `docs/handoff/201-csharp-upgrade.md`
+- `packages/core/src/treeSitter/runtime/capabilities.ts`
+- `packages/core/src/treeSitter/runtime/analyzeCSharp/file.ts`
+- `packages/core/src/treeSitter/runtime/analyzeCSharp/declarations.ts`
+- `packages/core/src/treeSitter/runtime/analyzeCSharp/references.ts`
+- `packages/core/src/treeSitter/runtime/analyzeCSharp/resolution.ts`
+- `packages/core/src/treeSitter/runtime/analyzeCSharp/usingImports.ts`
+- `packages/core/src/treeSitter/runtime/csharpIndex/nodes.ts`
+- `packages/core/src/treeSitter/runtime/csharpIndex/preAnalyze.ts`
+- `packages/core/src/treeSitter/runtime/csharpIndex/resolve.ts`
+- `packages/core/src/treeSitter/runtime/csharpIndex/store.ts`
+- `packages/core/src/treeSitter/runtime/csharpIndex/tree.ts`
+- `packages/core/src/graphControls/defaults/symbolNodeTypes.ts`
+- `packages/core/src/graph/data.ts`
+- `packages/core/src/graph/symbols.ts`
+- `packages/core/tests/treeSitter/csharp/*.test.ts`
+- `packages/core/tests/treeSitter/csharpIndex/*.test.ts`
+- `packages/core/tests/treeSitter/capabilities.test.ts`
+- `packages/core/tests/treeSitter/analyze.languageRelations.test.ts`
+- `packages/plugin-csharp/src/plugin.ts`
+- `packages/plugin-csharp/tests/plugin.test.ts`
+- `packages/plugin-csharp/README.md`
+- `packages/plugin-csharp/codegraphy.json`
+- `examples/example-csharp/README.md`
+- `examples/example-csharp/.codegraphy/settings.json`
+- `examples/example-csharp/.vscode/settings.json`
+- `examples/example-csharp/src/**/*.cs`
+- `examples/README.md`
+- `packages/extension/tests/acceptance/specs/csharp-example.md`
+- `packages/extension/tests/acceptance/specs/c-example.md`
+- `packages/extension/tests/acceptance/specs/cpp-example.md`
+
+External reference checked:
+
+- Microsoft Learn, C# type system:
+  `https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/`
+- Microsoft Learn, namespaces and using directives:
+  `https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/namespaces`
+- Microsoft Learn, program organization:
+  `https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/program-organization`

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ alias behavior.
 - `example-vue` — Vue 3 SFC workspace used to inspect baseline `.vue` graph support
 - `example-godot` — Godot/GDScript workspace used by plugin e2e
 - `example-python` — Python import-resolution workspace
-- `example-csharp` — C# namespace and type-usage workspace
+- `example-csharp` — C# task-runner workspace covering imports, references, calls, inheritance, and Core Tree-sitter symbol nodes
 - `example-markdown` — Markdown/wikilink workspace, including links inside non-markdown files
 - `example-rust` — Rust module/use example with strong core Tree-sitter coverage
 - `example-java` — Java import/inheritance example
@@ -69,7 +69,7 @@ Open the repo-root `examples/` folder when you want to compare languages side by
 | `example-vue` | A Vue 3 workspace with `<script setup lang="ts">`, normal `<script lang="ts">`, explicit `.vue` component imports, composables, type-only imports, interface inheritance, and a lazy async component import. |
 | `example-godot` | A runnable Godot project with `project.godot`, scenes, resources, autoloads, and GDScript. `enemy.gd` extends a file-backed base entity while Godot `class_name` declarations appear under Variable. |
 | `example-python` | `main.py` imports config, service, and helper functions; `ApiUser` inherits from `BaseApiUser`, and member-import files show how imports and function symbols identify the exact code path. |
-| `example-csharp` | `Program` calls into `Config`, `ApiService`, and `Helpers`; `ApiService` extends `BaseService` and implements `IRunner` so C# inheritance has file-level targets. |
+| `example-csharp` | `Program` calls into `Config`, `ApiService`, `RunRequest`, and `Helpers`; `ApiService` extends `BaseService`, implements `IRunner`, and uses `RunStatus` so C# class/interface/struct/enum/function symbols all have concrete targets. |
 | `example-markdown` | Markdown notes link to each other and to code, giving a mixed docs/code graph where symbol search still works on the TypeScript file. |
 | `example-rust` | `main.rs` uses local modules and declares `App`, `Status`, and `Service`, showing module edges plus type/function symbols. |
 | `example-java` | `App` imports `Helper`, extends `BaseService`, implements `RunnableThing`, and exposes class/interface/method symbols for import and inheritance checks. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ alias behavior.
 - `example-vue` — Vue 3 SFC workspace used to inspect baseline `.vue` graph support
 - `example-godot` — Godot/GDScript workspace used by plugin e2e
 - `example-python` — Python import-resolution workspace
-- `example-csharp` — C# task-runner workspace covering imports, references, calls, inheritance, and Core Tree-sitter symbol nodes
+- `example-csharp` — C# task-runner workspace covering imports, references, calls, inheritance, Core Tree-sitter symbol nodes, and C# field/parameter/local/constant variable nodes
 - `example-markdown` — Markdown/wikilink workspace, including links inside non-markdown files
 - `example-rust` — Rust module/use example with strong core Tree-sitter coverage
 - `example-java` — Java import/inheritance example
@@ -69,7 +69,7 @@ Open the repo-root `examples/` folder when you want to compare languages side by
 | `example-vue` | A Vue 3 workspace with `<script setup lang="ts">`, normal `<script lang="ts">`, explicit `.vue` component imports, composables, type-only imports, interface inheritance, and a lazy async component import. |
 | `example-godot` | A runnable Godot project with `project.godot`, scenes, resources, autoloads, and GDScript. `enemy.gd` extends a file-backed base entity while Godot `class_name` declarations appear under Variable. |
 | `example-python` | `main.py` imports config, service, and helper functions; `ApiUser` inherits from `BaseApiUser`, and member-import files show how imports and function symbols identify the exact code path. |
-| `example-csharp` | `Program` calls into `Config`, `ApiService`, `RunRequest`, and `Helpers`; `ApiService` extends `BaseService`, implements `IRunner`, and uses `RunStatus` so C# class/interface/struct/enum/function symbols all have concrete targets. |
+| `example-csharp` | `Program` calls into `Config`, `ApiService`, `RunRequest`, and `Helpers`; `ApiService` extends `BaseService`, implements `IRunner`, and uses `RunStatus` so C# class/interface/struct/enum/function symbols and field/parameter/local/constant variable nodes all have concrete targets. |
 | `example-markdown` | Markdown notes link to each other and to code, giving a mixed docs/code graph where symbol search still works on the TypeScript file. |
 | `example-rust` | `main.rs` uses local modules and declares `App`, `Status`, and `Service`, showing module edges plus type/function symbols. |
 | `example-java` | `App` imports `Helper`, extends `BaseService`, implements `RunnableThing`, and exposes class/interface/method symbols for import and inheritance checks. |

--- a/examples/example-csharp/README.md
+++ b/examples/example-csharp/README.md
@@ -1,9 +1,9 @@
 # C# Example
 
-A small C# workspace for manual checks of CodeGraphy's Core Tree-sitter C# support.
-The C# plugin currently contributes ecosystem defaults; Core Tree-sitter owns the
-C# Imports, References, Calls, Inherits, Contains, and symbol-node behavior shown
-by this example.
+A small C# task-runner workspace for manual checks of CodeGraphy's Core
+Tree-sitter C# support. The C# plugin currently contributes ecosystem defaults;
+Core Tree-sitter owns the C# Imports, References, Calls, Inherits, Contains,
+Symbol, and Variable behavior shown by this example.
 
 ## Graph Screenshot
 
@@ -14,18 +14,18 @@ by this example.
 ```
 src/
 ├── Program.cs          # Entry point
-├── Config.cs           # Configuration class and static call target
+├── Config.cs           # Configuration class, static call target, and const field
 ├── Orphan.cs           # No relationships (test showOrphans)
 ├── Contracts/
 │   └── IRunner.cs      # Runner interface
 ├── Models/
-│   ├── RunRequest.cs   # Struct used by Program and ApiService
+│   ├── RunRequest.cs   # Struct with fields, const, and constructor parameters
 │   └── RunStatus.cs    # Enum used by ApiService and formatting helpers
 ├── Utils/
 │   ├── Helpers.cs      # Static helper methods
 │   └── Formatter.cs    # Formatting utilities
 └── Services/
-    ├── ApiService.cs   # Service inheriting a base class and implementing IRunner
+    ├── ApiService.cs   # Service inheriting a base class, implementing IRunner, and declaring a field
     └── BaseService.cs  # Base service with inherited method call target
 ```
 
@@ -56,7 +56,10 @@ Orphan.cs (Orphan Node - only visible with showOrphans=true)
 | Inheritance | `class ApiService : BaseService, IRunner` | ApiService.cs |
 | Inherited method call | `Status()` | ApiService.cs |
 | Enum reference | `RunStatus.Succeeded` | ApiService.cs |
-| System usings | `using System;` | Program.cs |
+| Field | `private readonly string serviceName` | ApiService.cs |
+| Parameter | `Run(RunRequest request)` | ApiService.cs |
+| Local | `var currentStatus = ...` | ApiService.cs |
+| Constant | `const string DefaultName` | RunRequest.cs |
 
 ## Files
 
@@ -81,19 +84,23 @@ Orphan.cs (Orphan Node - only visible with showOrphans=true)
 4. Click the CodeGraphy icon in the activity bar
 5. Compare the graph to the expected structure above
 
-## Symbol Node Demo
+## Symbol And Variable Node Demo
 
 Suggested symbol check:
 
 1. Open `src/Program.cs`.
-2. In Graph Scope, enable **Symbol** and the C# symbol rows.
+2. In Graph Scope, enable **Symbol**, **Variable**, and the C# child rows.
 3. Search for `Program`, `Config`, `ApiService`, `BaseService`, `IRunner`,
-   `RunRequest`, `RunStatus`, `Helpers`, and `Formatter`.
+   `RunRequest`, `RunStatus`, `Helpers`, `Formatter`, `serviceName`,
+   `request`, `currentStatus`, and `DefaultName`.
 
 Expected behavior:
 
 - Class, Interface, Struct, Enum, and Function rows are relevant for this C# workspace.
 - Function includes C# method declarations such as `Main`, `LoadConfig`, `Run`,
   `Status`, `FormatStatus`, and `FormatOutput`.
+- Field, Parameter, Local, and Constant rows are relevant for this C# workspace.
+- Constant is intentionally narrow: explicit C# `const` declarations such as
+  `DefaultMaxItems` and `DefaultName`.
 - Contains edges connect each file to its symbols, and Calls edges can connect
   caller methods to method/type symbols when symbol nodes are enabled.

--- a/examples/example-csharp/README.md
+++ b/examples/example-csharp/README.md
@@ -1,6 +1,9 @@
 # C# Example
 
-A small C# workspace for manual checks of CodeGraphy's C# support.
+A small C# workspace for manual checks of CodeGraphy's Core Tree-sitter C# support.
+The C# plugin currently contributes ecosystem defaults; Core Tree-sitter owns the
+C# Imports, References, Calls, Inherits, Contains, and symbol-node behavior shown
+by this example.
 
 ## Graph Screenshot
 
@@ -10,54 +13,64 @@ A small C# workspace for manual checks of CodeGraphy's C# support.
 
 ```
 src/
-├── Program.cs         # Entry point
-├── Config.cs          # Configuration
-├── Orphan.cs          # No relationships (test showOrphans)
+├── Program.cs          # Entry point
+├── Config.cs           # Configuration class and static call target
+├── Orphan.cs           # No relationships (test showOrphans)
 ├── Contracts/
-│   └── IRunner.cs     # Runner contract
+│   └── IRunner.cs      # Runner interface
+├── Models/
+│   ├── RunRequest.cs   # Struct used by Program and ApiService
+│   └── RunStatus.cs    # Enum used by ApiService and formatting helpers
 ├── Utils/
-│   ├── Helpers.cs     # Utility functions
-│   └── Formatter.cs   # Formatting utilities
+│   ├── Helpers.cs      # Static helper methods
+│   └── Formatter.cs    # Formatting utilities
 └── Services/
-    ├── ApiService.cs  # API service
-    └── BaseService.cs # Base service
+    ├── ApiService.cs   # Service inheriting a base class and implementing IRunner
+    └── BaseService.cs  # Base service with inherited method call target
 ```
 
 ## Expected Graph Structure
 
 ```
 Program.cs ────┬──▶ Config.cs
-               │
-               ├──▶ Services/ApiService.cs ──▶ Utils/Helpers.cs ──▶ Utils/Formatter.cs
-               │
+               ├──▶ Models/RunRequest.cs
+               ├──▶ Services/ApiService.cs ──▶ Services/BaseService.cs
+               │                         └──▶ Utils/Helpers.cs ──▶ Utils/Formatter.cs
                └──▶ Utils/Helpers.cs
 
 Services/ApiService.cs ──inherit──▶ Services/BaseService.cs
 Services/ApiService.cs ──inherit──▶ Contracts/IRunner.cs
+Services/ApiService.cs ──reference──▶ Models/RunStatus.cs
 
 Orphan.cs (Orphan Node - only visible with showOrphans=true)
 ```
 
-## Using Patterns Tested
+## Core Tree-sitter Patterns Tested
 
 | Pattern | Example | File |
 |---------|---------|------|
 | Namespace using | `using MyApp.Utils;` | Program.cs |
-| Relative path | `using MyApp.Services;` | Program.cs |
+| Type construction | `new RunRequest(...)` | Program.cs |
+| Static call | `Config.LoadConfig()` | Program.cs |
+| Static helper call | `Helpers.FormatStatus(status)` | Program.cs |
 | Inheritance | `class ApiService : BaseService, IRunner` | ApiService.cs |
-| System usings | `using System;` | (ignored) |
+| Inherited method call | `Status()` | ApiService.cs |
+| Enum reference | `RunStatus.Succeeded` | ApiService.cs |
+| System usings | `using System;` | Program.cs |
 
 ## Files
 
 | File | Uses | Used By |
 |------|------|---------|
-| `Program.cs` | Config, ApiService, Helpers | — |
+| `Program.cs` | Config, ApiService, RunRequest, Helpers | — |
 | `Config.cs` | — | Program |
 | `Contracts/IRunner.cs` | — | ApiService |
+| `Models/RunRequest.cs` | — | Program |
+| `Models/RunStatus.cs` | — | ApiService |
 | `Orphan.cs` | — | — |
 | `Utils/Helpers.cs` | Formatter | Program, ApiService |
 | `Utils/Formatter.cs` | — | Helpers |
-| `Services/ApiService.cs` | BaseService, IRunner, Helpers | Program |
+| `Services/ApiService.cs` | BaseService, IRunner, RunStatus, Helpers | Program |
 | `Services/BaseService.cs` | — | ApiService |
 
 ## How to Test
@@ -73,10 +86,14 @@ Orphan.cs (Orphan Node - only visible with showOrphans=true)
 Suggested symbol check:
 
 1. Open `src/Program.cs`.
-2. In Graph Scope, enable **Symbol**.
-3. Search for `Program`, `Config`, `ApiService`, `BaseService`, `IRunner`, and `Helpers`.
+2. In Graph Scope, enable **Symbol** and the C# symbol rows.
+3. Search for `Program`, `Config`, `ApiService`, `BaseService`, `IRunner`,
+   `RunRequest`, `RunStatus`, `Helpers`, and `Formatter`.
 
 Expected behavior:
 
-- Class, Interface, and Function symbols show the application entry point, configuration object, service class, inherited base, implemented contract, and helper calls.
-- The file graph stays small, while symbol nodes explain why `Program.cs` reaches the service and utility files.
+- Class, Interface, Struct, Enum, and Function rows are relevant for this C# workspace.
+- Function includes C# method declarations such as `Main`, `LoadConfig`, `Run`,
+  `Status`, `FormatStatus`, and `FormatOutput`.
+- Contains edges connect each file to its symbols, and Calls edges can connect
+  caller methods to method/type symbols when symbol nodes are enabled.

--- a/examples/example-csharp/src/Config.cs
+++ b/examples/example-csharp/src/Config.cs
@@ -1,17 +1,13 @@
-namespace MyApp
-{
-    /// <summary>
-    /// Application configuration.
-    /// </summary>
-    public class Config
-    {
-        public string ApiUrl { get; set; } = "https://api.example.com";
-        public int Timeout { get; set; } = 30;
-        public bool Debug { get; set; } = false;
+namespace MyApp;
 
-        public static Config LoadConfig()
-        {
-            return new Config();
-        }
+public class Config
+{
+    public string ApiUrl { get; set; } = "https://api.example.com";
+    public int MaxItems { get; set; } = 3;
+    public bool Debug { get; set; } = false;
+
+    public static Config LoadConfig()
+    {
+        return new Config();
     }
 }

--- a/examples/example-csharp/src/Config.cs
+++ b/examples/example-csharp/src/Config.cs
@@ -2,12 +2,17 @@ namespace MyApp;
 
 public class Config
 {
+    public const int DefaultMaxItems = 3;
+
     public string ApiUrl { get; set; } = "https://api.example.com";
-    public int MaxItems { get; set; } = 3;
+    public int MaxItems { get; set; } = DefaultMaxItems;
     public bool Debug { get; set; } = false;
 
     public static Config LoadConfig()
     {
-        return new Config();
+        return new Config
+        {
+            ApiUrl = "https://api.example.com"
+        };
     }
 }

--- a/examples/example-csharp/src/Contracts/IRunner.cs
+++ b/examples/example-csharp/src/Contracts/IRunner.cs
@@ -1,7 +1,6 @@
-namespace MyApp.Contracts
+namespace MyApp.Contracts;
+
+public interface IRunner
 {
-    public interface IRunner
-    {
-        string Run();
-    }
+    MyApp.Models.RunStatus Run(MyApp.Models.RunRequest request);
 }

--- a/examples/example-csharp/src/Models/RunRequest.cs
+++ b/examples/example-csharp/src/Models/RunRequest.cs
@@ -2,12 +2,13 @@ namespace MyApp.Models;
 
 public struct RunRequest
 {
+    public const string DefaultName = "daily-sync";
+    public readonly string Name;
+    public readonly int MaxItems;
+
     public RunRequest(string name, int maxItems)
     {
         Name = name;
         MaxItems = maxItems;
     }
-
-    public string Name { get; }
-    public int MaxItems { get; }
 }

--- a/examples/example-csharp/src/Models/RunRequest.cs
+++ b/examples/example-csharp/src/Models/RunRequest.cs
@@ -1,0 +1,13 @@
+namespace MyApp.Models;
+
+public struct RunRequest
+{
+    public RunRequest(string name, int maxItems)
+    {
+        Name = name;
+        MaxItems = maxItems;
+    }
+
+    public string Name { get; }
+    public int MaxItems { get; }
+}

--- a/examples/example-csharp/src/Models/RunStatus.cs
+++ b/examples/example-csharp/src/Models/RunStatus.cs
@@ -1,0 +1,7 @@
+namespace MyApp.Models;
+
+public enum RunStatus
+{
+    Skipped,
+    Succeeded
+}

--- a/examples/example-csharp/src/Orphan.cs
+++ b/examples/example-csharp/src/Orphan.cs
@@ -1,15 +1,9 @@
-namespace MyApp
+namespace MyApp;
+
+public class Orphan
 {
-    /// <summary>
-    /// An orphan class with no usings or dependents.
-    /// This file is used to test the showOrphans setting.
-    /// When showOrphans=false, this file should not appear in the graph.
-    /// </summary>
-    public class Orphan
+    public string StandaloneMethod()
     {
-        public string StandaloneMethod()
-        {
-            return "I'm all alone";
-        }
+        return "I'm all alone";
     }
 }

--- a/examples/example-csharp/src/Program.cs
+++ b/examples/example-csharp/src/Program.cs
@@ -1,23 +1,19 @@
-using System;
+using MyApp.Models;
 using MyApp.Services;
 using MyApp.Utils;
 
-namespace MyApp
+namespace MyApp;
+
+class Program
 {
-    /// <summary>
-    /// Main entry point for the application.
-    /// </summary>
-    class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            var settings = Config.LoadConfig();
-            var api = new ApiService();
-            
-            var data = api.FetchData(settings.ApiUrl);
-            var result = Helpers.ProcessData(data);
-            
-            Console.WriteLine(result);
-        }
+        var settings = Config.LoadConfig();
+        var service = new ApiService();
+        var request = new RunRequest("daily-sync", settings.MaxItems);
+        var status = service.Run(request);
+        var output = Helpers.FormatStatus(status);
+
+        System.Console.WriteLine(output);
     }
 }

--- a/examples/example-csharp/src/Program.cs
+++ b/examples/example-csharp/src/Program.cs
@@ -6,11 +6,11 @@ namespace MyApp;
 
 class Program
 {
-    static void Main(string[] args)
+    static void Main()
     {
         var settings = Config.LoadConfig();
         var service = new ApiService();
-        var request = new RunRequest("daily-sync", settings.MaxItems);
+        var request = new RunRequest(RunRequest.DefaultName, settings.MaxItems);
         var status = service.Run(request);
         var output = Helpers.FormatStatus(status);
 

--- a/examples/example-csharp/src/Services/ApiService.cs
+++ b/examples/example-csharp/src/Services/ApiService.cs
@@ -1,31 +1,16 @@
 using MyApp.Contracts;
+using MyApp.Models;
 using MyApp.Utils;
 
-namespace MyApp.Services
+namespace MyApp.Services;
+
+public class ApiService : BaseService, IRunner
 {
-    /// <summary>
-    /// API service for fetching data.
-    /// </summary>
-    public class ApiService : BaseService, IRunner
+    public RunStatus Run(RunRequest request)
     {
-        public string Run()
-        {
-            return Status();
-        }
-
-        /// <summary>
-        /// Fetch data from the API.
-        /// This is a mock implementation for testing.
-        /// </summary>
-        public string[] FetchData(string url)
-        {
-            // In real code, this would make HTTP requests
-            return new[] { "apple", "banana", "cherry" };
-        }
-
-        public object PostData(string url, object payload)
-        {
-            return new { Status = "ok", Url = url };
-        }
+        var current = Status();
+        return Helpers.IsRunnable(request, current)
+            ? RunStatus.Succeeded
+            : RunStatus.Skipped;
     }
 }

--- a/examples/example-csharp/src/Services/ApiService.cs
+++ b/examples/example-csharp/src/Services/ApiService.cs
@@ -6,10 +6,14 @@ namespace MyApp.Services;
 
 public class ApiService : BaseService, IRunner
 {
+    private readonly string serviceName = "api";
+
     public RunStatus Run(RunRequest request)
     {
-        var current = Status();
-        return Helpers.IsRunnable(request, current)
+        var currentStatus = $"{serviceName}:{Status()}";
+        var isRunnable = Helpers.IsRunnable(request, currentStatus);
+
+        return isRunnable
             ? RunStatus.Succeeded
             : RunStatus.Skipped;
     }

--- a/examples/example-csharp/src/Services/BaseService.cs
+++ b/examples/example-csharp/src/Services/BaseService.cs
@@ -1,10 +1,9 @@
-namespace MyApp.Services
+namespace MyApp.Services;
+
+public class BaseService
 {
-    public class BaseService
+    public string Status()
     {
-        public string Status()
-        {
-            return "ready";
-        }
+        return "ready";
     }
 }

--- a/examples/example-csharp/src/Utils/Formatter.cs
+++ b/examples/example-csharp/src/Utils/Formatter.cs
@@ -1,18 +1,9 @@
-namespace MyApp.Utils
-{
-    /// <summary>
-    /// Formatting utilities.
-    /// </summary>
-    public static class Formatter
-    {
-        public static string FormatOutput(string text)
-        {
-            return $"[OUTPUT] {text}";
-        }
+namespace MyApp.Utils;
 
-        public static string FormatError(string message)
-        {
-            return $"[ERROR] {message}";
-        }
+public static class Formatter
+{
+    public static string FormatOutput(MyApp.Models.RunStatus status)
+    {
+        return $"[OUTPUT] {status}";
     }
 }

--- a/examples/example-csharp/src/Utils/Helpers.cs
+++ b/examples/example-csharp/src/Utils/Helpers.cs
@@ -1,21 +1,14 @@
-using System.Linq;
+namespace MyApp.Utils;
 
-namespace MyApp.Utils
+public static class Helpers
 {
-    /// <summary>
-    /// Helper utilities.
-    /// </summary>
-    public static class Helpers
+    public static bool IsRunnable(MyApp.Models.RunRequest request, string currentStatus)
     {
-        public static string ProcessData(string[] data)
-        {
-            if (data == null || data.Length == 0)
-            {
-                return Formatter.FormatOutput("No data");
-            }
+        return request.MaxItems > 0 && currentStatus == "ready";
+    }
 
-            var processed = data.Select(item => item.ToUpper());
-            return Formatter.FormatOutput(string.Join(", ", processed));
-        }
+    public static string FormatStatus(MyApp.Models.RunStatus status)
+    {
+        return Formatter.FormatOutput(status);
     }
 }

--- a/examples/example-csharp/src/Utils/Helpers.cs
+++ b/examples/example-csharp/src/Utils/Helpers.cs
@@ -4,7 +4,7 @@ public static class Helpers
 {
     public static bool IsRunnable(MyApp.Models.RunRequest request, string currentStatus)
     {
-        return request.MaxItems > 0 && currentStatus == "ready";
+        return request.MaxItems > 0 && currentStatus.EndsWith(":ready");
     }
 
     public static string FormatStatus(MyApp.Models.RunStatus status)

--- a/packages/core/src/treeSitter/runtime/capabilities.ts
+++ b/packages/core/src/treeSitter/runtime/capabilities.ts
@@ -24,7 +24,7 @@ const DEFAULT_TREE_SITTER_EDGE_TYPE_CAPABILITIES = [
 const TREE_SITTER_EDGE_TYPE_CAPABILITIES_BY_LANGUAGE = {
   'c': ['include', 'call', 'contains'],
   cpp: ['include', 'call', 'contains', 'inherit', 'overrides'],
-  csharp: ['import', 'reference', 'call', 'inherit'],
+  csharp: ['import', 'reference', 'call', 'contains', 'inherit'],
   dart: ['import', 'call', 'inherit'],
   go: ['import', 'call'],
   haskell: ['import', 'call'],

--- a/packages/core/tests/treeSitter/capabilities.test.ts
+++ b/packages/core/tests/treeSitter/capabilities.test.ts
@@ -34,6 +34,25 @@ describe('pipeline/plugins/treesitter/runtime/capabilities', () => {
     ]);
   });
 
+  it('advertises C# contains when C# symbol node capabilities are available', () => {
+    expect(listTreeSitterGraphScopeCapabilities(['src/Program.cs'])).toEqual({
+      nodeTypes: [
+        'symbol:function',
+        'symbol:class',
+        'symbol:interface',
+        'symbol:struct',
+        'symbol:enum',
+      ],
+      edgeTypes: [
+        'import',
+        'reference',
+        'call',
+        'contains',
+        'inherit',
+      ],
+    });
+  });
+
   it('advertises C includes without advertising imports for C source and header workspaces', () => {
     expect(listTreeSitterEdgeTypeCapabilities([
       'src/main.c',

--- a/packages/extension/tests/acceptance/specs/csharp-example.md
+++ b/packages/extension/tests/acceptance/specs/csharp-example.md
@@ -1,51 +1,157 @@
 # Feature: C# Example
 
-## Scenario: C# example renders expected file nodes and using relationships
+## Scenario: C# example covers Task Runner graph scope
 
 Given I open the examples/example-csharp workspace in VS Code
 When I open the CodeGraphy extension graph view
 And I have indexed the workspace
 Then I see graph nodes
 And I show no edge types
-Then I can see there are 11 nodes and 0 connections
+Then I can see there are 13 nodes and 0 connections
 And the graph nodes match the expected files in the examples/example-csharp workspace
 
 When I click the Graph Scope button
 And I select edge types
-Then the available edge types are Imports, References, Calls, Inherits
+Then the available edge types are only Imports, References, Calls, Contains, Inherits
+And I select node types
+Then the available C# node types are only Function, Class, Interface, Struct, Enum, Constant, Field, Parameter, Local
+And the Method node type is not available for the C# example
+And the Type node type is not available for the C# example
+And the Global node type is not available for the C# example
 And I close the Graph Scope
 
 When I toggle the Imports edge on
-Then I can see there are 11 nodes and 3 connections
+Then I can see there are 13 nodes and 6 connections
+And src/Program.cs points to src/Models/RunRequest.cs
 And src/Program.cs points to src/Services/ApiService.cs
 And src/Program.cs points to src/Utils/Helpers.cs
 And src/Services/ApiService.cs points to src/Contracts/IRunner.cs
+And src/Services/ApiService.cs points to src/Models/RunStatus.cs
+And src/Services/ApiService.cs points to src/Utils/Helpers.cs
 
+And src/Config.cs is an orphan node
 And src/Orphan.cs is an orphan node
 And src/Services/BaseService.cs is an orphan node
+And src/Utils/Formatter.cs is an orphan node
 And README.md is an orphan node
 And .gitignore is an orphan node
 And .vscode/settings.json is an orphan node
 
-Then I toggle the Imports edge off
-And I toggle the References edge on
-Then I can see there are 11 nodes and 4 connections
+Then I show only the References edge type
+Then I can see there are 13 nodes and 7 connections
 And src/Program.cs points to src/Config.cs
+And src/Program.cs points to src/Models/RunRequest.cs
 And src/Program.cs points to src/Services/ApiService.cs
 And src/Program.cs points to src/Utils/Helpers.cs
+And src/Services/ApiService.cs points to src/Models/RunStatus.cs
+And src/Services/ApiService.cs points to src/Utils/Helpers.cs
 And src/Utils/Helpers.cs points to src/Utils/Formatter.cs
 
-Then I toggle the References edge off
-And I toggle the Inherits edge on
-Then I can see there are 11 nodes and 2 connections
+Then I show only the Inherits edge type
+Then I can see there are 13 nodes and 2 connections
 And src/Services/ApiService.cs points to src/Services/BaseService.cs
 And src/Services/ApiService.cs points to src/Contracts/IRunner.cs
 
-Then I toggle the Inherits edge off
-And I toggle the Calls edge on
-Then I can see there are 11 nodes and 5 connections
+Then I show only the Calls edge type
+Then I can see there are 13 nodes and 7 connections
 And src/Program.cs points to src/Config.cs
+And src/Program.cs points to src/Models/RunRequest.cs
 And src/Program.cs points to src/Services/ApiService.cs
 And src/Program.cs points to src/Utils/Helpers.cs
 And src/Services/ApiService.cs points to src/Services/BaseService.cs
+And src/Services/ApiService.cs points to src/Utils/Helpers.cs
 And src/Utils/Helpers.cs points to src/Utils/Formatter.cs
+
+Then I show only the Contains edge type
+Then I show only the File and Class node types
+Then I can see there are 20 nodes and 7 connections
+And the visible graph includes the Class node Program from src/Program.cs
+And the visible graph includes the Class node Config from src/Config.cs
+And the visible graph includes the Class node ApiService from src/Services/ApiService.cs
+And the visible graph includes the Class node BaseService from src/Services/BaseService.cs
+And the visible graph includes the Class node Helpers from src/Utils/Helpers.cs
+And the visible graph includes the Class node Formatter from src/Utils/Formatter.cs
+
+Then I show only the File and Interface node types
+Then I can see there are 14 nodes and 1 connection
+And the visible graph includes the Interface node IRunner from src/Contracts/IRunner.cs
+
+Then I show only the File and Struct node types
+Then I can see there are 14 nodes and 1 connection
+And the visible graph includes the Struct node RunRequest from src/Models/RunRequest.cs
+
+Then I show only the File and Enum node types
+Then I can see there are 14 nodes and 1 connection
+And the visible graph includes the Enum node RunStatus from src/Models/RunStatus.cs
+
+Then I show only the File and Function node types
+Then I can see there are 22 nodes and 9 connections
+And the visible graph includes the Function node Main from src/Program.cs
+And the visible graph includes the Function node LoadConfig from src/Config.cs
+And the visible graph includes the Function node Run from src/Services/ApiService.cs
+And the visible graph includes the Function node Status from src/Services/BaseService.cs
+And the visible graph includes the Function node FormatStatus from src/Utils/Helpers.cs
+And the visible graph includes the Function node FormatOutput from src/Utils/Formatter.cs
+
+Then I show only the File and Constant node types
+Then I can see there are 15 nodes and 2 connections
+And the visible graph includes the Constant node DefaultMaxItems from src/Config.cs
+And the visible graph includes the Constant node DefaultName from src/Models/RunRequest.cs
+
+Then I show only the File and Field node types
+Then I can see there are 16 nodes and 3 connections
+And the visible graph includes the Field node Name from src/Models/RunRequest.cs
+And the visible graph includes the Field node MaxItems from src/Models/RunRequest.cs
+And the visible graph includes the Field node serviceName from src/Services/ApiService.cs
+
+Then I show only the File and Parameter node types
+Then I can see there are 21 nodes and 8 connections
+And the visible graph includes the Parameter node request from src/Contracts/IRunner.cs
+And the visible graph includes the Parameter node name from src/Models/RunRequest.cs
+And the visible graph includes the Parameter node maxItems from src/Models/RunRequest.cs
+And the visible graph includes the Parameter node request from src/Services/ApiService.cs
+And the visible graph includes the Parameter node currentStatus from src/Utils/Helpers.cs
+
+Then I show only the File and Local node types
+Then I can see there are 20 nodes and 7 connections
+And the visible graph includes the Local node settings from src/Program.cs
+And the visible graph includes the Local node service from src/Program.cs
+And the visible graph includes the Local node request from src/Program.cs
+And the visible graph includes the Local node currentStatus from src/Services/ApiService.cs
+And the visible graph includes the Local node isRunnable from src/Services/ApiService.cs
+
+Then I show no edge types
+Then I show only the File, Function, Class, Interface, Struct, Enum, Constant, Field, Parameter and Local node types
+Then I can see there are 52 nodes and 0 connections
+
+When I toggle the Contains edge on
+Then I can see there are 52 nodes and 39 connections
+And src/Config.cs points to src/Config.cs#DefaultMaxItems:constant
+And src/Models/RunRequest.cs points to src/Models/RunRequest.cs#RunRequest:struct
+And src/Models/RunRequest.cs points to src/Models/RunRequest.cs#DefaultName:constant
+And src/Models/RunRequest.cs points to src/Models/RunRequest.cs#Name:field
+And src/Services/ApiService.cs points to src/Services/ApiService.cs#serviceName:field
+And src/Services/ApiService.cs points to src/Services/ApiService.cs#request:parameter
+And src/Services/ApiService.cs points to src/Services/ApiService.cs#currentStatus:local
+And src/Services/ApiService.cs points to src/Services/ApiService.cs#isRunnable:local
+
+Then I show only the Calls edge type
+Then I can see there are 52 nodes and 7 connections
+And the visible graph shows Main in src/Program.cs calling LoadConfig in src/Config.cs
+And the visible graph shows Main in src/Program.cs calling RunRequest in src/Models/RunRequest.cs
+And the visible graph shows Main in src/Program.cs calling FormatStatus in src/Utils/Helpers.cs
+And the visible graph shows Run in src/Services/ApiService.cs calling Status in src/Services/BaseService.cs
+And the visible graph shows FormatStatus in src/Utils/Helpers.cs calling FormatOutput in src/Utils/Formatter.cs
+
+Then I show only the Inherits edge type
+Then I can see there are 52 nodes and 2 connections
+And the visible graph shows ApiService in src/Services/ApiService.cs inheriting from BaseService in src/Services/BaseService.cs
+And the visible graph shows ApiService in src/Services/ApiService.cs inheriting from IRunner in src/Contracts/IRunner.cs
+
+Then I show only the Imports edge type
+Then I can see there are 52 nodes and 6 connections
+And src/Program.cs points to src/Models/RunRequest.cs
+
+Then I show only the References edge type
+Then I can see there are 52 nodes and 7 connections
+And src/Program.cs points to src/Config.cs

--- a/packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts
+++ b/packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts
@@ -2082,11 +2082,11 @@ test.describe('C++ Example', () => {
 });
 
 test.describe('C# Example', () => {
-  test('C# example renders expected file nodes and using relationships', async ({}, testInfo) => {
+  test('C# example covers Task Runner graph scope', async ({}, testInfo) => {
     const context = await createAcceptanceContext({
       testInfo,
       sourcePath: 'tests/acceptance/specs/csharp-example.md',
-      scenario: 'C# example renders expected file nodes and using relationships'
+      scenario: 'C# example covers Task Runner graph scope'
     });
 
     try {
@@ -2141,10 +2141,10 @@ test.describe('C# Example', () => {
       });
 
       // tests/acceptance/specs/csharp-example.md:10
-      await test.step('Then I can see there are 11 nodes and 0 connections', async () => {
-        await runAcceptanceStep(context, 'I can see there are 11 nodes and 0 connections', {
+      await test.step('Then I can see there are 13 nodes and 0 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 13 nodes and 0 connections', {
           keyword: 'Then',
-          text: 'I can see there are 11 nodes and 0 connections',
+          text: 'I can see there are 13 nodes and 0 connections',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 10
         });
@@ -2181,322 +2181,1232 @@ test.describe('C# Example', () => {
       });
 
       // tests/acceptance/specs/csharp-example.md:15
-      await test.step('Then the available edge types are Imports, References, Calls, Inherits', async () => {
-        await runAcceptanceStep(context, 'the available edge types are Imports, References, Calls, Inherits', {
+      await test.step('Then the available edge types are only Imports, References, Calls, Contains, Inherits', async () => {
+        await runAcceptanceStep(context, 'the available edge types are only Imports, References, Calls, Contains, Inherits', {
           keyword: 'Then',
-          text: 'the available edge types are Imports, References, Calls, Inherits',
+          text: 'the available edge types are only Imports, References, Calls, Contains, Inherits',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 15
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:16
-      await test.step('And I close the Graph Scope', async () => {
-        await runAcceptanceStep(context, 'I close the Graph Scope', {
+      await test.step('And I select node types', async () => {
+        await runAcceptanceStep(context, 'I select node types', {
           keyword: 'And',
-          text: 'I close the Graph Scope',
+          text: 'I select node types',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 16
         });
       });
 
+      // tests/acceptance/specs/csharp-example.md:17
+      await test.step('Then the available C# node types are only Function, Class, Interface, Struct, Enum, Constant, Field, Parameter, Local', async () => {
+        await runAcceptanceStep(context, 'the available C# node types are only Function, Class, Interface, Struct, Enum, Constant, Field, Parameter, Local', {
+          keyword: 'Then',
+          text: 'the available C# node types are only Function, Class, Interface, Struct, Enum, Constant, Field, Parameter, Local',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 17
+        });
+      });
+
       // tests/acceptance/specs/csharp-example.md:18
-      await test.step('When I toggle the Imports edge on', async () => {
-        await runAcceptanceStep(context, 'I toggle the Imports edge on', {
-          keyword: 'When',
-          text: 'I toggle the Imports edge on',
+      await test.step('And the Method node type is not available for the C# example', async () => {
+        await runAcceptanceStep(context, 'the Method node type is not available for the C# example', {
+          keyword: 'And',
+          text: 'the Method node type is not available for the C# example',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 18
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:19
-      await test.step('Then I can see there are 11 nodes and 3 connections', async () => {
-        await runAcceptanceStep(context, 'I can see there are 11 nodes and 3 connections', {
-          keyword: 'Then',
-          text: 'I can see there are 11 nodes and 3 connections',
+      await test.step('And the Type node type is not available for the C# example', async () => {
+        await runAcceptanceStep(context, 'the Type node type is not available for the C# example', {
+          keyword: 'And',
+          text: 'the Type node type is not available for the C# example',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 19
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:20
-      await test.step('And src/Program.cs points to src/Services/ApiService.cs', async () => {
-        await runAcceptanceStep(context, 'src/Program.cs points to src/Services/ApiService.cs', {
+      await test.step('And the Global node type is not available for the C# example', async () => {
+        await runAcceptanceStep(context, 'the Global node type is not available for the C# example', {
           keyword: 'And',
-          text: 'src/Program.cs points to src/Services/ApiService.cs',
+          text: 'the Global node type is not available for the C# example',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 20
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:21
-      await test.step('And src/Program.cs points to src/Utils/Helpers.cs', async () => {
-        await runAcceptanceStep(context, 'src/Program.cs points to src/Utils/Helpers.cs', {
+      await test.step('And I close the Graph Scope', async () => {
+        await runAcceptanceStep(context, 'I close the Graph Scope', {
           keyword: 'And',
-          text: 'src/Program.cs points to src/Utils/Helpers.cs',
+          text: 'I close the Graph Scope',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 21
         });
       });
 
-      // tests/acceptance/specs/csharp-example.md:22
-      await test.step('And src/Services/ApiService.cs points to src/Contracts/IRunner.cs', async () => {
-        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Contracts/IRunner.cs', {
-          keyword: 'And',
-          text: 'src/Services/ApiService.cs points to src/Contracts/IRunner.cs',
+      // tests/acceptance/specs/csharp-example.md:23
+      await test.step('When I toggle the Imports edge on', async () => {
+        await runAcceptanceStep(context, 'I toggle the Imports edge on', {
+          keyword: 'When',
+          text: 'I toggle the Imports edge on',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
-          line: 22
+          line: 23
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:24
-      await test.step('And src/Orphan.cs is an orphan node', async () => {
-        await runAcceptanceStep(context, 'src/Orphan.cs is an orphan node', {
-          keyword: 'And',
-          text: 'src/Orphan.cs is an orphan node',
+      await test.step('Then I can see there are 13 nodes and 6 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 13 nodes and 6 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 13 nodes and 6 connections',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 24
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:25
-      await test.step('And src/Services/BaseService.cs is an orphan node', async () => {
-        await runAcceptanceStep(context, 'src/Services/BaseService.cs is an orphan node', {
+      await test.step('And src/Program.cs points to src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Models/RunRequest.cs', {
           keyword: 'And',
-          text: 'src/Services/BaseService.cs is an orphan node',
+          text: 'src/Program.cs points to src/Models/RunRequest.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 25
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:26
-      await test.step('And README.md is an orphan node', async () => {
-        await runAcceptanceStep(context, 'README.md is an orphan node', {
+      await test.step('And src/Program.cs points to src/Services/ApiService.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Services/ApiService.cs', {
           keyword: 'And',
-          text: 'README.md is an orphan node',
+          text: 'src/Program.cs points to src/Services/ApiService.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 26
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:27
-      await test.step('And .gitignore is an orphan node', async () => {
-        await runAcceptanceStep(context, '.gitignore is an orphan node', {
+      await test.step('And src/Program.cs points to src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Utils/Helpers.cs', {
           keyword: 'And',
-          text: '.gitignore is an orphan node',
+          text: 'src/Program.cs points to src/Utils/Helpers.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 27
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:28
-      await test.step('And .vscode/settings.json is an orphan node', async () => {
-        await runAcceptanceStep(context, '.vscode/settings.json is an orphan node', {
+      await test.step('And src/Services/ApiService.cs points to src/Contracts/IRunner.cs', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Contracts/IRunner.cs', {
           keyword: 'And',
-          text: '.vscode/settings.json is an orphan node',
+          text: 'src/Services/ApiService.cs points to src/Contracts/IRunner.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 28
         });
       });
 
+      // tests/acceptance/specs/csharp-example.md:29
+      await test.step('And src/Services/ApiService.cs points to src/Models/RunStatus.cs', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Models/RunStatus.cs', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Models/RunStatus.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 29
+        });
+      });
+
       // tests/acceptance/specs/csharp-example.md:30
-      await test.step('Then I toggle the Imports edge off', async () => {
-        await runAcceptanceStep(context, 'I toggle the Imports edge off', {
-          keyword: 'Then',
-          text: 'I toggle the Imports edge off',
+      await test.step('And src/Services/ApiService.cs points to src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Utils/Helpers.cs', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Utils/Helpers.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 30
         });
       });
 
-      // tests/acceptance/specs/csharp-example.md:31
-      await test.step('And I toggle the References edge on', async () => {
-        await runAcceptanceStep(context, 'I toggle the References edge on', {
-          keyword: 'And',
-          text: 'I toggle the References edge on',
-          sourcePath: 'tests/acceptance/specs/csharp-example.md',
-          line: 31
-        });
-      });
-
       // tests/acceptance/specs/csharp-example.md:32
-      await test.step('Then I can see there are 11 nodes and 4 connections', async () => {
-        await runAcceptanceStep(context, 'I can see there are 11 nodes and 4 connections', {
-          keyword: 'Then',
-          text: 'I can see there are 11 nodes and 4 connections',
+      await test.step('And src/Config.cs is an orphan node', async () => {
+        await runAcceptanceStep(context, 'src/Config.cs is an orphan node', {
+          keyword: 'And',
+          text: 'src/Config.cs is an orphan node',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 32
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:33
-      await test.step('And src/Program.cs points to src/Config.cs', async () => {
-        await runAcceptanceStep(context, 'src/Program.cs points to src/Config.cs', {
+      await test.step('And src/Orphan.cs is an orphan node', async () => {
+        await runAcceptanceStep(context, 'src/Orphan.cs is an orphan node', {
           keyword: 'And',
-          text: 'src/Program.cs points to src/Config.cs',
+          text: 'src/Orphan.cs is an orphan node',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 33
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:34
-      await test.step('And src/Program.cs points to src/Services/ApiService.cs', async () => {
-        await runAcceptanceStep(context, 'src/Program.cs points to src/Services/ApiService.cs', {
+      await test.step('And src/Services/BaseService.cs is an orphan node', async () => {
+        await runAcceptanceStep(context, 'src/Services/BaseService.cs is an orphan node', {
           keyword: 'And',
-          text: 'src/Program.cs points to src/Services/ApiService.cs',
+          text: 'src/Services/BaseService.cs is an orphan node',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 34
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:35
-      await test.step('And src/Program.cs points to src/Utils/Helpers.cs', async () => {
-        await runAcceptanceStep(context, 'src/Program.cs points to src/Utils/Helpers.cs', {
+      await test.step('And src/Utils/Formatter.cs is an orphan node', async () => {
+        await runAcceptanceStep(context, 'src/Utils/Formatter.cs is an orphan node', {
           keyword: 'And',
-          text: 'src/Program.cs points to src/Utils/Helpers.cs',
+          text: 'src/Utils/Formatter.cs is an orphan node',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 35
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:36
-      await test.step('And src/Utils/Helpers.cs points to src/Utils/Formatter.cs', async () => {
-        await runAcceptanceStep(context, 'src/Utils/Helpers.cs points to src/Utils/Formatter.cs', {
+      await test.step('And README.md is an orphan node', async () => {
+        await runAcceptanceStep(context, 'README.md is an orphan node', {
           keyword: 'And',
-          text: 'src/Utils/Helpers.cs points to src/Utils/Formatter.cs',
+          text: 'README.md is an orphan node',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 36
         });
       });
 
+      // tests/acceptance/specs/csharp-example.md:37
+      await test.step('And .gitignore is an orphan node', async () => {
+        await runAcceptanceStep(context, '.gitignore is an orphan node', {
+          keyword: 'And',
+          text: '.gitignore is an orphan node',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 37
+        });
+      });
+
       // tests/acceptance/specs/csharp-example.md:38
-      await test.step('Then I toggle the References edge off', async () => {
-        await runAcceptanceStep(context, 'I toggle the References edge off', {
-          keyword: 'Then',
-          text: 'I toggle the References edge off',
+      await test.step('And .vscode/settings.json is an orphan node', async () => {
+        await runAcceptanceStep(context, '.vscode/settings.json is an orphan node', {
+          keyword: 'And',
+          text: '.vscode/settings.json is an orphan node',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 38
         });
       });
 
-      // tests/acceptance/specs/csharp-example.md:39
-      await test.step('And I toggle the Inherits edge on', async () => {
-        await runAcceptanceStep(context, 'I toggle the Inherits edge on', {
-          keyword: 'And',
-          text: 'I toggle the Inherits edge on',
-          sourcePath: 'tests/acceptance/specs/csharp-example.md',
-          line: 39
-        });
-      });
-
       // tests/acceptance/specs/csharp-example.md:40
-      await test.step('Then I can see there are 11 nodes and 2 connections', async () => {
-        await runAcceptanceStep(context, 'I can see there are 11 nodes and 2 connections', {
+      await test.step('Then I show only the References edge type', async () => {
+        await runAcceptanceStep(context, 'I show only the References edge type', {
           keyword: 'Then',
-          text: 'I can see there are 11 nodes and 2 connections',
+          text: 'I show only the References edge type',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 40
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:41
-      await test.step('And src/Services/ApiService.cs points to src/Services/BaseService.cs', async () => {
-        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Services/BaseService.cs', {
-          keyword: 'And',
-          text: 'src/Services/ApiService.cs points to src/Services/BaseService.cs',
+      await test.step('Then I can see there are 13 nodes and 7 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 13 nodes and 7 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 13 nodes and 7 connections',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 41
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:42
-      await test.step('And src/Services/ApiService.cs points to src/Contracts/IRunner.cs', async () => {
-        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Contracts/IRunner.cs', {
+      await test.step('And src/Program.cs points to src/Config.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Config.cs', {
           keyword: 'And',
-          text: 'src/Services/ApiService.cs points to src/Contracts/IRunner.cs',
+          text: 'src/Program.cs points to src/Config.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 42
         });
       });
 
+      // tests/acceptance/specs/csharp-example.md:43
+      await test.step('And src/Program.cs points to src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'src/Program.cs points to src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 43
+        });
+      });
+
       // tests/acceptance/specs/csharp-example.md:44
-      await test.step('Then I toggle the Inherits edge off', async () => {
-        await runAcceptanceStep(context, 'I toggle the Inherits edge off', {
-          keyword: 'Then',
-          text: 'I toggle the Inherits edge off',
+      await test.step('And src/Program.cs points to src/Services/ApiService.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Services/ApiService.cs', {
+          keyword: 'And',
+          text: 'src/Program.cs points to src/Services/ApiService.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 44
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:45
-      await test.step('And I toggle the Calls edge on', async () => {
-        await runAcceptanceStep(context, 'I toggle the Calls edge on', {
+      await test.step('And src/Program.cs points to src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Utils/Helpers.cs', {
           keyword: 'And',
-          text: 'I toggle the Calls edge on',
+          text: 'src/Program.cs points to src/Utils/Helpers.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 45
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:46
-      await test.step('Then I can see there are 11 nodes and 5 connections', async () => {
-        await runAcceptanceStep(context, 'I can see there are 11 nodes and 5 connections', {
-          keyword: 'Then',
-          text: 'I can see there are 11 nodes and 5 connections',
+      await test.step('And src/Services/ApiService.cs points to src/Models/RunStatus.cs', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Models/RunStatus.cs', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Models/RunStatus.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 46
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:47
-      await test.step('And src/Program.cs points to src/Config.cs', async () => {
-        await runAcceptanceStep(context, 'src/Program.cs points to src/Config.cs', {
+      await test.step('And src/Services/ApiService.cs points to src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Utils/Helpers.cs', {
           keyword: 'And',
-          text: 'src/Program.cs points to src/Config.cs',
+          text: 'src/Services/ApiService.cs points to src/Utils/Helpers.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 47
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:48
-      await test.step('And src/Program.cs points to src/Services/ApiService.cs', async () => {
-        await runAcceptanceStep(context, 'src/Program.cs points to src/Services/ApiService.cs', {
+      await test.step('And src/Utils/Helpers.cs points to src/Utils/Formatter.cs', async () => {
+        await runAcceptanceStep(context, 'src/Utils/Helpers.cs points to src/Utils/Formatter.cs', {
           keyword: 'And',
-          text: 'src/Program.cs points to src/Services/ApiService.cs',
+          text: 'src/Utils/Helpers.cs points to src/Utils/Formatter.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 48
         });
       });
 
-      // tests/acceptance/specs/csharp-example.md:49
-      await test.step('And src/Program.cs points to src/Utils/Helpers.cs', async () => {
-        await runAcceptanceStep(context, 'src/Program.cs points to src/Utils/Helpers.cs', {
-          keyword: 'And',
-          text: 'src/Program.cs points to src/Utils/Helpers.cs',
-          sourcePath: 'tests/acceptance/specs/csharp-example.md',
-          line: 49
-        });
-      });
-
       // tests/acceptance/specs/csharp-example.md:50
-      await test.step('And src/Services/ApiService.cs points to src/Services/BaseService.cs', async () => {
-        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Services/BaseService.cs', {
-          keyword: 'And',
-          text: 'src/Services/ApiService.cs points to src/Services/BaseService.cs',
+      await test.step('Then I show only the Inherits edge type', async () => {
+        await runAcceptanceStep(context, 'I show only the Inherits edge type', {
+          keyword: 'Then',
+          text: 'I show only the Inherits edge type',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
           line: 50
         });
       });
 
       // tests/acceptance/specs/csharp-example.md:51
+      await test.step('Then I can see there are 13 nodes and 2 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 13 nodes and 2 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 13 nodes and 2 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 51
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:52
+      await test.step('And src/Services/ApiService.cs points to src/Services/BaseService.cs', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Services/BaseService.cs', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Services/BaseService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 52
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:53
+      await test.step('And src/Services/ApiService.cs points to src/Contracts/IRunner.cs', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Contracts/IRunner.cs', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Contracts/IRunner.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 53
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:55
+      await test.step('Then I show only the Calls edge type', async () => {
+        await runAcceptanceStep(context, 'I show only the Calls edge type', {
+          keyword: 'Then',
+          text: 'I show only the Calls edge type',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 55
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:56
+      await test.step('Then I can see there are 13 nodes and 7 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 13 nodes and 7 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 13 nodes and 7 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 56
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:57
+      await test.step('And src/Program.cs points to src/Config.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Config.cs', {
+          keyword: 'And',
+          text: 'src/Program.cs points to src/Config.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 57
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:58
+      await test.step('And src/Program.cs points to src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'src/Program.cs points to src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 58
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:59
+      await test.step('And src/Program.cs points to src/Services/ApiService.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Services/ApiService.cs', {
+          keyword: 'And',
+          text: 'src/Program.cs points to src/Services/ApiService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 59
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:60
+      await test.step('And src/Program.cs points to src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Utils/Helpers.cs', {
+          keyword: 'And',
+          text: 'src/Program.cs points to src/Utils/Helpers.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 60
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:61
+      await test.step('And src/Services/ApiService.cs points to src/Services/BaseService.cs', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Services/BaseService.cs', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Services/BaseService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 61
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:62
+      await test.step('And src/Services/ApiService.cs points to src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Utils/Helpers.cs', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Utils/Helpers.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 62
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:63
       await test.step('And src/Utils/Helpers.cs points to src/Utils/Formatter.cs', async () => {
         await runAcceptanceStep(context, 'src/Utils/Helpers.cs points to src/Utils/Formatter.cs', {
           keyword: 'And',
           text: 'src/Utils/Helpers.cs points to src/Utils/Formatter.cs',
           sourcePath: 'tests/acceptance/specs/csharp-example.md',
-          line: 51
+          line: 63
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:65
+      await test.step('Then I show only the Contains edge type', async () => {
+        await runAcceptanceStep(context, 'I show only the Contains edge type', {
+          keyword: 'Then',
+          text: 'I show only the Contains edge type',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 65
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:66
+      await test.step('Then I show only the File and Class node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File and Class node types', {
+          keyword: 'Then',
+          text: 'I show only the File and Class node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 66
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:67
+      await test.step('Then I can see there are 20 nodes and 7 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 20 nodes and 7 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 20 nodes and 7 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 67
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:68
+      await test.step('And the visible graph includes the Class node Program from src/Program.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Class node Program from src/Program.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Class node Program from src/Program.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 68
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:69
+      await test.step('And the visible graph includes the Class node Config from src/Config.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Class node Config from src/Config.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Class node Config from src/Config.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 69
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:70
+      await test.step('And the visible graph includes the Class node ApiService from src/Services/ApiService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Class node ApiService from src/Services/ApiService.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Class node ApiService from src/Services/ApiService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 70
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:71
+      await test.step('And the visible graph includes the Class node BaseService from src/Services/BaseService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Class node BaseService from src/Services/BaseService.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Class node BaseService from src/Services/BaseService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 71
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:72
+      await test.step('And the visible graph includes the Class node Helpers from src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Class node Helpers from src/Utils/Helpers.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Class node Helpers from src/Utils/Helpers.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 72
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:73
+      await test.step('And the visible graph includes the Class node Formatter from src/Utils/Formatter.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Class node Formatter from src/Utils/Formatter.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Class node Formatter from src/Utils/Formatter.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 73
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:75
+      await test.step('Then I show only the File and Interface node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File and Interface node types', {
+          keyword: 'Then',
+          text: 'I show only the File and Interface node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 75
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:76
+      await test.step('Then I can see there are 14 nodes and 1 connection', async () => {
+        await runAcceptanceStep(context, 'I can see there are 14 nodes and 1 connection', {
+          keyword: 'Then',
+          text: 'I can see there are 14 nodes and 1 connection',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 76
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:77
+      await test.step('And the visible graph includes the Interface node IRunner from src/Contracts/IRunner.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Interface node IRunner from src/Contracts/IRunner.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Interface node IRunner from src/Contracts/IRunner.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 77
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:79
+      await test.step('Then I show only the File and Struct node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File and Struct node types', {
+          keyword: 'Then',
+          text: 'I show only the File and Struct node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 79
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:80
+      await test.step('Then I can see there are 14 nodes and 1 connection', async () => {
+        await runAcceptanceStep(context, 'I can see there are 14 nodes and 1 connection', {
+          keyword: 'Then',
+          text: 'I can see there are 14 nodes and 1 connection',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 80
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:81
+      await test.step('And the visible graph includes the Struct node RunRequest from src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Struct node RunRequest from src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Struct node RunRequest from src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 81
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:83
+      await test.step('Then I show only the File and Enum node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File and Enum node types', {
+          keyword: 'Then',
+          text: 'I show only the File and Enum node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 83
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:84
+      await test.step('Then I can see there are 14 nodes and 1 connection', async () => {
+        await runAcceptanceStep(context, 'I can see there are 14 nodes and 1 connection', {
+          keyword: 'Then',
+          text: 'I can see there are 14 nodes and 1 connection',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 84
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:85
+      await test.step('And the visible graph includes the Enum node RunStatus from src/Models/RunStatus.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Enum node RunStatus from src/Models/RunStatus.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Enum node RunStatus from src/Models/RunStatus.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 85
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:87
+      await test.step('Then I show only the File and Function node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File and Function node types', {
+          keyword: 'Then',
+          text: 'I show only the File and Function node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 87
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:88
+      await test.step('Then I can see there are 22 nodes and 9 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 22 nodes and 9 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 22 nodes and 9 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 88
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:89
+      await test.step('And the visible graph includes the Function node Main from src/Program.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Function node Main from src/Program.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Function node Main from src/Program.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 89
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:90
+      await test.step('And the visible graph includes the Function node LoadConfig from src/Config.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Function node LoadConfig from src/Config.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Function node LoadConfig from src/Config.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 90
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:91
+      await test.step('And the visible graph includes the Function node Run from src/Services/ApiService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Function node Run from src/Services/ApiService.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Function node Run from src/Services/ApiService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 91
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:92
+      await test.step('And the visible graph includes the Function node Status from src/Services/BaseService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Function node Status from src/Services/BaseService.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Function node Status from src/Services/BaseService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 92
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:93
+      await test.step('And the visible graph includes the Function node FormatStatus from src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Function node FormatStatus from src/Utils/Helpers.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Function node FormatStatus from src/Utils/Helpers.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 93
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:94
+      await test.step('And the visible graph includes the Function node FormatOutput from src/Utils/Formatter.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Function node FormatOutput from src/Utils/Formatter.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Function node FormatOutput from src/Utils/Formatter.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 94
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:96
+      await test.step('Then I show only the File and Constant node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File and Constant node types', {
+          keyword: 'Then',
+          text: 'I show only the File and Constant node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 96
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:97
+      await test.step('Then I can see there are 15 nodes and 2 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 15 nodes and 2 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 15 nodes and 2 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 97
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:98
+      await test.step('And the visible graph includes the Constant node DefaultMaxItems from src/Config.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Constant node DefaultMaxItems from src/Config.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Constant node DefaultMaxItems from src/Config.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 98
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:99
+      await test.step('And the visible graph includes the Constant node DefaultName from src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Constant node DefaultName from src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Constant node DefaultName from src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 99
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:101
+      await test.step('Then I show only the File and Field node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File and Field node types', {
+          keyword: 'Then',
+          text: 'I show only the File and Field node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 101
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:102
+      await test.step('Then I can see there are 16 nodes and 3 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 16 nodes and 3 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 16 nodes and 3 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 102
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:103
+      await test.step('And the visible graph includes the Field node Name from src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Field node Name from src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Field node Name from src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 103
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:104
+      await test.step('And the visible graph includes the Field node MaxItems from src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Field node MaxItems from src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Field node MaxItems from src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 104
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:105
+      await test.step('And the visible graph includes the Field node serviceName from src/Services/ApiService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Field node serviceName from src/Services/ApiService.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Field node serviceName from src/Services/ApiService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 105
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:107
+      await test.step('Then I show only the File and Parameter node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File and Parameter node types', {
+          keyword: 'Then',
+          text: 'I show only the File and Parameter node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 107
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:108
+      await test.step('Then I can see there are 21 nodes and 8 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 21 nodes and 8 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 21 nodes and 8 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 108
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:109
+      await test.step('And the visible graph includes the Parameter node request from src/Contracts/IRunner.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Parameter node request from src/Contracts/IRunner.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Parameter node request from src/Contracts/IRunner.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 109
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:110
+      await test.step('And the visible graph includes the Parameter node name from src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Parameter node name from src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Parameter node name from src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 110
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:111
+      await test.step('And the visible graph includes the Parameter node maxItems from src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Parameter node maxItems from src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Parameter node maxItems from src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 111
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:112
+      await test.step('And the visible graph includes the Parameter node request from src/Services/ApiService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Parameter node request from src/Services/ApiService.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Parameter node request from src/Services/ApiService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 112
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:113
+      await test.step('And the visible graph includes the Parameter node currentStatus from src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Parameter node currentStatus from src/Utils/Helpers.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Parameter node currentStatus from src/Utils/Helpers.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 113
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:115
+      await test.step('Then I show only the File and Local node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File and Local node types', {
+          keyword: 'Then',
+          text: 'I show only the File and Local node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 115
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:116
+      await test.step('Then I can see there are 20 nodes and 7 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 20 nodes and 7 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 20 nodes and 7 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 116
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:117
+      await test.step('And the visible graph includes the Local node settings from src/Program.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Local node settings from src/Program.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Local node settings from src/Program.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 117
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:118
+      await test.step('And the visible graph includes the Local node service from src/Program.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Local node service from src/Program.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Local node service from src/Program.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 118
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:119
+      await test.step('And the visible graph includes the Local node request from src/Program.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Local node request from src/Program.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Local node request from src/Program.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 119
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:120
+      await test.step('And the visible graph includes the Local node currentStatus from src/Services/ApiService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Local node currentStatus from src/Services/ApiService.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Local node currentStatus from src/Services/ApiService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 120
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:121
+      await test.step('And the visible graph includes the Local node isRunnable from src/Services/ApiService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph includes the Local node isRunnable from src/Services/ApiService.cs', {
+          keyword: 'And',
+          text: 'the visible graph includes the Local node isRunnable from src/Services/ApiService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 121
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:123
+      await test.step('Then I show no edge types', async () => {
+        await runAcceptanceStep(context, 'I show no edge types', {
+          keyword: 'Then',
+          text: 'I show no edge types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 123
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:124
+      await test.step('Then I show only the File, Function, Class, Interface, Struct, Enum, Constant, Field, Parameter and Local node types', async () => {
+        await runAcceptanceStep(context, 'I show only the File, Function, Class, Interface, Struct, Enum, Constant, Field, Parameter and Local node types', {
+          keyword: 'Then',
+          text: 'I show only the File, Function, Class, Interface, Struct, Enum, Constant, Field, Parameter and Local node types',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 124
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:125
+      await test.step('Then I can see there are 52 nodes and 0 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 52 nodes and 0 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 52 nodes and 0 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 125
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:127
+      await test.step('When I toggle the Contains edge on', async () => {
+        await runAcceptanceStep(context, 'I toggle the Contains edge on', {
+          keyword: 'When',
+          text: 'I toggle the Contains edge on',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 127
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:128
+      await test.step('Then I can see there are 52 nodes and 39 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 52 nodes and 39 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 52 nodes and 39 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 128
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:129
+      await test.step('And src/Config.cs points to src/Config.cs#DefaultMaxItems:constant', async () => {
+        await runAcceptanceStep(context, 'src/Config.cs points to src/Config.cs#DefaultMaxItems:constant', {
+          keyword: 'And',
+          text: 'src/Config.cs points to src/Config.cs#DefaultMaxItems:constant',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 129
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:130
+      await test.step('And src/Models/RunRequest.cs points to src/Models/RunRequest.cs#RunRequest:struct', async () => {
+        await runAcceptanceStep(context, 'src/Models/RunRequest.cs points to src/Models/RunRequest.cs#RunRequest:struct', {
+          keyword: 'And',
+          text: 'src/Models/RunRequest.cs points to src/Models/RunRequest.cs#RunRequest:struct',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 130
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:131
+      await test.step('And src/Models/RunRequest.cs points to src/Models/RunRequest.cs#DefaultName:constant', async () => {
+        await runAcceptanceStep(context, 'src/Models/RunRequest.cs points to src/Models/RunRequest.cs#DefaultName:constant', {
+          keyword: 'And',
+          text: 'src/Models/RunRequest.cs points to src/Models/RunRequest.cs#DefaultName:constant',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 131
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:132
+      await test.step('And src/Models/RunRequest.cs points to src/Models/RunRequest.cs#Name:field', async () => {
+        await runAcceptanceStep(context, 'src/Models/RunRequest.cs points to src/Models/RunRequest.cs#Name:field', {
+          keyword: 'And',
+          text: 'src/Models/RunRequest.cs points to src/Models/RunRequest.cs#Name:field',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 132
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:133
+      await test.step('And src/Services/ApiService.cs points to src/Services/ApiService.cs#serviceName:field', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Services/ApiService.cs#serviceName:field', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Services/ApiService.cs#serviceName:field',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 133
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:134
+      await test.step('And src/Services/ApiService.cs points to src/Services/ApiService.cs#request:parameter', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Services/ApiService.cs#request:parameter', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Services/ApiService.cs#request:parameter',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 134
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:135
+      await test.step('And src/Services/ApiService.cs points to src/Services/ApiService.cs#currentStatus:local', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Services/ApiService.cs#currentStatus:local', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Services/ApiService.cs#currentStatus:local',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 135
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:136
+      await test.step('And src/Services/ApiService.cs points to src/Services/ApiService.cs#isRunnable:local', async () => {
+        await runAcceptanceStep(context, 'src/Services/ApiService.cs points to src/Services/ApiService.cs#isRunnable:local', {
+          keyword: 'And',
+          text: 'src/Services/ApiService.cs points to src/Services/ApiService.cs#isRunnable:local',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 136
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:138
+      await test.step('Then I show only the Calls edge type', async () => {
+        await runAcceptanceStep(context, 'I show only the Calls edge type', {
+          keyword: 'Then',
+          text: 'I show only the Calls edge type',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 138
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:139
+      await test.step('Then I can see there are 52 nodes and 7 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 52 nodes and 7 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 52 nodes and 7 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 139
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:140
+      await test.step('And the visible graph shows Main in src/Program.cs calling LoadConfig in src/Config.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph shows Main in src/Program.cs calling LoadConfig in src/Config.cs', {
+          keyword: 'And',
+          text: 'the visible graph shows Main in src/Program.cs calling LoadConfig in src/Config.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 140
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:141
+      await test.step('And the visible graph shows Main in src/Program.cs calling RunRequest in src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph shows Main in src/Program.cs calling RunRequest in src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'the visible graph shows Main in src/Program.cs calling RunRequest in src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 141
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:142
+      await test.step('And the visible graph shows Main in src/Program.cs calling FormatStatus in src/Utils/Helpers.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph shows Main in src/Program.cs calling FormatStatus in src/Utils/Helpers.cs', {
+          keyword: 'And',
+          text: 'the visible graph shows Main in src/Program.cs calling FormatStatus in src/Utils/Helpers.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 142
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:143
+      await test.step('And the visible graph shows Run in src/Services/ApiService.cs calling Status in src/Services/BaseService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph shows Run in src/Services/ApiService.cs calling Status in src/Services/BaseService.cs', {
+          keyword: 'And',
+          text: 'the visible graph shows Run in src/Services/ApiService.cs calling Status in src/Services/BaseService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 143
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:144
+      await test.step('And the visible graph shows FormatStatus in src/Utils/Helpers.cs calling FormatOutput in src/Utils/Formatter.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph shows FormatStatus in src/Utils/Helpers.cs calling FormatOutput in src/Utils/Formatter.cs', {
+          keyword: 'And',
+          text: 'the visible graph shows FormatStatus in src/Utils/Helpers.cs calling FormatOutput in src/Utils/Formatter.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 144
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:146
+      await test.step('Then I show only the Inherits edge type', async () => {
+        await runAcceptanceStep(context, 'I show only the Inherits edge type', {
+          keyword: 'Then',
+          text: 'I show only the Inherits edge type',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 146
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:147
+      await test.step('Then I can see there are 52 nodes and 2 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 52 nodes and 2 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 52 nodes and 2 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 147
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:148
+      await test.step('And the visible graph shows ApiService in src/Services/ApiService.cs inheriting from BaseService in src/Services/BaseService.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph shows ApiService in src/Services/ApiService.cs inheriting from BaseService in src/Services/BaseService.cs', {
+          keyword: 'And',
+          text: 'the visible graph shows ApiService in src/Services/ApiService.cs inheriting from BaseService in src/Services/BaseService.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 148
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:149
+      await test.step('And the visible graph shows ApiService in src/Services/ApiService.cs inheriting from IRunner in src/Contracts/IRunner.cs', async () => {
+        await runAcceptanceStep(context, 'the visible graph shows ApiService in src/Services/ApiService.cs inheriting from IRunner in src/Contracts/IRunner.cs', {
+          keyword: 'And',
+          text: 'the visible graph shows ApiService in src/Services/ApiService.cs inheriting from IRunner in src/Contracts/IRunner.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 149
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:151
+      await test.step('Then I show only the Imports edge type', async () => {
+        await runAcceptanceStep(context, 'I show only the Imports edge type', {
+          keyword: 'Then',
+          text: 'I show only the Imports edge type',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 151
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:152
+      await test.step('Then I can see there are 52 nodes and 6 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 52 nodes and 6 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 52 nodes and 6 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 152
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:153
+      await test.step('And src/Program.cs points to src/Models/RunRequest.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Models/RunRequest.cs', {
+          keyword: 'And',
+          text: 'src/Program.cs points to src/Models/RunRequest.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 153
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:155
+      await test.step('Then I show only the References edge type', async () => {
+        await runAcceptanceStep(context, 'I show only the References edge type', {
+          keyword: 'Then',
+          text: 'I show only the References edge type',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 155
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:156
+      await test.step('Then I can see there are 52 nodes and 7 connections', async () => {
+        await runAcceptanceStep(context, 'I can see there are 52 nodes and 7 connections', {
+          keyword: 'Then',
+          text: 'I can see there are 52 nodes and 7 connections',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 156
+        });
+      });
+
+      // tests/acceptance/specs/csharp-example.md:157
+      await test.step('And src/Program.cs points to src/Config.cs', async () => {
+        await runAcceptanceStep(context, 'src/Program.cs points to src/Config.cs', {
+          keyword: 'And',
+          text: 'src/Program.cs points to src/Config.cs',
+          sourcePath: 'tests/acceptance/specs/csharp-example.md',
+          line: 157
         });
       });
 


### PR DESCRIPTION
# Trello 201: C# Upgrade

## Current State

- State: pre-role alignment complete; dispatching Specifier for approved example and acceptance spec updates.
- Trello: [C# Upgrade](https://trello.com/c/rSYGlC3d), moved to In Progress on 2026-06-12.
- Branch: `codex/201-csharp-upgrade`
- Worktree: `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4`
- PR: [#276](https://github.com/joesobo/CodeGraphyV4/pull/276) draft.
- Next route: Specifier.

## Human Gates

- Human-owned acceptance spec Markdown under `packages/extension/tests/acceptance/specs/` must not be edited, created, renamed, deleted, or committed without explicit approval.
- This card asks to add or update the C# example acceptance spec only after the support contract is clear, so Specifier should prepare the acceptance shape and pause for approval before any spec Markdown change.
- VS Code Playwright acceptance and mutation work should run on `codegraphy-mini` unless the human explicitly approves local focus-stealing runs.

## Request

Start Trello card `https://trello.com/c/rSYGlC3d/201-c-upgrade`, then follow `docs/agents/codegraphy-loop.md`.

## Trello Card Summary

Goal: upgrade `examples/example-csharp` so C# feels like a real, focused CodeGraphy demo project and has acceptance coverage that proves visible graph behavior.

Important card requirements:

- Treat this as a support audit before fixture polish.
- Review official C# docs and the C# parser/plugin surface currently in use.
- Inventory current C# symbols, variables, and edges emitted by CodeGraphy.
- Compare that inventory to Graph Scope when opening `examples/example-csharp`.
- Separate capability gaps by generic Core Tree-sitter behavior, plugin-owned behavior, and out-of-scope language-specific semantics.
- Make `examples/example-csharp` a believable small project that intentionally demonstrates every visible supported C# node and edge toggle.
- Keep README/settings honest about current support and known limitations.
- Follow the C and C++ acceptance pattern, including toggle behavior and stable node/connection counts.
- Run focused analyzer/plugin tests, focused generated VS Code acceptance for `examples/example-csharp`, mutation for touched production files when required, and organize/typecheck/lint gates before review.

## Setup Context Read

- `AGENTS.md`
- `CONTEXT.md`
- `docs/agents/codegraphy-loop.md`
- `docs/agents/loops/orchestrator.md`
- `docs/agents/loops/specifier.md`
- `docs/agents/loops/coder.md`
- `docs/agents/loops/refactorer.md`
- `docs/agents/loops/architect.md`
- `docs/agents/acceptance-specs.md`
- `docs/agents/issue-tracker.md`
- `docs/agents/triage-labels.md`
- `docs/agents/domain.md`
- `packages/extension/tests/acceptance/README.md`
- `packages/extension/tests/acceptance/specs/csharp-example.md`
- `packages/extension/tests/acceptance/specs/c-example.md`
- `packages/extension/tests/acceptance/specs/cpp-example.md`
- `examples/example-csharp/README.md`
- `examples/example-csharp/src/**/*.cs`
- `packages/plugin-csharp/src/plugin.ts`
- `packages/plugin-csharp/tests/plugin.test.ts`
- `packages/plugin-csharp/codegraphy.json`
- `packages/plugin-csharp/README.md`
- repo search for C# analyzer and acceptance references

## Initial Observations

- The C# plugin is currently metadata-only: it contributes supported extensions, C# ecosystem default filters, and empty file colors. Core Tree-sitter Analysis owns baseline C# analysis.
- Core C# analysis lives under `packages/core/src/treeSitter/runtime/analyzeCSharp` with a C# workspace index under `packages/core/src/treeSitter/runtime/csharpIndex`.
- Existing C# acceptance coverage checks file nodes and file-level Imports, References, Inherits, and Calls edge toggles.
- The newer C and C++ acceptance specs include deeper Graph Scope coverage for language node types, Contains edges, symbol nodes, and stable counts. The current C# spec does not yet follow that richer shape.
- The current C# example README describes a small namespace/type-usage workspace and a symbol node demo, but the acceptance spec does not yet prove the symbol-node behavior described there.
- The protected main checkout had an existing modified generated acceptance file before this worktree was created. It was not touched by this loop setup.

## Event Log

### 2026-06-12T20:51:39Z - Orchestrator Setup

- Read loop, tracker, role, acceptance, domain, example, plugin, and nearby acceptance context.
- Fetched the Trello card and confirmed it had no comments.
- Moved the Trello card from Todo to In Progress.
- Created isolated worktree `/Users/poleski/.codex/worktrees/201-csharp-upgrade/CodeGraphyV4` on branch `codex/201-csharp-upgrade` from `origin/main`.
- Recorded setup context and human gates.
- Current blocker before first role dispatch: pre-role alignment is required because the card is language-support, acceptance-spec, and support-audit sensitive.

### 2026-06-12T20:55:00Z - Draft PR Published

- Pushed branch `codex/201-csharp-upgrade`.
- Opened draft PR [#276](https://github.com/joesobo/CodeGraphyV4/pull/276).
- Next action remains the pre-role alignment gate before dispatching Specifier.

### 2026-06-12T21:02:00Z - Alignment Scope Clarified

- Human decision: keep all C# upgrade work in this loop rather than spinning off the main C# support upgrades immediately.
- Ordered scope: first make `examples/example-csharp` look like expected C# support, matching expected Tree-sitter-supported nodes and edges; then make acceptance tests match that expected example.
- Implication for first route: Specifier should inventory the expected C# Tree-sitter node and edge capabilities, compare those to the current example, and draft the acceptance contract around the upgraded example shape before any human-owned spec Markdown is edited.

### 2026-06-12T21:08:00Z - Specifier Dispatch

- Dispatching Specifier with the clarified scope.
- Relevant current C# Core surface: `packages/core/src/treeSitter/runtime/analyzeCSharp` emits `class`, `interface`, `enum`, and `method` symbols plus Imports, References, Calls, and Inherits relations. The C# plugin is metadata-only.
- Specifier stopping condition: return an acceptance contract and example-shape plan, including whether human-owned `packages/extension/tests/acceptance/specs/csharp-example.md` needs an approved edit before Coder runs.

### 2026-06-12T21:40:00Z - Specifier Inventory And Contract

- Result: needs human acceptance before spec Markdown edits.
- Plan path: `docs/plans/201-csharp-upgrade-specifier-plan.md`.
- Inventory result:
  - Core Tree-sitter C# owns C# analysis; `packages/plugin-csharp` is metadata-only and contributes supported extension/default-filter settings only.
  - Current C# edge capability metadata advertises `Imports`, `References`, `Calls`, and `Inherits`.
  - Current C# symbol node capability metadata advertises `Function`, `Class`, `Interface`, `Struct`, and `Enum`.
  - C# method declarations are emitted with symbol kind `method`, but the product Graph Scope row for C# is `Function` because `symbol:function` matches both `function` and `method`. C# does not currently advertise the narrower `Method` node type.
  - Analyzer tests prove C# can emit class/interface/struct/enum/method symbols, resolved namespace `Imports`, uppercase type `References`, object/static/inherited `Calls`, and base-list `Inherits`.
- Example-shape plan:
  - Keep all C# upgrade work in this loop.
  - Reshape `examples/example-csharp` into a small file-scoped-namespace task-runner/service demo.
  - Add explicit struct and enum source files, likely `src/Models/RunRequest.cs` and `src/Models/RunStatus.cs`, so every advertised C# symbol node type is visible.
  - Keep representative classes/interfaces/methods: `Program`, `Config`, `ApiService`, `BaseService`, `IRunner`, `Helpers`, `Formatter`, and one intentional orphan class.
  - Keep file relationships deliberate: Program resolves/calls Config, ApiService, RunRequest/RunStatus, and Helpers; ApiService inherits BaseService and implements IRunner; Helpers calls Formatter; ApiService calls an inherited BaseService method.
  - Update README/settings honestly around Core Tree-sitter C# support and the metadata-only C# plugin.
- Acceptance contract:
  - Update `packages/extension/tests/acceptance/specs/csharp-example.md` only after human approval.
  - Follow the C/C++ pattern with one file-relationship scenario and one symbol-node scenario.
  - File scenario should assert available C# edge types, stable no-edge and per-edge counts, and representative file edges for Imports, References, Inherits, and Calls.
  - Symbol scenario should assert available C# node types are only Function, Class, Interface, Struct, and Enum; Method and Type should not be available for this C# example.
  - Symbol scenario should prove each supported C# symbol node type with visible graph assertions and use `Contains` to prove file-to-symbol projection.
  - Red-first gap to verify: if `Contains` is unavailable for the upgraded C# symbol scenario, Coder should add the smallest Core capability test/fix that exposes `Contains` consistently with C# symbol nodes.
- Acceptance impact scan:
  - Directly affected human-owned spec: `packages/extension/tests/acceptance/specs/csharp-example.md`.
  - Likely generated/tooling after approval: `packages/extension/tests/playwright-vscode/generated/acceptance.spec.ts`.
  - Potential fixture/docs edits: `examples/example-csharp/README.md`, `examples/example-csharp/src/**/*.cs`, `examples/example-csharp/.codegraphy/settings.json`, and `examples/README.md`.
  - Intentionally unaffected specs: `c-example.md`, `cpp-example.md`, and generic Graph Scope specs unless Coder changes shared Graph Scope capability behavior for `Contains`.
- Human approval status: required before editing human-owned acceptance spec Markdown.
- Open questions:
  - Should Orchestrator treat the approval already given in this thread ("then we make sure the acceptance tests match the expected example") as permission to edit `packages/extension/tests/acceptance/specs/csharp-example.md`, or pause for an explicit spec-Markdown approval because the loop docs require it?
  - Should Coder make the example source update first and return measured counts before the spec Markdown is edited, or should the approved spec draft lead with expected names and allow Coder to fill counts after the example is implemented?
- Exact files inspected are listed in `docs/plans/201-csharp-upgrade-specifier-plan.md`.

### 2026-06-12T21:55:00Z - Orchestrator Receives Specifier

- Verified Specifier commit `53c72492` on `origin/codex/201-csharp-upgrade`.
- Closed completed Specifier subagent.
- Routing to Coder for the first implementation slice:
  - update `examples/example-csharp` source/README/settings so the example visibly demonstrates expected current C# Tree-sitter-supported nodes and edges;
  - verify the red-first `Contains` capability gap and add the smallest Core test/fix if needed;
  - measure expected node/edge counts for the upgraded example.
- Human-owned acceptance spec Markdown remains gated until the upgraded example is measured and the proposed spec update is concrete.

### 2026-06-12T22:42:00Z - Coder Example And Core Capability Pass

- Result: behavior green for the Coder slice; ready for Orchestrator to approve or route the acceptance Markdown update.
- Updated `examples/example-csharp` into a small task-runner/service demo:
  - `Program.cs` calls `Config.LoadConfig()`, creates `ApiService`, creates a `RunRequest` struct, and formats the returned status through `Helpers`.
  - `ApiService.cs` inherits `BaseService`, implements `IRunner`, calls inherited `Status()`, calls `Helpers.IsRunnable(...)`, and references `RunStatus`.
  - Added `src/Models/RunRequest.cs` as the C# Struct target and `src/Models/RunStatus.cs` as the C# Enum target.
  - Kept `Orphan.cs` as an intentionally unrelated class.
  - Updated `examples/example-csharp/README.md` and `examples/README.md` to describe current Core Tree-sitter C# behavior and the metadata-only C# plugin boundary.
- Verified the red-first Core gap:
  - Added a focused failing test proving C# should advertise `Contains` when C# symbol node capabilities are available.
  - Red evidence before the fix: `packages/core/tests/treeSitter/capabilities.test.ts` failed because C# edge capabilities were `import`, `reference`, `call`, `inherit` and missed `contains`.
  - Smallest fix: added `contains` to the C# entry in `packages/core/src/treeSitter/runtime/capabilities.ts`.
- Measured upgraded example using local Core source APIs:
  - Default file graph after indexing `examples/example-csharp`: `13 files`, `13 nodes`, `22 edges`.
  - File-only Graph Scope slices with package/folder disabled:
    - no edges: `13 nodes / 0 edges`
    - Imports: `13 nodes / 6 edges`
    - References: `13 nodes / 7 edges`
    - Calls: `13 nodes / 7 edges`
    - Inherits: `13 nodes / 2 edges`
    - Contains: `13 nodes / 0 edges`
  - Representative file edges:
    - Imports: `Program.cs -> Models/RunRequest.cs`, `Program.cs -> Services/ApiService.cs`, `Program.cs -> Utils/Helpers.cs`, `ApiService.cs -> Contracts/IRunner.cs`, `ApiService.cs -> Models/RunStatus.cs`, `ApiService.cs -> Utils/Helpers.cs`.
    - References: `Program.cs -> Config.cs`, `Program.cs -> Models/RunRequest.cs`, `Program.cs -> Services/ApiService.cs`, `Program.cs -> Utils/Helpers.cs`, `ApiService.cs -> Models/RunStatus.cs`, `ApiService.cs -> Utils/Helpers.cs`, `Helpers.cs -> Formatter.cs`.
    - Calls: `Program.cs -> Config.cs`, `Program.cs -> Models/RunRequest.cs`, `Program.cs -> Services/ApiService.cs`, `Program.cs -> Utils/Helpers.cs`, `ApiService.cs -> Services/BaseService.cs`, `ApiService.cs -> Utils/Helpers.cs`, `Helpers.cs -> Formatter.cs`.
    - Inherits: `ApiService.cs -> Contracts/IRunner.cs`, `ApiService.cs -> Services/BaseService.cs`.
  - Symbol-projected graph with File plus C# Function/Class/Interface/Struct/Enum enabled: `32 nodes`, `41 edges`.
    - Symbols visible with no edges: `19` total, grouped as `7 class`, `9 method` under Function, `1 interface`, `1 struct`, `1 enum`.
    - Contains slice: `32 nodes / 19 edges`; representative edges include `Models/RunRequest.cs -> Models/RunRequest.cs#RunRequest:struct`, `Models/RunStatus.cs -> Models/RunStatus.cs#RunStatus:enum`, `Program.cs -> Program.cs#Main:method`, and `Services/ApiService.cs -> Services/ApiService.cs#Run:method`.
    - Calls slice with symbols enabled: `32 nodes / 7 edges`; representative symbol edges include `Program.cs#Main:method -> Config.cs#LoadConfig:method`, `Program.cs#Main:method -> Models/RunRequest.cs#RunRequest:struct`, `ApiService.cs#Run:method -> Services/BaseService.cs#Status:method`, and `Helpers.cs#FormatStatus:method -> Formatter.cs#FormatOutput:method`.
- Verification:
  - `pnpm test tests/treeSitter/csharp/analyze.test.ts tests/treeSitter/csharpIndex.test.ts tests/treeSitter/capabilities.test.ts` from `packages/core`: passed, `18 tests`.
  - `pnpm --filter @codegraphy-dev/core lint`: passed.
  - `pnpm --filter @codegraphy-dev/core typecheck`: passed.
  - `pnpm run check:acceptance-specs`: passed; no human-owned acceptance spec Markdown edited.
  - `git diff --check`: passed.
- Notes for Orchestrator:
  - Acceptance Markdown is still gated by the human-owned spec rule. The next acceptance update should use the measured file counts for file-edge scenarios and measured symbol-projected counts for symbol/Contains scenarios.
  - This pass changes user-facing Core Graph Scope capability behavior for C# by advertising `Contains`; a changeset may be needed in a later loop role if release policy applies to this PR.

### 2026-06-12T22:48:00Z - Orchestrator Receives Coder And Enters Human Gate

- Verified Coder commit `e1ea6b0c` on `origin/codex/201-csharp-upgrade`.
- Closed completed Coder subagent.
- Moved Trello card to Review while waiting for human approval to edit human-owned acceptance spec Markdown.
- Approval needed: edit `packages/extension/tests/acceptance/specs/csharp-example.md` so the C# acceptance spec matches the upgraded `examples/example-csharp` example and the measured counts recorded above, then regenerate generated acceptance output.

### 2026-06-13T00:00:00Z - Orchestrator Process Correction

- Human correction: the Orchestrator routed to Coder too early. The loop contract should be executed as a contract, not treated as guidance.
- Correct current state: human review is for the Specifier acceptance contract and proposed `packages/extension/tests/acceptance/specs/csharp-example.md` modifications.
- The acceptance spec Markdown has not been edited yet. The Coder example/Core pass is premature downstream work and should be treated as available evidence, not as permission to skip the Specifier approval gate.
- No further Coder, Refactorer, or Architect routing should happen until the human approves or revises the Specifier acceptance contract.
- After approval, route back to Specifier to apply the approved acceptance spec Markdown change, then route forward through Coder again because downstream Coder state is stale relative to the approved acceptance contract.

### 2026-06-13T00:10:00Z - Orchestrator Process Correction 2

- Human correction: the loop requires completing `grill-with-docs` before the first role dispatch.
- Reread `docs/agents/codegraphy-loop.md`, `docs/agents/loops/orchestrator.md`, `docs/agents/loops/specifier.md`, and `docs/agents/acceptance-specs.md`.
- Correct current state: the pre-role alignment gate was not completed. The loop is not at Specifier human review yet.
- Correct sequence from here:
  1. Orchestrator finishes the docs-backed alignment grill, one question at a time, until scope, acceptance shape, human gates, and first route are clear.
  2. After the alignment gate passes, Orchestrator dispatches Specifier.
  3. Specifier owns drafting and applying approved acceptance spec Markdown changes when the human has explicitly approved that exact spec change during/after alignment.
  4. Human reviews the Specifier acceptance-test modifications.
  5. Only after that review passes does Orchestrator route to Coder.
- Existing Specifier and Coder commits are downstream artifacts from premature routing. Treat them as stale evidence until the proper alignment and Specifier pass decide whether to keep, revise, or replace them.

### 2026-06-13T00:20:00Z - Alignment Grill: Acceptance Scenario Shape

- Human decision: C# should use one acceptance scenario, matching the C++ acceptance-test style, rather than separate file and symbol scenarios.
- Acceptance scope should cover everything expected for C# with Tree-sitter in one scenario: all supported symbols, variables, and edges.
- Example-shape decision: `examples/example-csharp` should be built as a clean demo for every feature the C# Tree-sitter support covers, not a syntax museum.
- Orchestrator read `packages/extension/tests/acceptance/specs/cpp-example.md` to ground the shape. The C++ pattern is one scenario that checks available edge rows, available node/variable rows, individual row counts, combined symbol graph counts, and representative edge assertions.
- Current uncertainty for the next grill question: existing C# capability metadata advertises symbols (`Function`, `Class`, `Interface`, `Struct`, `Enum`) and edges (`Imports`, `References`, `Calls`, `Contains`, `Inherits` after the premature Coder pass), but it does not currently advertise variable rows such as `Field`, `Parameter`, `Local`, `Global`, or `Constant`.

### 2026-06-13T00:28:00Z - Alignment Grill: C# Variable Scope

- Human decision: this loop should include C# Tree-sitter variable node support so the C# acceptance scenario covers variables as well as symbols and edges, following the C++ acceptance style.
- Aligned baseline: C# should cover `Field`, `Parameter`, and `Local` if Core can emit them cleanly from Tree-sitter.
- Human decision: C# should include `Constant` in this loop, but narrowly for explicit C# `const` declarations that Tree-sitter can identify cleanly.
- Human decision: keep `Global` out of C# for now because C# does not have the same clean global-variable model as C/C++.

### 2026-06-15T00:00:00Z - Alignment Gate Complete

- Human decision: alignment gate is complete.
- Approved Specifier scope:
  - update `examples/example-csharp` based on the grill decisions;
  - update `packages/extension/tests/acceptance/specs/csharp-example.md` to test all agreed C# Tree-sitter features using the example as the base;
  - shape the acceptance spec as one C++-style scenario;
  - cover C# symbols `Function`, `Class`, `Interface`, `Struct`, `Enum`;
  - cover C# variables `Field`, `Parameter`, `Local`, and narrow `Constant`;
  - cover C# edges `Imports`, `References`, `Calls`, `Contains`, `Inherits`;
  - keep `Global` out of C#.
- Human review gate after Specifier: the human will review and approve the example plus acceptance-test modifications before Orchestrator routes to Coder.
- Existing premature Specifier/Coder commits may be reused as evidence or revised by the new Specifier pass, but downstream role approval remains stale until this proper Specifier pass completes and receives human review.
