### PR TITLE
Stabilize mutation seed dry runs

### DIFF
--- a/packages/core/tests/plugins/packageRuntime.test.ts
+++ b/packages/core/tests/plugins/packageRuntime.test.ts
@@ -14,6 +14,12 @@ async function createWorkspace(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-workspace-'));
 }
 
+async function createPackageFixtureRoot(prefix: string): Promise<string> {
+  const root = path.join(process.cwd(), 'node_modules', '.cache', 'codegraphy-test-packages');
+  await fs.mkdir(root, { recursive: true });
+  return fs.mkdtemp(path.join(root, prefix));
+}
+
 async function createPluginPackage(packageRoot: string): Promise<void> {
   await fs.mkdir(packageRoot, { recursive: true });
   await fs.writeFile(
@@ -127,7 +133,7 @@ describe('CodeGraphy package runtime', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-home-'));
     const packageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-package-')),
+      await createPackageFixtureRoot('codegraphy-package-runtime-package-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-data-host',
@@ -178,7 +184,7 @@ describe('CodeGraphy package runtime', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-home-'));
     const packageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-package-')),
+      await createPackageFixtureRoot('codegraphy-package-runtime-package-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-disabled-runtime',
@@ -222,13 +228,13 @@ describe('CodeGraphy package runtime', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-home-'));
     const packageRootOne = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-package-')),
+      await createPackageFixtureRoot('codegraphy-package-runtime-package-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-vue-one',
     );
     const packageRootTwo = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-package-')),
+      await createPackageFixtureRoot('codegraphy-package-runtime-package-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-vue-two',
@@ -297,13 +303,13 @@ describe('CodeGraphy package runtime', () => {
     const packageName = '@acme/codegraphy-plugin-bundled-runtime';
     const pluginId = 'acme.bundled-runtime';
     const stalePackageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-package-')),
+      await createPackageFixtureRoot('codegraphy-package-runtime-package-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-bundled-runtime',
     );
     const bundledPackageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-bundled-')),
+      await createPackageFixtureRoot('codegraphy-package-runtime-bundled-'),
       'codegraphy-plugin-bundled-runtime',
     );
 
@@ -346,6 +352,9 @@ describe('CodeGraphy package runtime', () => {
       settings: readCodeGraphyWorkspaceSettings(workspaceRoot),
       homeDir,
       workspaceRoot,
+      warn: message => {
+        throw new Error(message);
+      },
     });
 
     expect(loadedPlugin?.bundled).toBe(true);
@@ -357,7 +366,7 @@ describe('CodeGraphy package runtime', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-home-'));
     const packageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-package-runtime-package-')),
+      await createPackageFixtureRoot('codegraphy-package-runtime-package-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-id-mismatch',

--- a/packages/extension/tests/extension/graphView/webview/providerMessages/listener.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/providerMessages/listener.test.ts
@@ -546,7 +546,7 @@ describe('graph view provider listener bridge', () => {
     expect(execute).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'reset-settings' }),
     );
-  });
+  }, 15_000);
 
   it('does not enumerate proposed workspace getters while building default dependencies', async () => {
     vi.resetModules();

--- a/packages/extension/tests/extension/pipeline/plugins/bootstrap.test.ts
+++ b/packages/extension/tests/extension/pipeline/plugins/bootstrap.test.ts
@@ -32,6 +32,12 @@ async function createWorkspace(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-bootstrap-'));
 }
 
+async function createPackageFixtureRoot(prefix: string): Promise<string> {
+  const root = path.join(process.cwd(), 'node_modules', '.cache', 'codegraphy-test-packages');
+  await fs.mkdir(root, { recursive: true });
+  return fs.mkdtemp(path.join(root, prefix));
+}
+
 async function createPluginPackage(packageRoot: string): Promise<void> {
   await fs.mkdir(packageRoot, { recursive: true });
   await fs.writeFile(
@@ -344,7 +350,7 @@ describe('pipeline/plugins/bootstrap', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-home-'));
     const packageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-global-')),
+      await createPackageFixtureRoot('codegraphy-extension-global-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-extension-bootstrap',
@@ -404,13 +410,13 @@ describe('pipeline/plugins/bootstrap', () => {
     const packageName = '@acme/codegraphy-plugin-bundled';
     const pluginId = 'acme.bundled';
     const stalePackageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-global-')),
+      await createPackageFixtureRoot('codegraphy-extension-global-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-bundled',
     );
     const bundledPackageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-bundled-')),
+      await createPackageFixtureRoot('codegraphy-extension-bundled-'),
       'codegraphy-plugin-bundled',
     );
 
@@ -450,6 +456,9 @@ describe('pipeline/plugins/bootstrap', () => {
       bundledPluginPackageRoots: [bundledPackageRoot],
       getWorkspaceRoot: () => workspaceRoot,
       userHomeDir: homeDir,
+      warn: message => {
+        throw new Error(message);
+      },
     });
 
     const bundledRegistration = registry.register.mock.calls.find(
@@ -477,7 +486,7 @@ describe('pipeline/plugins/bootstrap', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-home-'));
     const packageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-global-')),
+      await createPackageFixtureRoot('codegraphy-extension-global-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-extension-bootstrap',
@@ -536,7 +545,7 @@ describe('pipeline/plugins/bootstrap', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-home-'));
     const packageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-global-')),
+      await createPackageFixtureRoot('codegraphy-extension-global-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-extension-bootstrap',
@@ -575,7 +584,7 @@ describe('pipeline/plugins/bootstrap', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-home-'));
     const packageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-global-')),
+      await createPackageFixtureRoot('codegraphy-extension-global-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-extension-data-host',
@@ -650,7 +659,7 @@ describe('pipeline/plugins/bootstrap', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-home-'));
     const packageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-global-')),
+      await createPackageFixtureRoot('codegraphy-extension-global-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-extension-bootstrap',
@@ -734,7 +743,7 @@ describe('pipeline/plugins/bootstrap', () => {
     const workspaceRoot = await createWorkspace();
     const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-home-'));
     const packageRoot = path.join(
-      await fs.mkdtemp(path.join(os.tmpdir(), 'codegraphy-extension-global-')),
+      await createPackageFixtureRoot('codegraphy-extension-global-'),
       'node_modules',
       '@acme',
       'codegraphy-plugin-extension-bootstrap',


### PR DESCRIPTION
## Summary
- keep dynamically imported plugin package fixtures inside the worktree cache so Stryker sandboxed dry runs can resolve them
- make bundled-plugin tests fail loudly on swallowed package-load warnings
- give the mock-heavy undo dependency bridge test a focused timeout for instrumented mutation dry runs

## Verification
- pnpm --filter @codegraphy-dev/core exec vitest run --config vitest.config.ts tests/plugins/packageRuntime.test.ts
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/pipeline/plugins/bootstrap.test.ts
- pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/webview/providerMessages/listener.test.ts -t "wires the default undo-execution dependency"
- pnpm run lint
- pre-commit typecheck
- mutation seed dry-run reached "Initial test run succeeded" for core/core, extension/host-platform-core-shared, extension/host-indexing, extension/host-graphview-model, extension/host-graphview-provider; local runs were stopped after dry-run success to avoid multi-hour full seed refreshes