### PR TITLE
224 Display CSS snippets section

### DIFF
--- a/.changeset/display-css-snippets-section.md
+++ b/.changeset/display-css-snippets-section.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Show the CSS Snippets section in the Themes panel even when no snippets are configured.

--- a/docs/handoff/224-display-css-snippets-section.md
+++ b/docs/handoff/224-display-css-snippets-section.md
@@ -1,0 +1,36 @@
+# 224 Display CSS Snippets Section
+
+## Public State
+
+- Trello: https://trello.com/c/3biGolNd, already in `In Progress` on setup.
+- Branch: `codex/224-display-css-snippets-section`
+- Worktree: `/Users/poleski/.codex/worktrees/9679/CodeGraphyV4`
+- Draft PR: https://github.com/joesobo/CodeGraphyV4/pull/279
+- Setup commit: `0ab53fd8a` (`chore: set up css snippets section workstream`)
+
+## Context Read
+
+- `AGENTS.md`
+- `CONTEXT.md`
+- `docs/agents/issue-tracker.md`
+- `docs/agents/triage-labels.md`
+- `docs/agents/domain.md`
+- `docs/agents/acceptance-specs.md`
+- `docs/adr/0001-typescript-project-resolution-belongs-to-plugin-analysis.md`
+- Trello card `3biGolNd`
+- `packages/extension/src/webview/components/legends/panel/cssSnippets.tsx`
+- `packages/extension/src/webview/components/legends/panel/view.tsx`
+
+`docs/agents/codegraphy-loop.md` was requested but is not present in this worktree.
+
+## Human-Owned Boundaries
+
+- No acceptance spec Markdown was created, edited, renamed, or deleted.
+
+## TDD Evidence
+
+- Red: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts packages/extension/tests/webview/components/legends/panel/cssSnippets.test.tsx`
+  - Failed because no accessible `CSS Snippets` button rendered for an empty snippet map.
+- Green: same targeted test passed after rendering the section for empty snippets.
+- Regression: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts packages/extension/tests/webview/components/legends/panel/cssSnippets.test.tsx packages/extension/tests/extension/graphView/webview/settingsMessages/cssSnippets.test.ts packages/extension/tests/extension/graphView/webview/messages/legends.test.ts`
+  - 3 files, 9 tests passed.

--- a/packages/extension/src/webview/components/legends/panel/cssSnippets.tsx
+++ b/packages/extension/src/webview/components/legends/panel/cssSnippets.tsx
@@ -45,9 +45,6 @@ export function CssSnippetsSection({
   });
   const open = !collapsed;
   const entries = Object.entries(snippets);
-  if (entries.length === 0) {
-    return null;
-  }
 
   return (
     <Collapsible open={open} onOpenChange={onOpenChange}>
@@ -69,7 +66,14 @@ export function CssSnippetsSection({
             className="overflow-hidden rounded-md border border-[var(--cg-border-subtle)] bg-[var(--cg-surface-subtle)] divide-y divide-[var(--cg-divider-subtle)]"
             data-codegraphy-list="css-snippets"
           >
-            {entries.map(([path, enabled]) => (
+            {entries.length === 0 ? (
+              <div
+                className="px-3 py-2 text-xs text-[var(--cg-text-muted)]"
+                data-codegraphy-row="css-snippet-empty"
+              >
+                No CSS snippets configured
+              </div>
+            ) : entries.map(([path, enabled]) => (
               <div
                 key={path}
                 className="flex items-center gap-3 px-3 py-2 transition-colors hover:bg-[var(--cg-accent-subtle)]"

--- a/packages/extension/tests/webview/components/legends/panel/cssSnippets.test.tsx
+++ b/packages/extension/tests/webview/components/legends/panel/cssSnippets.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CssSnippetsSection } from '../../../../../src/webview/components/legends/panel/cssSnippets';
+
+vi.mock('../../../../../src/webview/vscodeApi', () => ({
+  postMessage: vi.fn(),
+}));
+
+describe('CssSnippetsSection', () => {
+  it('renders the section when no snippets are configured', () => {
+    render(
+      <CssSnippetsSection
+        collapsedEntries={{}}
+        onCollapsedChange={vi.fn()}
+        snippets={{}}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'CSS Snippets' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Keeps the Themes panel CSS Snippets section visible even when no CSS snippets are configured.
- Shows a compact empty state in the section body for empty snippet maps.
- Adds a focused webview component test, a patch changeset, and a handoff note for Trello card 224.

## Trello

https://trello.com/c/3biGolNd/224-display-css-snippets-section-no-matter-if-there-are-no-setting-snippets

## Verification

- Red: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts packages/extension/tests/webview/components/legends/panel/cssSnippets.test.tsx` failed because no accessible `CSS Snippets` button rendered for an empty snippet map.
- Green: same targeted test passed after the component change.
- Regression: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts packages/extension/tests/webview/components/legends/panel/cssSnippets.test.tsx packages/extension/tests/extension/graphView/webview/settingsMessages/cssSnippets.test.ts packages/extension/tests/extension/graphView/webview/messages/legends.test.ts` passed, 3 files / 9 tests.
- Full: `pnpm run test` passed, including 13 unit package tasks and 72/72 Playwright VS Code tests.
- Pre-commit: acceptance spec ownership guard, typecheck, and lint passed.

## Notes

- No human-owned acceptance spec Markdown was edited.
- `docs/agents/codegraphy-loop.md` was requested in setup but is not present in this worktree; setup and TDD evidence are recorded in `docs/handoff/224-display-css-snippets-section.md`.