### PR TITLE
[codex] Fix fresh sidebar graph discovery

### DIFF
--- a/.changeset/fresh-sidebar-discovery.md
+++ b/.changeset/fresh-sidebar-discovery.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Fix fresh workspace startup in the CodeGraphy sidebar so opening the graph requests initial workspace discovery immediately. Non-indexed workspaces can show useful file and folder structure before the user runs Index Workspace, while explicit indexing still adds relationship edges and writes the Graph Cache.

--- a/packages/extension/src/extension/graphView/provider/webview/resolve.ts
+++ b/packages/extension/src/extension/graphView/provider/webview/resolve.ts
@@ -1,4 +1,5 @@
 import type * as vscode from 'vscode';
+import type { IGraphData } from '../../../../shared/graph/contracts';
 import type { GraphViewProviderWebviewMethodDependencies } from './defaultDependencies';
 import type { GraphViewProviderSidebarViewSource } from './sidebarViews';
 import {
@@ -10,8 +11,36 @@ import {
 
 export interface GraphViewProviderWebviewResolveSource extends GraphViewProviderSidebarViewSource {
   _extensionUri: vscode.Uri;
+  _analysisController?: AbortController;
+  _graphData?: IGraphData;
+  _webviewReadyNotified?: boolean;
   _getLocalResourceRoots(): vscode.Uri[];
+  _loadAndSendData?(): Promise<void>;
   flushPendingWorkspaceRefresh?(): void;
+}
+
+function shouldRequestInitialGraphData(
+  source: GraphViewProviderWebviewResolveSource,
+): boolean {
+  return source._loadAndSendData !== undefined
+    && !source._webviewReadyNotified
+    && source._analysisController === undefined
+    && (source._graphData?.nodes.length ?? 0) === 0
+    && (source._graphData?.edges.length ?? 0) === 0;
+}
+
+function requestInitialGraphDataAfterResolve(
+  source: GraphViewProviderWebviewResolveSource,
+): void {
+  setTimeout(() => {
+    if (!shouldRequestInitialGraphData(source)) {
+      return;
+    }
+
+    void source._loadAndSendData?.().catch(error => {
+      console.warn('[CodeGraphy] Failed to load graph data after resolving graph view.', error);
+    });
+  }, 0);
 }
 
 export function resolveGraphViewProviderWebviewView(
@@ -51,5 +80,8 @@ export function resolveGraphViewProviderWebviewView(
     executeCommand: (command: string, key: string, value: boolean) =>
       dependencies.executeCommand(command, key, value),
   } as never);
+  if (viewKind === 'graph') {
+    requestInitialGraphDataAfterResolve(source);
+  }
   maybeFlushPendingWorkspaceRefresh(source, webviewView, viewKind);
 }

--- a/packages/extension/tests/extension/graphView/provider/webview/resolve.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/webview/resolve.test.ts
@@ -111,6 +111,77 @@ describe('graphView/provider/webview/resolve', () => {
     expect(source._timelineView).toBe(webviewView);
   });
 
+  it('requests initial graph data when the graph sidebar resolves without active analysis', async () => {
+    const webview = {
+      options: {},
+      html: '',
+    } as unknown as vscode.Webview;
+    const webviewView = {
+      viewType: 'codegraphy.graphView',
+      webview,
+      visible: true,
+      onDidChangeVisibility: vi.fn(() => undefined),
+      onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
+    } as unknown as vscode.WebviewView;
+    const resolveWebviewView = vi.fn((_view, options) => {
+      options.getHtml(webview);
+    });
+    const source = {
+      _extensionUri: vscode.Uri.file('/test/extension'),
+      _view: undefined,
+      _timelineView: undefined,
+      _analysisController: undefined,
+      _graphData: { nodes: [], edges: [] },
+      _webviewReadyNotified: false,
+      _getLocalResourceRoots: vi.fn(() => []),
+      _loadAndSendData: vi.fn(async () => undefined),
+      flushPendingWorkspaceRefresh: vi.fn(),
+    };
+
+    resolveGraphViewProviderWebviewView(source as never, {
+      createHtml: vi.fn(() => '<graph html />'),
+      executeCommand: vi.fn(() => Promise.resolve(undefined)),
+      resolveWebviewView,
+      setWebviewMessageListener: vi.fn(),
+    }, webviewView);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(source._loadAndSendData).toHaveBeenCalledOnce();
+  });
+
+  it('does not request fallback graph data when webview ready already started analysis', async () => {
+    const webviewView = {
+      viewType: 'codegraphy.graphView',
+      webview: {},
+      visible: true,
+      onDidChangeVisibility: vi.fn(() => undefined),
+      onDidDispose: vi.fn(() => ({ dispose: vi.fn() })),
+    } as unknown as vscode.WebviewView;
+    const source = {
+      _extensionUri: vscode.Uri.file('/test/extension'),
+      _view: undefined,
+      _timelineView: undefined,
+      _analysisController: new AbortController(),
+      _graphData: { nodes: [], edges: [] },
+      _webviewReadyNotified: false,
+      _getLocalResourceRoots: vi.fn(() => []),
+      _loadAndSendData: vi.fn(async () => undefined),
+      flushPendingWorkspaceRefresh: vi.fn(),
+    };
+
+    resolveGraphViewProviderWebviewView(source as never, {
+      createHtml: vi.fn(() => '<graph html />'),
+      executeCommand: vi.fn(() => Promise.resolve(undefined)),
+      resolveWebviewView: vi.fn(),
+      setWebviewMessageListener: vi.fn(),
+    }, webviewView);
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(source._loadAndSendData).not.toHaveBeenCalled();
+  });
+
   it('keeps a different timeline view attached when the graph view disposes', () => {
     let disposeListener: (() => void) | undefined;
     const resourceRoots = [vscode.Uri.file('/test/root')];


### PR DESCRIPTION
## Summary

Fixes Trello #253: Fresh workspaces should open properly in the CodeGraphy sidebar.

Fresh, non-indexed workspaces can currently open the sidebar at `0 nodes / 0 connections` even though the same workspace can show file nodes through Open in Editor, reload, or explicit reindex. This change adds a guarded sidebar-resolve fallback that requests initial graph data when the graph sidebar resolves empty and no webview-ready analysis is already in progress.

The normal `WEBVIEW_READY` load path remains the primary path. The fallback only runs when the graph sidebar is still empty and idle, so it does not duplicate loads once webview-ready analysis starts.

## User Impact

New users opening CodeGraphy in the sidebar on a fresh workspace should get useful file/folder discovery before they know about Index Workspace. Explicit indexing still hydrates relationship edges and writes the Graph Cache.

## Tests

- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/provider/webview/resolve.test.ts tests/extension/graphViewProvider.fileInfo.test.ts`
- `pnpm --filter @codegraphy-dev/extension run lint`
- `pnpm --filter @codegraphy-dev/extension run typecheck`
- `pnpm --filter @codegraphy-dev/extension test`
- Commit hook: acceptance spec guard, root typecheck, lint-staged

## Notes

Live Trello read confirmed card #253 at https://trello.com/c/Kyfu6wUm is in `In Progress` and matches the fallback card content used for the TDD pass.
