### PR TITLE
Fix main mutation seed CI

### DIFF
--- a/packages/extension/tests/acceptance/cucumber/generator.test.ts
+++ b/packages/extension/tests/acceptance/cucumber/generator.test.ts
@@ -5,6 +5,18 @@ import { CUCUMBER_STEPS_PATH, formatCucumberSteps } from './generator';
 
 describe('Cucumber editor step declarations', () => {
   it('are generated from the executable acceptance step registry', () => {
-    expect(fs.readFileSync(CUCUMBER_STEPS_PATH, 'utf8')).toBe(formatCucumberSteps(acceptanceStepExpressions));
+    const currentContent = stripStrykerTsNoCheckPrefix(fs.readFileSync(CUCUMBER_STEPS_PATH, 'utf8'));
+
+    expect(currentContent).toBe(formatCucumberSteps(acceptanceStepExpressions));
+  });
+
+  it('ignores Stryker mutation instrumentation in generated step declarations', () => {
+    const generatedContent = formatCucumberSteps(acceptanceStepExpressions);
+
+    expect(stripStrykerTsNoCheckPrefix(`// @ts-nocheck\n${generatedContent}`)).toBe(generatedContent);
   });
 });
+
+function stripStrykerTsNoCheckPrefix(content: string): string {
+  return content.replace(/^\/\/ @ts-nocheck\r?\n/, '');
+}


### PR DESCRIPTION
## Summary
- tolerate Stryker's injected `// @ts-nocheck` prefix when the Cucumber generated-step freshness test runs under mutation instrumentation
- keep the generated step declarations themselves lintable and TypeScript-checked

## Verification
- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/acceptance/cucumber/generator.test.ts`
- `pnpm --filter @codegraphy-dev/extension run typecheck`
- `pnpm --filter @codegraphy-dev/extension run lint`
- pre-commit: `pnpm run typecheck` + lint-staged