### PR TITLE
Fix unsafe Graph View file names

### DIFF
--- a/.changeset/safe-graph-view-file-names.md
+++ b/.changeset/safe-graph-view-file-names.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Graph View file and folder creation now supports safe nested relative paths, such as `a/b/c/d.ts`, while create and rename prompts reject names that could escape or move outside the selected folder.

--- a/packages/extension/src/extension/actions/createFile.ts
+++ b/packages/extension/src/extension/actions/createFile.ts
@@ -12,6 +12,7 @@ import { IUndoableAction } from '../undoManager';
  */
 export class CreateFileAction implements IUndoableAction {
   readonly description: string;
+  private _createdParentPaths: string[] = [];
 
   /**
    * Creates a new CreateFileAction.
@@ -29,6 +30,16 @@ export class CreateFileAction implements IUndoableAction {
 
   async execute(): Promise<void> {
     const fileUri = vscode.Uri.joinPath(this._workspaceFolder, this._path);
+    const parentPath = this._path.split('/').slice(0, -1).join('/');
+    if (parentPath) {
+      this._createdParentPaths = await collectMissingParentPaths(
+        this._workspaceFolder,
+        parentPath
+      );
+      await vscode.workspace.fs.createDirectory(
+        vscode.Uri.joinPath(this._workspaceFolder, parentPath)
+      );
+    }
     await vscode.workspace.fs.writeFile(fileUri, new Uint8Array());
 
     // Open the new file in editor
@@ -52,6 +63,41 @@ export class CreateFileAction implements IUndoableAction {
 
     // Delete to trash for safety
     await vscode.workspace.fs.delete(fileUri, { useTrash: true });
+    await deleteCreatedParentDirectories(this._workspaceFolder, this._createdParentPaths);
     await this._refreshGraph();
+  }
+}
+
+async function collectMissingParentPaths(
+  workspaceFolder: vscode.Uri,
+  parentPath: string
+): Promise<string[]> {
+  const missingPaths: string[] = [];
+  const segments = parentPath.split('/');
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const path = segments.slice(0, index + 1).join('/');
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.joinPath(workspaceFolder, path));
+    } catch {
+      missingPaths.push(path);
+    }
+  }
+
+  return missingPaths;
+}
+
+async function deleteCreatedParentDirectories(
+  workspaceFolder: vscode.Uri,
+  createdParentPaths: readonly string[]
+): Promise<void> {
+  for (const parentPath of [...createdParentPaths].reverse()) {
+    const parentUri = vscode.Uri.joinPath(workspaceFolder, parentPath);
+    const entries = await vscode.workspace.fs.readDirectory(parentUri);
+    if (entries.length > 0) {
+      break;
+    }
+
+    await vscode.workspace.fs.delete(parentUri, { recursive: false, useTrash: true });
   }
 }

--- a/packages/extension/src/extension/graphView/files/actions.ts
+++ b/packages/extension/src/extension/graphView/files/actions.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { isSafeGraphViewChildPath } from './validation';
 
 interface GraphViewWorkspaceFolderRef {
   uri: vscode.Uri;
@@ -61,7 +62,11 @@ export async function createGraphViewFile(
     placeHolder: 'newfile.ts',
     ignoreFocusOut: true,
   });
-  if (!fileName) return undefined;
+  if (fileName === undefined) return undefined;
+  if (!isSafeGraphViewChildPath(fileName)) {
+    handlers.showErrorMessage('Enter a relative file path inside this folder.');
+    return undefined;
+  }
 
   const filePath = directory === '.' ? fileName : `${directory}/${fileName}`;
 
@@ -85,7 +90,11 @@ export async function createGraphViewFolder(
     placeHolder: 'new-folder',
     ignoreFocusOut: true,
   });
-  if (!folderName) return undefined;
+  if (folderName === undefined) return undefined;
+  if (!isSafeGraphViewChildPath(folderName)) {
+    handlers.showErrorMessage('Enter a relative folder path inside this folder.');
+    return undefined;
+  }
 
   const folderPath = directory === '.' ? folderName : `${directory}/${folderName}`;
 

--- a/packages/extension/src/extension/graphView/files/rename.ts
+++ b/packages/extension/src/extension/graphView/files/rename.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { isSafeGraphViewBasename } from './validation';
 
 interface GraphViewWorkspaceFolderRef {
   uri: vscode.Uri;
@@ -31,7 +32,11 @@ export async function renameGraphViewFile(
     ignoreFocusOut: true,
   });
 
-  if (!newName || newName === oldName) return;
+  if (newName === undefined || newName === oldName) return;
+  if (!isSafeGraphViewBasename(newName)) {
+    handlers.showErrorMessage('Enter a file name without folder separators.');
+    return;
+  }
 
   const newPath = filePath.replace(/[^/]+$/, newName);
 

--- a/packages/extension/src/extension/graphView/files/validation.ts
+++ b/packages/extension/src/extension/graphView/files/validation.ts
@@ -1,0 +1,17 @@
+export function isSafeGraphViewChildPath(input: string): boolean {
+  const value = input.trim();
+  if (!value || value.startsWith('/') || value.includes('\\') || /^[A-Za-z]:($|\/)/.test(value)) {
+    return false;
+  }
+
+  return value.split('/').every(isSafePathSegment);
+}
+
+export function isSafeGraphViewBasename(input: string): boolean {
+  const value = input.trim();
+  return isSafePathSegment(value) && !value.includes('/') && !value.includes('\\');
+}
+
+function isSafePathSegment(segment: string): boolean {
+  return Boolean(segment) && segment !== '.' && segment !== '..';
+}

--- a/packages/extension/tests/extension/actions/createFile.test.ts
+++ b/packages/extension/tests/extension/actions/createFile.test.ts
@@ -5,8 +5,11 @@ import { CreateFileAction } from '../../../src/extension/actions/createFile';
 vi.mock('vscode', () => ({
   workspace: {
     fs: {
+      createDirectory: vi.fn().mockResolvedValue(undefined),
       writeFile: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),
+      readDirectory: vi.fn().mockResolvedValue([]),
+      stat: vi.fn().mockResolvedValue({}),
     },
     openTextDocument: vi.fn(),
   },
@@ -32,6 +35,12 @@ describe('CreateFileAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRefreshGraph = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(vscode.workspace.fs.readDirectory).mockResolvedValue([]);
+    vi.mocked(vscode.workspace.fs.stat).mockResolvedValue({} as vscode.FileStat);
+    vi.mocked(vscode.Uri.joinPath).mockImplementation((base: { fsPath: string }, ...pathSegments: string[]) => ({
+      fsPath: `${base.fsPath}/${pathSegments.join('/')}`,
+      toString: () => `file://${base.fsPath}/${pathSegments.join('/')}`,
+    }) as vscode.Uri);
 
     const mockDocument = {
       uri: { toString: () => 'file:///workspace/src/new.ts' },
@@ -69,6 +78,33 @@ describe('CreateFileAction', () => {
         expect.objectContaining({ fsPath: '/workspace/src/new.ts' }),
         expect.any(Uint8Array)
       );
+    });
+
+    it('creates parent directories before creating a nested file', async () => {
+      vi.mocked(vscode.workspace.fs.stat).mockRejectedValue(new Error('missing'));
+      const action = new CreateFileAction(
+        'test/a/b/c/d.ts',
+        mockWorkspaceFolder,
+        mockRefreshGraph,
+      );
+
+      await action.execute();
+
+      expect(vscode.workspace.fs.createDirectory).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: '/workspace/test/a/b/c' }),
+      );
+      expect(vscode.workspace.fs.writeFile).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: '/workspace/test/a/b/c/d.ts' }),
+        expect.any(Uint8Array),
+      );
+    });
+
+    it('does not create a parent directory for root-level files', async () => {
+      const action = new CreateFileAction('index.ts', mockWorkspaceFolder, mockRefreshGraph);
+
+      await action.execute();
+
+      expect(vscode.workspace.fs.createDirectory).not.toHaveBeenCalled();
     });
 
     it('writes an empty file', async () => {
@@ -154,6 +190,79 @@ describe('CreateFileAction', () => {
 
       expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith('workbench.action.closeActiveEditor');
       expect(vscode.workspace.fs.delete).toHaveBeenCalledOnce();
+    });
+
+    it('removes created parent directories when undoing a nested file create', async () => {
+      vi.mocked(vscode.workspace.fs.stat).mockImplementation(async (uri: vscode.Uri) => {
+        if (uri.fsPath === '/workspace/test') {
+          return {} as vscode.FileStat;
+        }
+
+        throw new Error('missing');
+      });
+
+      const action = new CreateFileAction(
+        'test/a/b/c/d.ts',
+        mockWorkspaceFolder,
+        mockRefreshGraph,
+      );
+
+      await action.execute();
+      vi.mocked(vscode.workspace.fs.delete).mockClear();
+      mockRefreshGraph.mockClear();
+
+      await action.undo();
+
+      expect(vscode.workspace.fs.delete).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ fsPath: '/workspace/test/a/b/c/d.ts' }),
+        { useTrash: true },
+      );
+      expect(vscode.workspace.fs.delete).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ fsPath: '/workspace/test/a/b/c' }),
+        { recursive: false, useTrash: true },
+      );
+      expect(vscode.workspace.fs.delete).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ fsPath: '/workspace/test/a/b' }),
+        { recursive: false, useTrash: true },
+      );
+      expect(vscode.workspace.fs.delete).toHaveBeenNthCalledWith(
+        4,
+        expect.objectContaining({ fsPath: '/workspace/test/a' }),
+        { recursive: false, useTrash: true },
+      );
+      expect(vscode.workspace.fs.delete).toHaveBeenCalledTimes(4);
+      expect(mockRefreshGraph).toHaveBeenCalledOnce();
+    });
+
+    it('keeps created parent directories that are no longer empty on undo', async () => {
+      vi.mocked(vscode.workspace.fs.stat).mockRejectedValue(new Error('missing'));
+      vi.mocked(vscode.workspace.fs.readDirectory).mockImplementation(async (uri: vscode.Uri) => {
+        if (uri.fsPath === '/workspace/test/a/b/c') {
+          return [['later.ts', 1 as vscode.FileType]];
+        }
+
+        return [];
+      });
+
+      const action = new CreateFileAction(
+        'test/a/b/c/d.ts',
+        mockWorkspaceFolder,
+        mockRefreshGraph,
+      );
+
+      await action.execute();
+      vi.mocked(vscode.workspace.fs.delete).mockClear();
+
+      await action.undo();
+
+      expect(vscode.workspace.fs.delete).toHaveBeenCalledOnce();
+      expect(vscode.workspace.fs.delete).toHaveBeenCalledWith(
+        expect.objectContaining({ fsPath: '/workspace/test/a/b/c/d.ts' }),
+        { useTrash: true },
+      );
     });
   });
 });

--- a/packages/extension/tests/extension/graphView/files/actions.test.ts
+++ b/packages/extension/tests/extension/graphView/files/actions.test.ts
@@ -117,6 +117,49 @@ describe('graphView/files/actions', () => {
     );
   });
 
+  it('creates nested files below the selected directory', async () => {
+    const executeCreateAction = vi.fn(async () => undefined);
+
+    await createGraphViewFile('test', {
+      workspaceFolder: { uri: vscode.Uri.file('/workspace') },
+      showInputBox: vi.fn(async () => 'a/b/c/d.ts'),
+      executeCreateAction,
+      showErrorMessage: vi.fn(),
+    });
+
+    expect(executeCreateAction).toHaveBeenCalledWith(
+      'test/a/b/c/d.ts',
+      vscode.Uri.file('/workspace'),
+    );
+  });
+
+  it.each([
+    ['../outside.ts'],
+    ['components/../outside.ts'],
+    ['/absolute.ts'],
+    ['C:/outside.ts'],
+    ['nested//file.ts'],
+    ['nested/'],
+    ['nested\\file.ts'],
+    ['.'],
+    ['..'],
+    [''],
+    ['   '],
+  ])('rejects unsafe file names from the create prompt: %j', async (fileName) => {
+    const executeCreateAction = vi.fn(async () => undefined);
+    const showErrorMessage = vi.fn();
+
+    await createGraphViewFile('src', {
+      workspaceFolder: { uri: vscode.Uri.file('/workspace') },
+      showInputBox: vi.fn(async () => fileName),
+      executeCreateAction,
+      showErrorMessage,
+    });
+
+    expect(executeCreateAction).not.toHaveBeenCalled();
+    expect(showErrorMessage).toHaveBeenCalledWith('Enter a relative file path inside this folder.');
+  });
+
   it('creates the folder selected in the input box', async () => {
     const executeCreateFolderAction = vi.fn(async () => undefined);
     const showInputBox = vi.fn(async () => 'components');
@@ -137,6 +180,49 @@ describe('graphView/files/actions', () => {
       'src/components',
       vscode.Uri.file('/workspace'),
     );
+  });
+
+  it('creates nested folders below the selected directory', async () => {
+    const executeCreateFolderAction = vi.fn(async () => undefined);
+
+    await createGraphViewFolder('src', {
+      workspaceFolder: { uri: vscode.Uri.file('/workspace') },
+      showInputBox: vi.fn(async () => 'components/forms'),
+      executeCreateFolderAction,
+      showErrorMessage: vi.fn(),
+    });
+
+    expect(executeCreateFolderAction).toHaveBeenCalledWith(
+      'src/components/forms',
+      vscode.Uri.file('/workspace'),
+    );
+  });
+
+  it.each([
+    ['../outside'],
+    ['components/../outside'],
+    ['/absolute'],
+    ['C:/outside'],
+    ['nested//folder'],
+    ['nested/'],
+    ['nested\\folder'],
+    ['.'],
+    ['..'],
+    [''],
+    ['   '],
+  ])('rejects unsafe folder names from the create prompt: %j', async (folderName) => {
+    const executeCreateFolderAction = vi.fn(async () => undefined);
+    const showErrorMessage = vi.fn();
+
+    await createGraphViewFolder('src', {
+      workspaceFolder: { uri: vscode.Uri.file('/workspace') },
+      showInputBox: vi.fn(async () => folderName),
+      executeCreateFolderAction,
+      showErrorMessage,
+    });
+
+    expect(executeCreateFolderAction).not.toHaveBeenCalled();
+    expect(showErrorMessage).toHaveBeenCalledWith('Enter a relative folder path inside this folder.');
   });
 
   it('returns before prompting when no workspace folder is available for create', async () => {

--- a/packages/extension/tests/extension/graphView/files/rename.test.ts
+++ b/packages/extension/tests/extension/graphView/files/rename.test.ts
@@ -59,6 +59,47 @@ describe('graphView/files/rename', () => {
     });
   });
 
+  it('allows renaming to a hidden filename', async () => {
+    const executeRenameAction = vi.fn(async () => undefined);
+
+    await renameGraphViewFile('src/config.ts', {
+      workspaceFolder: { uri: vscode.Uri.file('/workspace') },
+      showInputBox: vi.fn(async () => '.env.local'),
+      executeRenameAction,
+      showErrorMessage: vi.fn(),
+    });
+
+    expect(executeRenameAction).toHaveBeenCalledWith(
+      'src/config.ts',
+      'src/.env.local',
+      vscode.Uri.file('/workspace'),
+    );
+  });
+
+  it.each([
+    ['../outside.ts'],
+    ['nested/file.ts'],
+    ['nested\\file.ts'],
+    ['C:/outside.ts'],
+    ['.'],
+    ['..'],
+    [''],
+    ['   '],
+  ])('rejects unsafe names from the rename prompt: %j', async (newName) => {
+    const executeRenameAction = vi.fn(async () => undefined);
+    const showErrorMessage = vi.fn();
+
+    await renameGraphViewFile('src/original.ts', {
+      workspaceFolder: { uri: vscode.Uri.file('/workspace') },
+      showInputBox: vi.fn(async () => newName),
+      executeRenameAction,
+      showErrorMessage,
+    });
+
+    expect(executeRenameAction).not.toHaveBeenCalled();
+    expect(showErrorMessage).toHaveBeenCalledWith('Enter a file name without folder separators.');
+  });
+
   it('does not rename when the user keeps the original name', async () => {
     const executeRenameAction = vi.fn(async () => undefined);
 

--- a/packages/extension/tests/extension/graphView/files/validation.test.ts
+++ b/packages/extension/tests/extension/graphView/files/validation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSafeGraphViewBasename,
+  isSafeGraphViewChildPath,
+} from '../../../../src/extension/graphView/files/validation';
+
+describe('graphView/files/validation', () => {
+  it.each(['newfile.ts', '.env.local', 'components/Button.tsx', 'components/forms/Input.tsx'])(
+    'accepts safe child paths: %j',
+    (input) => {
+      expect(isSafeGraphViewChildPath(input)).toBe(true);
+    },
+  );
+
+  it.each([
+    '../outside.ts',
+    'components/../outside.ts',
+    '/absolute.ts',
+    'C:/outside.ts',
+    'nested//file.ts',
+    'nested/',
+    'nested\\file.ts',
+    '.',
+    '..',
+    '',
+    '   ',
+  ])('rejects unsafe child paths: %j', (input) => {
+    expect(isSafeGraphViewChildPath(input)).toBe(false);
+  });
+
+  it.each(['renamed.ts', '.env.local'])('accepts safe basenames: %j', (input) => {
+    expect(isSafeGraphViewBasename(input)).toBe(true);
+  });
+
+  it.each(['../outside.ts', 'nested/file.ts', 'nested\\file.ts', 'C:/outside.ts', '.', '..', '', '   '])(
+    'rejects unsafe basenames: %j',
+    (input) => {
+      expect(isSafeGraphViewBasename(input)).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Reject unsafe Graph View create/rename prompt inputs before they reach workspace file actions
- Allow safe nested relative paths for Graph View create file/folder prompts
- Create parent directories before writing nested files
- Keep rename basename-only so rename cannot silently move a file

Trello: https://trello.com/c/6330Vt0C/198-bug-graph-view-create-and-rename-should-reject-unsafe-names

## Verification
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/files/actions.test.ts tests/extension/graphView/files/rename.test.ts tests/extension/graphView/files/validation.test.ts tests/extension/actions/createFile.test.ts
- pnpm --filter @codegraphy-dev/extension test
- pnpm --filter @codegraphy-dev/extension lint
- pnpm --filter @codegraphy-dev/extension typecheck
- pre-commit: pnpm run check:acceptance-specs, pnpm run typecheck, lint-staged eslint --fix

## Notes
- No human-owned acceptance spec Markdown was edited.
- Extension lint currently reports generated Playwright spacing warnings, but exits successfully with 0 errors.
