### PR TITLE
Stop auto-running mutation seed on main pushes

### DIFF
--- a/.github/workflows/mutation-seed.yml
+++ b/.github/workflows/mutation-seed.yml
@@ -1,8 +1,6 @@
 name: Mutation Seed
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- remove the automatic `push` trigger from the Mutation Seed workflow
- keep `workflow_dispatch` so mutation seed refreshes can still be run intentionally

## Verification
- `git diff --check`
- inspected `.github/workflows/ci.yml` and confirmed normal CI does not invoke mutation tests