### PR TITLE
[codex] Add CSS snippet UI input

### DIFF
--- a/.changeset/silent-snippets-add.md
+++ b/.changeset/silent-snippets-add.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Add a Themes panel input for adding CodeGraphy CSS snippet paths.

--- a/packages/extension/src/webview/components/legends/panel/cssSnippets.tsx
+++ b/packages/extension/src/webview/components/legends/panel/cssSnippets.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
-import { mdiChevronDown, mdiChevronUp } from '@mdi/js';
+import React, { useState } from 'react';
+import { mdiChevronDown, mdiChevronUp, mdiPlus } from '@mdi/js';
 import { graphStore } from '../../../store/state';
 import { postMessage } from '../../../vscodeApi';
 import { MdiIcon } from '../../icons/MdiIcon';
+import { Button } from '../../ui/button';
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '../../ui/disclosure/collapsible';
+import { Input } from '../../ui/input';
 import { Switch } from '../../ui/switch';
 import { useCollapsibleEntryState } from './section/collapseState';
 
@@ -33,11 +35,17 @@ function postCssSnippetToggle(path: string, enabled: boolean): void {
   });
 }
 
+function addCssSnippet(path: string): void {
+  setCssSnippetEnabled(path, true);
+  postCssSnippetToggle(path, true);
+}
+
 export function CssSnippetsSection({
   collapsedEntries,
   onCollapsedChange,
   snippets,
 }: CssSnippetsSectionProps): React.ReactElement | null {
+  const [draftPath, setDraftPath] = useState('');
   const { collapsed, onOpenChange } = useCollapsibleEntryState({
     collapsedEntries,
     onCollapsedChange,
@@ -45,9 +53,7 @@ export function CssSnippetsSection({
   });
   const open = !collapsed;
   const entries = Object.entries(snippets);
-  if (entries.length === 0) {
-    return null;
-  }
+  const trimmedDraftPath = draftPath.trim();
 
   return (
     <Collapsible open={open} onOpenChange={onOpenChange}>
@@ -65,29 +71,70 @@ export function CssSnippetsSection({
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div
-            className="overflow-hidden rounded-md border border-[var(--cg-border-subtle)] bg-[var(--cg-surface-subtle)] divide-y divide-[var(--cg-divider-subtle)]"
-            data-codegraphy-list="css-snippets"
-          >
-            {entries.map(([path, enabled]) => (
-              <div
-                key={path}
-                className="flex items-center gap-3 px-3 py-2 transition-colors hover:bg-[var(--cg-accent-subtle)]"
-                data-codegraphy-row="css-snippet"
+          <div className="space-y-2">
+            <div
+              className="flex items-center gap-2 rounded-md border border-[var(--cg-border-subtle)] bg-[var(--cg-surface-subtle)] px-3 py-2"
+            >
+              <Input
+                aria-label="CSS snippet path"
+                className="h-7 min-w-0 border-0 bg-transparent px-0 text-xs shadow-none focus-visible:ring-0"
+                placeholder=".codegraphy/snippets/custom.css"
+                value={draftPath}
+                onChange={(event) => setDraftPath(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key !== 'Enter' || !trimmedDraftPath) {
+                    return;
+                  }
+
+                  event.preventDefault();
+                  addCssSnippet(trimmedDraftPath);
+                  setDraftPath('');
+                }}
+              />
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-7 w-7 shrink-0 border-[var(--cg-border-subtle)] bg-[var(--cg-surface-subtle)] p-0 text-muted-foreground hover:bg-[var(--cg-accent-subtle)] hover:text-foreground"
+                disabled={!trimmedDraftPath}
+                onClick={() => {
+                  if (!trimmedDraftPath) {
+                    return;
+                  }
+
+                  addCssSnippet(trimmedDraftPath);
+                  setDraftPath('');
+                }}
+                title="Add CSS snippet"
               >
-                <span className="min-w-0 flex-1 truncate text-xs font-medium" title={path}>
-                  {path}
-                </span>
-                <Switch
-                  aria-label={`Toggle ${path}`}
-                  checked={enabled}
-                  onCheckedChange={(nextEnabled) => {
-                    setCssSnippetEnabled(path, nextEnabled);
-                    postCssSnippetToggle(path, nextEnabled);
-                  }}
-                />
+                <MdiIcon path={mdiPlus} size={14} />
+              </Button>
+            </div>
+            {entries.length > 0 ? (
+              <div
+                className="overflow-hidden rounded-md border border-[var(--cg-border-subtle)] bg-[var(--cg-surface-subtle)] divide-y divide-[var(--cg-divider-subtle)]"
+                data-codegraphy-list="css-snippets"
+              >
+                {entries.map(([path, enabled]) => (
+                  <div
+                    key={path}
+                    className="flex items-center gap-3 px-3 py-2 transition-colors hover:bg-[var(--cg-accent-subtle)]"
+                    data-codegraphy-row="css-snippet"
+                  >
+                    <span className="min-w-0 flex-1 truncate text-xs font-medium" title={path}>
+                      {path}
+                    </span>
+                    <Switch
+                      aria-label={`Toggle ${path}`}
+                      checked={enabled}
+                      onCheckedChange={(nextEnabled) => {
+                        setCssSnippetEnabled(path, nextEnabled);
+                        postCssSnippetToggle(path, nextEnabled);
+                      }}
+                    />
+                  </div>
+                ))}
               </div>
-            ))}
+            ) : null}
           </div>
         </CollapsibleContent>
       </section>

--- a/packages/extension/tests/webview/legends/panel/view.test.tsx
+++ b/packages/extension/tests/webview/legends/panel/view.test.tsx
@@ -347,6 +347,34 @@ describe('LegendsPanel', () => {
     });
   });
 
+  it('adds a CSS snippet path from the themes panel', () => {
+    sentMessages.length = 0;
+    graphStore.setState({
+      graphNodeTypes: [],
+      graphEdgeTypes: [],
+      nodeColors: {},
+      legends: [],
+      cssSnippets: {},
+    });
+
+    render(<LegendsPanel isOpen={true} onClose={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText('CSS snippet path'), {
+      target: { value: '  .codegraphy/snippets/ocean.css  ' },
+    });
+    fireEvent.click(screen.getByTitle('Add CSS snippet'));
+
+    expect(graphStore.getState().cssSnippets['.codegraphy/snippets/ocean.css']).toBe(true);
+    expect(sentMessages.at(-1)).toEqual({
+      type: 'UPDATE_CSS_SNIPPET',
+      payload: {
+        path: '.codegraphy/snippets/ocean.css',
+        enabled: true,
+      },
+    });
+    expect(screen.getByLabelText('CSS snippet path')).toHaveValue('');
+  });
+
   it('shows plugin default legend rules without exposing delete controls', () => {
     graphStore.setState({
       graphNodeTypes: [{ id: 'file', label: 'Files', defaultColor: '#111111', defaultVisible: true }],


### PR DESCRIPTION
## Summary
- Adds a CSS snippet path input to the Themes panel so users can register a new CodeGraphy CSS snippet without editing settings by hand.
- Keeps the existing CSS snippet toggle list and optimistic update flow.
- Adds a patch changeset for the extension package.

Trello: https://trello.com/c/T44wb0wQ/225-add-someway-of-ui-inputtting-new-css-snippets

## Verification
- Red first: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/legends/panel/view.test.tsx` failed because `CSS snippet path` was missing.
- Green: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/webview/legends/panel/view.test.tsx`
- Green: `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/webview/settingsMessages/cssSnippets.test.ts`
- Green: `pnpm --filter @codegraphy-dev/extension typecheck`
- Green with existing generated Playwright spacing warnings: `pnpm --filter @codegraphy-dev/extension lint`
- Green: `pnpm --filter @codegraphy-dev/extension build:webview`
- Green pre-commit hook: acceptance spec ownership guard and repo `turbo run typecheck` passed before commit `f27c9dd08`.
- Live UI verification: opened built webview harness at `http://127.0.0.1:4173`, opened Themes, confirmed CSS Snippets shows `CSS snippet path` input and `Add CSS snippet`, added `.codegraphy/snippets/ocean.css`, confirmed the input cleared and the new row appeared.

## Notes
- `docs/agents/codegraphy-loop.md` is absent in this checkout; setup used the available repo workflow docs listed in AGENTS.md.
