### PR TITLE
Clarify New Folder support from folder nodes

### DIFF
--- a/docs/INTERACTIONS.md
+++ b/docs/INTERACTIONS.md
@@ -38,6 +38,7 @@ Right-click background, nodes, multi-node selections, or edges to access context
 | Delete | Move file(s) to trash | Yes |
 | Rename | Rename file via inline prompt | Yes |
 | Create File | Create a new file in the same directory | Yes |
+| Create Folder | Create a new folder in the selected Folder Node or workspace root | Yes |
 | Toggle Favorite | Mark or unmark with yellow outline | Yes |
 | Add to Filter | Hide from graph via filter pattern | Yes |
 | Copy Source/Target/Both Paths (edge) | Copy connected file paths from an edge | - |
@@ -127,7 +128,7 @@ The timeline bar appears below the graph after indexing. See [Timeline](./TIMELI
 | Click node | Select and focus the node; File Nodes open a temporary preview at the selected commit |
 | Double-click node | Select and focus the node; File Nodes open the file at the selected commit as a persistent editor tab |
 
-During timeline mode, destructive context menu actions (Delete, Rename, Create File, Add to Filter) are hidden.
+During timeline mode, destructive context menu actions (Delete, Rename, Create File, Create Folder, Add to Filter) are hidden.
 
 ## Export
 

--- a/docs/TIMELINE.md
+++ b/docs/TIMELINE.md
@@ -50,7 +50,7 @@ Double-clicking a File Node opens that file at the selected commit as a persiste
 
 ## Context menu
 
-During timeline mode, destructive file actions (Delete, Rename, Create File, Add to Filter) are hidden from the context menu. Non-destructive actions (Open File, Reveal in Explorer, Copy Path, Toggle Favorite) remain available.
+During timeline mode, destructive file actions (Delete, Rename, Create File, Create Folder, Add to Filter) are hidden from the context menu. Non-destructive actions (Open File, Reveal in Explorer, Copy Path, Toggle Favorite) remain available.
 
 ## Refreshing
 

--- a/packages/extension/tests/webview/graph/contextMenu/node/view/folderActions.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/node/view/folderActions.test.tsx
@@ -49,4 +49,18 @@ describe('Graph node context menu folder actions', () => {
     });
     expect(findMessage('DELETE_FILES')?.payload.paths).toEqual(['src']);
   });
+
+  it('posts New Folder messages with the folder path', async () => {
+    await openNodeMenu(folderData, 'src');
+    await waitFor(() => {
+      expect(screen.getByText('New Folder')).toBeInTheDocument();
+    });
+
+    clearSentMessages();
+    await act(async () => {
+      fireEvent.click(screen.getByText('New Folder'));
+    });
+
+    expect(findMessage('CREATE_FOLDER')?.payload.directory).toBe('src');
+  });
 });


### PR DESCRIPTION
## Summary
- Verified Folder Node context menus already expose New Folder support and route it through existing graph mutation handling.
- Added a focused webview regression that clicks New Folder from a Folder Node and asserts the CREATE_FOLDER directory payload.
- Clarified interaction and timeline docs so Create Folder is documented with other undoable and timeline-hidden mutation actions.

## Verification
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts packages/extension/tests/webview/graph/contextMenu/node/view/folderActions.test.tsx packages/extension/tests/webview/graph/contextMenu/node/folderEntries.test.ts packages/extension/tests/webview/graph/contextActions/builders.test.ts packages/extension/tests/extension/graphView/webview/nodeFile/edit.test.ts
- pnpm --filter @codegraphy-dev/extension test
- pre-commit: pnpm run check:acceptance-specs, pnpm run typecheck, lint-staged

Trello: https://trello.com/c/midfO8au/226-add-or-clarify-new-folder-support-from-folder-nodes