### PR TITLE
refactor: consolidate type guards, validate JSON boundaries with zod, remove duplicated micro-helpers

### DIFF
--- a/packages/core/src/graphCache/database/records/values.ts
+++ b/packages/core/src/graphCache/database/records/values.ts
@@ -1,3 +1,5 @@
+import { nonEmptyStringSchema, stringValueSchema } from '../../../values';
+
 export function parseOptionalJson<T>(value: unknown): T | undefined {
   if (typeof value !== 'string' || value.length === 0) {
     return undefined;
@@ -8,15 +10,13 @@ export function parseOptionalJson<T>(value: unknown): T | undefined {
 }
 
 export function readOptionalString(value: unknown): string | undefined {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-
-  return value.length > 0 ? value : undefined;
+  const parsed = nonEmptyStringSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 export function readRequiredString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined;
+  const parsed = stringValueSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 export function readOptionalNumber(value: unknown): number | undefined {

--- a/packages/core/src/treeSitter/runtime/languages/load.ts
+++ b/packages/core/src/treeSitter/runtime/languages/load.ts
@@ -47,30 +47,41 @@ function loadTreeSitterParserCtor(): Promise<TreeSitterConstructor> {
   return treeSitterParserCtorPromise;
 }
 
+function toTreeSitterLanguage(value: unknown): Parser.Language {
+  return value as Parser.Language;
+}
+
+function readLanguageModuleDefault(module: { default: unknown }): Parser.Language {
+  return toTreeSitterLanguage(module.default);
+}
+
+function readLanguageModuleProperty(
+  module: { default: unknown },
+  property: string,
+): Parser.Language {
+  return toTreeSitterLanguage((module.default as Record<string, unknown>)[property]);
+}
+
 const TREE_SITTER_LANGUAGE_LOADERS: Record<TreeSitterLanguageBindingName, TreeSitterLanguageLoader> = {
-  cLanguage: async () => (await import('tree-sitter-c')).default as unknown as Parser.Language,
-  cpp: async () => (await import('tree-sitter-cpp')).default as unknown as Parser.Language,
-  csharp: async () => (await import('tree-sitter-c-sharp')).default as unknown as Parser.Language,
-  dart: async () => (await import('@driftlog/tree-sitter-dart')).default as unknown as Parser.Language,
-  go: async () => (await import('tree-sitter-go')).default as unknown as Parser.Language,
-  haskell: async () => (await import('tree-sitter-haskell')).default as unknown as Parser.Language,
-  java: async () => (await import('tree-sitter-java')).default as unknown as Parser.Language,
-  javaScript: async () => (await import('tree-sitter-javascript')).default as unknown as Parser.Language,
-  kotlin: async () => (await import('@tree-sitter-grammars/tree-sitter-kotlin')).default as unknown as Parser.Language,
-  lua: async () => (await import('@tree-sitter-grammars/tree-sitter-lua')).default as unknown as Parser.Language,
-  objectiveC: async () => (await import('tree-sitter-objc')).default as unknown as Parser.Language,
-  php: async () => ((await import('tree-sitter-php')).default as unknown as { php: Parser.Language }).php,
-  python: async () => (await import('tree-sitter-python')).default as unknown as Parser.Language,
-  ruby: async () => (await import('tree-sitter-ruby')).default as unknown as Parser.Language,
-  rust: async () => (await import('tree-sitter-rust')).default as unknown as Parser.Language,
-  scala: async () => (await import('tree-sitter-scala')).default as unknown as Parser.Language,
-  swift: async () => (await import('tree-sitter-swift')).default as unknown as Parser.Language,
-  tsx: async () => ((await import('tree-sitter-typescript')).default as unknown as {
-    tsx: Parser.Language;
-  }).tsx,
-  typeScript: async () => ((await import('tree-sitter-typescript')).default as unknown as {
-    typescript: Parser.Language;
-  }).typescript,
+  cLanguage: async () => readLanguageModuleDefault(await import('tree-sitter-c')),
+  cpp: async () => readLanguageModuleDefault(await import('tree-sitter-cpp')),
+  csharp: async () => readLanguageModuleDefault(await import('tree-sitter-c-sharp')),
+  dart: async () => readLanguageModuleDefault(await import('@driftlog/tree-sitter-dart')),
+  go: async () => readLanguageModuleDefault(await import('tree-sitter-go')),
+  haskell: async () => readLanguageModuleDefault(await import('tree-sitter-haskell')),
+  java: async () => readLanguageModuleDefault(await import('tree-sitter-java')),
+  javaScript: async () => readLanguageModuleDefault(await import('tree-sitter-javascript')),
+  kotlin: async () => readLanguageModuleDefault(await import('@tree-sitter-grammars/tree-sitter-kotlin')),
+  lua: async () => readLanguageModuleDefault(await import('@tree-sitter-grammars/tree-sitter-lua')),
+  objectiveC: async () => readLanguageModuleDefault(await import('tree-sitter-objc')),
+  php: async () => readLanguageModuleProperty(await import('tree-sitter-php'), 'php'),
+  python: async () => readLanguageModuleDefault(await import('tree-sitter-python')),
+  ruby: async () => readLanguageModuleDefault(await import('tree-sitter-ruby')),
+  rust: async () => readLanguageModuleDefault(await import('tree-sitter-rust')),
+  scala: async () => readLanguageModuleDefault(await import('tree-sitter-scala')),
+  swift: async () => readLanguageModuleDefault(await import('tree-sitter-swift')),
+  tsx: async () => readLanguageModuleProperty(await import('tree-sitter-typescript'), 'tsx'),
+  typeScript: async () => readLanguageModuleProperty(await import('tree-sitter-typescript'), 'typescript'),
 };
 
 async function loadTreeSitterLanguage(
@@ -150,35 +161,28 @@ export async function loadTreeSitterBindings(): Promise<ITreeSitterBindings | nu
       scalaModule,
       swiftModule,
       typeScriptModule,
-    ]) => {
-      const typeScriptLanguages = typeScriptModule.default as unknown as {
-        tsx: Parser.Language;
-        typescript: Parser.Language;
-      };
-
-      return {
-        ParserCtor,
-        cLanguage: cModule.default as unknown as Parser.Language,
-        cpp: cppModule.default as unknown as Parser.Language,
-        csharp: csharpModule.default as unknown as Parser.Language,
-        dart: dartModule.default as unknown as Parser.Language,
-        go: goModule.default as unknown as Parser.Language,
-        haskell: haskellModule.default as unknown as Parser.Language,
-        java: javaModule.default as unknown as Parser.Language,
-        javaScript: javaScriptModule.default as unknown as Parser.Language,
-        kotlin: kotlinModule.default as unknown as Parser.Language,
-        lua: luaModule.default as unknown as Parser.Language,
-        objectiveC: objectiveCModule.default as unknown as Parser.Language,
-        php: (phpModule.default as unknown as { php: Parser.Language }).php,
-        python: pythonModule.default as unknown as Parser.Language,
-        ruby: rubyModule.default as unknown as Parser.Language,
-        rust: rustModule.default as unknown as Parser.Language,
-        scala: scalaModule.default as unknown as Parser.Language,
-        swift: swiftModule.default as unknown as Parser.Language,
-        tsx: typeScriptLanguages.tsx,
-        typeScript: typeScriptLanguages.typescript,
-      };
-    })
+    ]) => ({
+      ParserCtor,
+      cLanguage: readLanguageModuleDefault(cModule),
+      cpp: readLanguageModuleDefault(cppModule),
+      csharp: readLanguageModuleDefault(csharpModule),
+      dart: readLanguageModuleDefault(dartModule),
+      go: readLanguageModuleDefault(goModule),
+      haskell: readLanguageModuleDefault(haskellModule),
+      java: readLanguageModuleDefault(javaModule),
+      javaScript: readLanguageModuleDefault(javaScriptModule),
+      kotlin: readLanguageModuleDefault(kotlinModule),
+      lua: readLanguageModuleDefault(luaModule),
+      objectiveC: readLanguageModuleDefault(objectiveCModule),
+      php: readLanguageModuleProperty(phpModule, 'php'),
+      python: readLanguageModuleDefault(pythonModule),
+      ruby: readLanguageModuleDefault(rubyModule),
+      rust: readLanguageModuleDefault(rustModule),
+      scala: readLanguageModuleDefault(scalaModule),
+      swift: readLanguageModuleDefault(swiftModule),
+      tsx: readLanguageModuleProperty(typeScriptModule, 'tsx'),
+      typeScript: readLanguageModuleProperty(typeScriptModule, 'typescript'),
+    }))
     .catch((error: unknown) => {
       warnTreeSitterBindingsUnavailable(error);
 

--- a/packages/core/src/values.ts
+++ b/packages/core/src/values.ts
@@ -1,8 +1,13 @@
 import { z } from 'zod';
 
+// Kept package-local so the published core API does not expose generic zod helpers.
 export const unknownRecordSchema = z.record(z.string(), z.unknown());
 
 export const looseStringArraySchema = z
   .array(z.unknown())
   .catch([])
   .transform(entries => entries.filter((entry): entry is string => typeof entry === 'string'));
+
+export const stringValueSchema = z.string();
+
+export const nonEmptyStringSchema = z.string().min(1);

--- a/packages/core/src/workspace/meta.ts
+++ b/packages/core/src/workspace/meta.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { z } from 'zod';
 import { WORKSPACE_ANALYSIS_CACHE_VERSION } from '../analysis/cache';
+import { looseStringArraySchema } from '../values';
 import { getWorkspaceMetaPath } from './paths';
 
 export interface CodeGraphyWorkspaceMeta {
@@ -11,6 +13,24 @@ export interface CodeGraphyWorkspaceMeta {
   analysisVersion: string | null;
   pendingChangedFiles: string[];
 }
+
+const optionalNullableStringSchema = z.union([z.string(), z.null()]).optional().catch(undefined);
+
+const codeGraphyWorkspaceMetaSchema = z.looseObject({
+  analysisVersion: optionalNullableStringSchema,
+  lastIndexedAt: optionalNullableStringSchema,
+  pendingChangedFiles: looseStringArraySchema,
+  pluginSignature: optionalNullableStringSchema,
+  settingsSignature: optionalNullableStringSchema,
+}).transform((meta): CodeGraphyWorkspaceMeta => ({
+  ...createDefaultCodeGraphyWorkspaceMeta(),
+  ...(meta.analysisVersion !== undefined ? { analysisVersion: meta.analysisVersion } : {}),
+  ...(meta.lastIndexedAt !== undefined ? { lastIndexedAt: meta.lastIndexedAt } : {}),
+  ...(meta.pluginSignature !== undefined ? { pluginSignature: meta.pluginSignature } : {}),
+  ...(meta.settingsSignature !== undefined ? { settingsSignature: meta.settingsSignature } : {}),
+  pendingChangedFiles: meta.pendingChangedFiles,
+  version: 1,
+}));
 
 export function createDefaultCodeGraphyWorkspaceMeta(): CodeGraphyWorkspaceMeta {
   return {
@@ -25,14 +45,10 @@ export function createDefaultCodeGraphyWorkspaceMeta(): CodeGraphyWorkspaceMeta 
 
 export function readCodeGraphyWorkspaceMeta(workspaceRoot: string): CodeGraphyWorkspaceMeta {
   try {
-    const parsed = JSON.parse(fs.readFileSync(getWorkspaceMetaPath(workspaceRoot), 'utf-8')) as Partial<CodeGraphyWorkspaceMeta>;
-    return {
-      ...createDefaultCodeGraphyWorkspaceMeta(),
-      ...parsed,
-      pendingChangedFiles: Array.isArray(parsed.pendingChangedFiles)
-        ? parsed.pendingChangedFiles.filter((entry): entry is string => typeof entry === 'string')
-        : [],
-    };
+    const parsed = codeGraphyWorkspaceMetaSchema.safeParse(
+      JSON.parse(fs.readFileSync(getWorkspaceMetaPath(workspaceRoot), 'utf-8')),
+    );
+    return parsed.success ? parsed.data : createDefaultCodeGraphyWorkspaceMeta();
   } catch {
     return createDefaultCodeGraphyWorkspaceMeta();
   }

--- a/packages/core/tests/values.test.ts
+++ b/packages/core/tests/values.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  looseStringArraySchema,
+  nonEmptyStringSchema,
+  stringValueSchema,
+} from '../src/values';
+
+describe('values', () => {
+  it('filters loose string arrays while defaulting non-arrays to empty arrays', () => {
+    expect(looseStringArraySchema.parse(['src/**', 7, 'tests/**'])).toEqual(['src/**', 'tests/**']);
+    expect(looseStringArraySchema.parse('src/**')).toEqual([]);
+  });
+
+  it('validates required string values while allowing empty strings', () => {
+    expect(stringValueSchema.safeParse('symbol-id').success).toBe(true);
+    expect(stringValueSchema.safeParse('').success).toBe(true);
+    expect(stringValueSchema.safeParse(7).success).toBe(false);
+  });
+
+  it('validates optional non-empty strings', () => {
+    expect(nonEmptyStringSchema.safeParse('route').success).toBe(true);
+    expect(nonEmptyStringSchema.safeParse('').success).toBe(false);
+  });
+});

--- a/packages/core/tests/workspace/meta.test.ts
+++ b/packages/core/tests/workspace/meta.test.ts
@@ -1,0 +1,83 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createDefaultCodeGraphyWorkspaceMeta,
+  readCodeGraphyWorkspaceMeta,
+  writeCodeGraphyWorkspaceMeta,
+} from '../../src/workspace/meta';
+import { getWorkspaceMetaPath } from '../../src/workspace/paths';
+
+const tempDirectories: string[] = [];
+
+function createTempWorkspace(): string {
+  const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraphy-workspace-meta-'));
+  tempDirectories.push(workspaceRoot);
+  return workspaceRoot;
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('workspace/meta', () => {
+  it('returns defaults when workspace metadata is missing', () => {
+    expect(readCodeGraphyWorkspaceMeta(createTempWorkspace())).toEqual(createDefaultCodeGraphyWorkspaceMeta());
+  });
+
+  it('writes and reads workspace metadata', () => {
+    const workspaceRoot = createTempWorkspace();
+    const meta = {
+      version: 1 as const,
+      lastIndexedAt: '2026-04-08T19:00:00.000Z',
+      pluginSignature: 'codegraphy.markdown@1.0.0',
+      settingsSignature: 'settings-sha',
+      analysisVersion: null,
+      pendingChangedFiles: ['src/index.ts'],
+    };
+
+    writeCodeGraphyWorkspaceMeta(workspaceRoot, meta);
+
+    expect(readCodeGraphyWorkspaceMeta(workspaceRoot)).toEqual(meta);
+  });
+
+  it('filters invalid persisted metadata fields through the workspace meta schema', () => {
+    const workspaceRoot = createTempWorkspace();
+    const metaPath = getWorkspaceMetaPath(workspaceRoot);
+
+    fs.mkdirSync(path.dirname(metaPath), { recursive: true });
+    fs.writeFileSync(
+      metaPath,
+      JSON.stringify({
+        version: 999,
+        analysisVersion: null,
+        lastIndexedAt: 42,
+        pluginSignature: 'plugins-sha',
+        settingsSignature: { sha: 'settings-sha' },
+        pendingChangedFiles: ['src/app.ts', 7, 'src/index.ts'],
+      }, null, 2),
+      'utf8',
+    );
+
+    expect(readCodeGraphyWorkspaceMeta(workspaceRoot)).toEqual({
+      ...createDefaultCodeGraphyWorkspaceMeta(),
+      analysisVersion: null,
+      pluginSignature: 'plugins-sha',
+      pendingChangedFiles: ['src/app.ts', 'src/index.ts'],
+      version: 1,
+    });
+  });
+
+  it('falls back to defaults when metadata JSON is invalid', () => {
+    const workspaceRoot = createTempWorkspace();
+    const metaPath = getWorkspaceMetaPath(workspaceRoot);
+
+    fs.mkdirSync(path.dirname(metaPath), { recursive: true });
+    fs.writeFileSync(metaPath, '{bad json', 'utf8');
+
+    expect(readCodeGraphyWorkspaceMeta(workspaceRoot)).toEqual(createDefaultCodeGraphyWorkspaceMeta());
+  });
+});

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -78,6 +78,7 @@
     "tree-sitter-scala": "0.24.0",
     "tree-sitter-swift": "0.7.1",
     "tree-sitter-typescript": "^0.23.2",
+    "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/packages/extension/src/e2e/workspacePlugins.ts
+++ b/packages/extension/src/e2e/workspacePlugins.ts
@@ -1,7 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { z } from 'zod';
-import { unknownRecordSchema } from '../shared/values';
+import {
+  looseStringArraySchema,
+  trimmedNonEmptyStringSchema,
+  unknownRecordSchema,
+} from '../shared/values';
 import type { E2EScenario } from './scenarios';
 
 interface CodeGraphyInstalledPluginRecord {
@@ -65,14 +69,9 @@ const scenarioPackageJsonSchema = z.looseObject({
   }),
 });
 
-function readStringArray(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === 'string')
-    : [];
-}
-
-function readOptionalString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+function readTrimmedOptionalString(value: unknown): string | undefined {
+  const parsed = trimmedNonEmptyStringSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 function readScenarioPackageDescriptor(
@@ -86,13 +85,13 @@ function readScenarioPackageDescriptor(
     throw new Error(`E2E scenario package has invalid codegraphy.json: ${packageRoot}`);
   }
 
-  const pluginId = readOptionalString(descriptor.data.id);
+  const pluginId = readTrimmedOptionalString(descriptor.data.id);
   if (!pluginId) {
     throw new Error(`E2E scenario package is missing codegraphy.json id: ${packageRoot}`);
   }
 
-  const pluginName = readOptionalString(descriptor.data.name);
-  const supportedExtensions = readStringArray(descriptor.data.supportedExtensions);
+  const pluginName = readTrimmedOptionalString(descriptor.data.name);
+  const supportedExtensions = looseStringArraySchema.parse(descriptor.data.supportedExtensions);
   return {
     pluginId,
     ...(pluginName ? { pluginName } : {}),
@@ -124,7 +123,7 @@ function readScenarioPackageRecord(packageRoot: string): CodeGraphyInstalledPlug
     version,
     apiVersion: codegraphy.apiVersion,
     packageRoot,
-    disclosures: readStringArray(codegraphy.disclosures),
+    disclosures: looseStringArraySchema.parse(codegraphy.disclosures),
     ...readScenarioPackageDescriptor(packageRoot),
   };
   if (codegraphy.defaultOptions) {
@@ -178,22 +177,22 @@ function readWorkspaceSettingsOrInitial(workspacePath: string): E2EWorkspaceSett
   }
 
   const settings = parsed.data;
-  const include = readStringArray(settings.include);
+  const include = looseStringArraySchema.parse(settings.include);
   return {
     version: 1,
     maxFiles: settings.maxFiles ?? DEFAULT_MAX_FILES,
     include: include.length > 0 ? include : DEFAULT_INCLUDE,
     respectGitignore: settings.respectGitignore ?? true,
     showOrphans: settings.showOrphans ?? true,
-    filterPatterns: readStringArray(settings.filterPatterns),
-    disabledCustomFilterPatterns: readStringArray(settings.disabledCustomFilterPatterns),
+    filterPatterns: looseStringArraySchema.parse(settings.filterPatterns),
+    disabledCustomFilterPatterns: looseStringArraySchema.parse(settings.disabledCustomFilterPatterns),
     plugins: settings.plugins
       .map(entry => workspacePluginShapeSchema.safeParse(entry))
       .filter(result => result.success)
       .map((result): CodeGraphyWorkspacePluginSettings | null => {
         const plugin = result.data;
-        const pluginId = readOptionalString(plugin.id)
-          ?? readOptionalString(plugin.package);
+        const pluginId = readTrimmedOptionalString(plugin.id)
+          ?? readTrimmedOptionalString(plugin.package);
         if (!pluginId) {
           return null;
         }

--- a/packages/extension/src/e2e/workspacePlugins.ts
+++ b/packages/extension/src/e2e/workspacePlugins.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { z } from 'zod';
+import { unknownRecordSchema } from '../shared/values';
 import type { E2EScenario } from './scenarios';
 
 interface CodeGraphyInstalledPluginRecord {
@@ -35,9 +37,33 @@ const CODEGRAPHY_MARKDOWN_PLUGIN_ID = 'codegraphy.markdown';
 const DEFAULT_MAX_FILES = 1000;
 const DEFAULT_INCLUDE = ['**/*'];
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+const workspaceSettingsShapeSchema = z.looseObject({
+  maxFiles: z.number().optional().catch(undefined),
+  include: z.unknown(),
+  respectGitignore: z.boolean().optional().catch(undefined),
+  showOrphans: z.boolean().optional().catch(undefined),
+  filterPatterns: z.unknown(),
+  disabledCustomFilterPatterns: z.unknown(),
+  plugins: z.array(z.unknown()),
+});
+
+const workspacePluginShapeSchema = z.looseObject({
+  id: z.unknown(),
+  package: z.unknown(),
+  enabled: z.boolean().optional().catch(undefined),
+  options: unknownRecordSchema.optional().catch(undefined),
+});
+
+const scenarioPackageJsonSchema = z.looseObject({
+  name: z.string().catch(''),
+  version: z.string().catch(''),
+  codegraphy: z.looseObject({
+    type: z.unknown(),
+    apiVersion: z.string().catch(''),
+    disclosures: z.unknown(),
+    defaultOptions: unknownRecordSchema.optional().catch(undefined),
+  }),
+});
 
 function readStringArray(value: unknown): string[] {
   return Array.isArray(value)
@@ -53,18 +79,20 @@ function readScenarioPackageDescriptor(
   packageRoot: string,
 ): Pick<CodeGraphyInstalledPluginRecord, 'pluginId' | 'pluginName' | 'supportedExtensions'> {
   const descriptorPath = path.join(packageRoot, 'codegraphy.json');
-  const descriptor = JSON.parse(fs.readFileSync(descriptorPath, 'utf-8')) as unknown;
-  if (!isRecord(descriptor)) {
+  const descriptor = unknownRecordSchema.safeParse(
+    JSON.parse(fs.readFileSync(descriptorPath, 'utf-8')),
+  );
+  if (!descriptor.success) {
     throw new Error(`E2E scenario package has invalid codegraphy.json: ${packageRoot}`);
   }
 
-  const pluginId = readOptionalString(descriptor.id);
+  const pluginId = readOptionalString(descriptor.data.id);
   if (!pluginId) {
     throw new Error(`E2E scenario package is missing codegraphy.json id: ${packageRoot}`);
   }
 
-  const pluginName = readOptionalString(descriptor.name);
-  const supportedExtensions = readStringArray(descriptor.supportedExtensions);
+  const pluginName = readOptionalString(descriptor.data.name);
+  const supportedExtensions = readStringArray(descriptor.data.supportedExtensions);
   return {
     pluginId,
     ...(pluginName ? { pluginName } : {}),
@@ -74,21 +102,19 @@ function readScenarioPackageDescriptor(
 
 function readScenarioPackageRecord(packageRoot: string): CodeGraphyInstalledPluginRecord {
   const packageJsonPath = path.join(packageRoot, 'package.json');
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as unknown;
-  if (!isRecord(packageJson) || !isRecord(packageJson.codegraphy)) {
+  const packageJson = scenarioPackageJsonSchema.safeParse(
+    JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')),
+  );
+  if (!packageJson.success) {
     throw new Error(`E2E scenario package is not a CodeGraphy plugin: ${packageRoot}`);
   }
 
-  const packageName = typeof packageJson.name === 'string' ? packageJson.name : '';
-  const version = typeof packageJson.version === 'string' ? packageJson.version : '';
-  const apiVersion = typeof packageJson.codegraphy.apiVersion === 'string'
-    ? packageJson.codegraphy.apiVersion
-    : '';
+  const { name: packageName, version, codegraphy } = packageJson.data;
   if (
     packageName.length === 0
     || version.length === 0
-    || packageJson.codegraphy.type !== 'plugin'
-    || apiVersion.length === 0
+    || codegraphy.type !== 'plugin'
+    || codegraphy.apiVersion.length === 0
   ) {
     throw new Error(`E2E scenario package is not a CodeGraphy plugin: ${packageRoot}`);
   }
@@ -96,13 +122,13 @@ function readScenarioPackageRecord(packageRoot: string): CodeGraphyInstalledPlug
   const plugin: CodeGraphyInstalledPluginRecord = {
     package: packageName,
     version,
-    apiVersion,
+    apiVersion: codegraphy.apiVersion,
     packageRoot,
-    disclosures: readStringArray(packageJson.codegraphy.disclosures),
+    disclosures: readStringArray(codegraphy.disclosures),
     ...readScenarioPackageDescriptor(packageRoot),
   };
-  if (isRecord(packageJson.codegraphy.defaultOptions)) {
-    plugin.defaultOptions = { ...packageJson.codegraphy.defaultOptions };
+  if (codegraphy.defaultOptions) {
+    plugin.defaultOptions = { ...codegraphy.defaultOptions };
   }
 
   return plugin;
@@ -144,23 +170,28 @@ function readWorkspaceSettingsOrInitial(workspacePath: string): E2EWorkspaceSett
     return createInitialWorkspaceSettings([]);
   }
 
-  const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as unknown;
-  if (!isRecord(settings) || !Array.isArray(settings.plugins)) {
+  const parsed = workspaceSettingsShapeSchema.safeParse(
+    JSON.parse(fs.readFileSync(settingsPath, 'utf-8')),
+  );
+  if (!parsed.success) {
     return createInitialWorkspaceSettings([]);
   }
 
+  const settings = parsed.data;
   const include = readStringArray(settings.include);
   return {
     version: 1,
-    maxFiles: typeof settings.maxFiles === 'number' ? settings.maxFiles : DEFAULT_MAX_FILES,
+    maxFiles: settings.maxFiles ?? DEFAULT_MAX_FILES,
     include: include.length > 0 ? include : DEFAULT_INCLUDE,
-    respectGitignore: typeof settings.respectGitignore === 'boolean' ? settings.respectGitignore : true,
-    showOrphans: typeof settings.showOrphans === 'boolean' ? settings.showOrphans : true,
+    respectGitignore: settings.respectGitignore ?? true,
+    showOrphans: settings.showOrphans ?? true,
     filterPatterns: readStringArray(settings.filterPatterns),
     disabledCustomFilterPatterns: readStringArray(settings.disabledCustomFilterPatterns),
     plugins: settings.plugins
-      .filter(isRecord)
-      .map((plugin): CodeGraphyWorkspacePluginSettings | null => {
+      .map(entry => workspacePluginShapeSchema.safeParse(entry))
+      .filter(result => result.success)
+      .map((result): CodeGraphyWorkspacePluginSettings | null => {
+        const plugin = result.data;
         const pluginId = readOptionalString(plugin.id)
           ?? readOptionalString(plugin.package);
         if (!pluginId) {
@@ -169,9 +200,9 @@ function readWorkspaceSettingsOrInitial(workspacePath: string): E2EWorkspaceSett
 
         const normalized: CodeGraphyWorkspacePluginSettings = {
           id: pluginId,
-          enabled: typeof plugin.enabled === 'boolean' ? plugin.enabled : true,
+          enabled: plugin.enabled ?? true,
         };
-        if (isRecord(plugin.options)) {
+        if (plugin.options) {
           normalized.options = { ...plugin.options };
         }
         return normalized;

--- a/packages/extension/src/extension/gitHistory/cache/storage.ts
+++ b/packages/extension/src/extension/gitHistory/cache/storage.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
+import { z } from 'zod';
 import type { IGraphData } from '../../../shared/graph/contracts';
 import { getCacheDir, getCachePath } from './paths';
 
@@ -11,6 +12,42 @@ type GraphCacheFs = Pick<
 function emptyGraphData(): IGraphData {
   return { nodes: [], edges: [] };
 }
+
+const cachedGraphNodeSchema = z.looseObject({
+  id: z.string(),
+  label: z.string(),
+  color: z.string(),
+}).transform((node): IGraphData['nodes'][number] => node as IGraphData['nodes'][number]);
+
+const cachedGraphEdgeSourceSchema = z.looseObject({
+  id: z.string(),
+  pluginId: z.string(),
+  sourceId: z.string(),
+  label: z.string(),
+}).transform((source): IGraphData['edges'][number]['sources'][number] =>
+  source as IGraphData['edges'][number]['sources'][number]
+);
+
+const cachedGraphEdgeSourcesSchema = z
+  .array(z.unknown())
+  .catch([])
+  .transform((sources): IGraphData['edges'][number]['sources'] => sources.flatMap((source) => {
+    const parsed = cachedGraphEdgeSourceSchema.safeParse(source);
+    return parsed.success ? [parsed.data] : [];
+  }));
+
+const cachedGraphEdgeSchema = z.looseObject({
+  id: z.string(),
+  from: z.string(),
+  to: z.string(),
+  kind: z.string(),
+  sources: cachedGraphEdgeSourcesSchema,
+}).transform((edge): IGraphData['edges'][number] => edge as IGraphData['edges'][number]);
+
+const cachedGraphDataSchema = z.looseObject({
+  nodes: z.array(cachedGraphNodeSchema),
+  edges: z.array(cachedGraphEdgeSchema),
+}).transform(({ nodes, edges }): IGraphData => ({ nodes, edges }));
 
 export async function readCachedGraphData(
   storageUri: vscode.Uri | undefined,
@@ -25,7 +62,8 @@ export async function readCachedGraphData(
   try {
     await fsPromises.access(cachePath);
     const raw = await fsPromises.readFile(cachePath, 'utf-8');
-    return JSON.parse(raw) as IGraphData;
+    const parsed = cachedGraphDataSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : emptyGraphData();
   } catch {
     return emptyGraphData();
   }

--- a/packages/extension/src/extension/graphView/analysis/execution/publish/equality/collections.ts
+++ b/packages/extension/src/extension/graphView/analysis/execution/publish/equality/collections.ts
@@ -1,3 +1,5 @@
+import { isObjectRecord } from '../../../../../../shared/records';
+
 type CompareGraphValue = (left: unknown, right: unknown) => boolean;
 
 function areGraphRecordsEqual(
@@ -26,12 +28,6 @@ function areGraphArraysEqual(
     && left.every((leftValue, index) => compareValue(leftValue, right[index]));
 }
 
-function isGraphRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null
-    && typeof value === 'object'
-    && !Array.isArray(value);
-}
-
 export function compareGraphArrayValues(
   left: unknown,
   right: unknown,
@@ -49,5 +45,5 @@ export function compareGraphRecordValues(
   right: unknown,
   compareValue: CompareGraphValue,
 ): boolean {
-  return isGraphRecord(left) && isGraphRecord(right) && areGraphRecordsEqual(left, right, compareValue);
+  return isObjectRecord(left) && isObjectRecord(right) && areGraphRecordsEqual(left, right, compareValue);
 }

--- a/packages/extension/src/extension/graphView/groups/defaults/materialTheme/manifest.ts
+++ b/packages/extension/src/extension/graphView/groups/defaults/materialTheme/manifest.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { z } from 'zod';
+import { unknownRecordSchema } from '../../../../../shared/values';
 import type { MaterialThemeCacheEntry, MaterialIconManifest } from './model';
 import { createMaterialExtensionMatcher } from './extensionMatch';
 import { createMaterialPathRuleMatcher } from './pathMatch';
@@ -8,8 +10,74 @@ import { createMaterialPathRuleMatcher } from './pathMatch';
 const materialThemeCache = new Map<string, MaterialThemeCacheEntry | null>();
 const materialIconThemePackageName = 'material-icon-theme';
 
+const materialStringRecordSchema = unknownRecordSchema.transform((record): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(record).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  )
+);
+
+const materialIconDefinitionSchema = z.looseObject({
+  iconPath: z.string(),
+});
+
+const materialIconDefinitionsSchema = unknownRecordSchema.transform((record): MaterialIconManifest['iconDefinitions'] =>
+  Object.fromEntries(
+    Object.entries(record).flatMap(([key, value]) => {
+      const parsed = materialIconDefinitionSchema.safeParse(value);
+      return parsed.success ? [[key, { iconPath: parsed.data.iconPath }] as [string, { iconPath: string }]] : [];
+    }),
+  )
+);
+
+const materialIconManifestSchema = z.looseObject({
+  fileExtensions: materialStringRecordSchema.optional().catch(undefined),
+  fileNames: materialStringRecordSchema.optional().catch(undefined),
+  folder: z.string().optional().catch(undefined),
+  folderNames: materialStringRecordSchema.optional().catch(undefined),
+  folderNamesExpanded: materialStringRecordSchema.optional().catch(undefined),
+  iconDefinitions: materialIconDefinitionsSchema.optional().catch(undefined),
+  languageIds: materialStringRecordSchema.optional().catch(undefined),
+  rootFolder: z.string().optional().catch(undefined),
+}).transform((manifest): MaterialIconManifest => {
+  const normalized: MaterialIconManifest = {};
+  if (manifest.fileExtensions !== undefined) {
+    normalized.fileExtensions = manifest.fileExtensions;
+  }
+  if (manifest.fileNames !== undefined) {
+    normalized.fileNames = manifest.fileNames;
+  }
+  if (manifest.folder !== undefined) {
+    normalized.folder = manifest.folder;
+  }
+  if (manifest.folderNames !== undefined) {
+    normalized.folderNames = manifest.folderNames;
+  }
+  if (manifest.folderNamesExpanded !== undefined) {
+    normalized.folderNamesExpanded = manifest.folderNamesExpanded;
+  }
+  if (manifest.iconDefinitions !== undefined) {
+    normalized.iconDefinitions = manifest.iconDefinitions;
+  }
+  if (manifest.languageIds !== undefined) {
+    normalized.languageIds = manifest.languageIds;
+  }
+  if (manifest.rootFolder !== undefined) {
+    normalized.rootFolder = manifest.rootFolder;
+  }
+  return normalized;
+});
+
 export function clearMaterialThemeCache(): void {
   materialThemeCache.clear();
+}
+
+function readMaterialIconManifest(manifestPath: string): MaterialIconManifest | null {
+  try {
+    const parsed = materialIconManifestSchema.safeParse(JSON.parse(fs.readFileSync(manifestPath, 'utf8')));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
 }
 
 export function resolveMaterialThemeRoot(extensionUri: vscode.Uri): string | undefined {
@@ -40,7 +108,12 @@ export function loadMaterialTheme(extensionUri: vscode.Uri): MaterialThemeCacheE
     return null;
   }
 
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as MaterialIconManifest;
+  const manifest = readMaterialIconManifest(manifestPath);
+  if (!manifest) {
+    materialThemeCache.set(cacheKey, null);
+    return null;
+  }
+
   const theme = {
     extensionMatcher: manifest.fileExtensions
       ? createMaterialExtensionMatcher(manifest.fileExtensions)

--- a/packages/extension/src/extension/graphView/webview/settingsMessages/updates/apply/pluginData.ts
+++ b/packages/extension/src/extension/graphView/webview/settingsMessages/updates/apply/pluginData.ts
@@ -2,6 +2,7 @@ import { createCodeGraphyWorkspacePluginSettingUpdateIndexingPlan } from '@codeg
 import type { WebviewToExtensionMessage } from '../../../../../../shared/protocol/webviewToExtension';
 import type { GraphViewSettingsMessageHandlers } from '../../router';
 import { applyPluginGraphWorkPlan } from '../../pluginGraphWork';
+import { unknownRecordSchema } from '../../../../../../shared/values';
 
 export async function applyPluginDataMessage(
   message: WebviewToExtensionMessage,
@@ -43,17 +44,24 @@ export async function applyPluginDataMessage(
   return true;
 }
 
+function parsePluginDataRecord(value: unknown): Record<string, unknown> | undefined {
+  const parsed = unknownRecordSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
 function hasPluginDataChanged(previousData: unknown, nextData: unknown): boolean {
-  if (!isRecord(previousData) || !isRecord(nextData)) {
+  const previousRecord = parsePluginDataRecord(previousData);
+  const nextRecord = parsePluginDataRecord(nextData);
+  if (!previousRecord || !nextRecord) {
     return !Object.is(previousData, nextData);
   }
 
-  return getChangedPluginDataKeys(previousData, nextData).length > 0;
+  return changedPluginDataRecordKeys(previousRecord, nextRecord).length > 0;
 }
 
 function getChangedPluginDataKeys(previousData: unknown, nextData: unknown): string[] {
-  const previousRecord = isRecord(previousData) ? previousData : undefined;
-  const nextRecord = isRecord(nextData) ? nextData : undefined;
+  const previousRecord = parsePluginDataRecord(previousData);
+  const nextRecord = parsePluginDataRecord(nextData);
 
   if (!previousRecord && !nextRecord) {
     return [];
@@ -67,14 +75,17 @@ function getChangedPluginDataKeys(previousData: unknown, nextData: unknown): str
     return Object.keys(previousRecord);
   }
 
+  return changedPluginDataRecordKeys(previousRecord, nextRecord);
+}
+
+function changedPluginDataRecordKeys(
+  previousRecord: Record<string, unknown>,
+  nextRecord: Record<string, unknown>,
+): string[] {
   const keys = new Set([
     ...Object.keys(previousRecord),
     ...Object.keys(nextRecord),
   ]);
 
   return [...keys].filter(key => !Object.is(previousRecord[key], nextRecord[key]));
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/extension/src/extension/repoSettings/meta.ts
+++ b/packages/extension/src/extension/repoSettings/meta.ts
@@ -1,5 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { z } from 'zod';
+import { looseStringArraySchema } from '../../shared/values';
 
 export interface ICodeGraphyRepoMeta {
   version: 1;
@@ -11,6 +13,24 @@ export interface ICodeGraphyRepoMeta {
 }
 
 const META_FILE_NAME = 'meta.json';
+
+const optionalNullableStringSchema = z.union([z.string(), z.null()]).optional().catch(undefined);
+
+const codeGraphyRepoMetaSchema = z.looseObject({
+  lastIndexedAt: optionalNullableStringSchema,
+  lastIndexedCommit: optionalNullableStringSchema,
+  pendingChangedFiles: looseStringArraySchema,
+  pluginSignature: optionalNullableStringSchema,
+  settingsSignature: optionalNullableStringSchema,
+}).transform((meta): ICodeGraphyRepoMeta => ({
+  ...createDefaultCodeGraphyRepoMeta(),
+  ...(meta.lastIndexedAt !== undefined ? { lastIndexedAt: meta.lastIndexedAt } : {}),
+  ...(meta.lastIndexedCommit !== undefined ? { lastIndexedCommit: meta.lastIndexedCommit } : {}),
+  ...(meta.pluginSignature !== undefined ? { pluginSignature: meta.pluginSignature } : {}),
+  ...(meta.settingsSignature !== undefined ? { settingsSignature: meta.settingsSignature } : {}),
+  pendingChangedFiles: meta.pendingChangedFiles,
+  version: 1,
+}));
 
 export function createDefaultCodeGraphyRepoMeta(): ICodeGraphyRepoMeta {
   return {
@@ -31,11 +51,8 @@ export function readCodeGraphyRepoMeta(workspaceRoot: string): ICodeGraphyRepoMe
   const metaPath = getCodeGraphyRepoMetaPath(workspaceRoot);
 
   try {
-    const parsed = JSON.parse(fs.readFileSync(metaPath, 'utf8')) as Partial<ICodeGraphyRepoMeta>;
-    return {
-      ...createDefaultCodeGraphyRepoMeta(),
-      ...parsed,
-    };
+    const parsed = codeGraphyRepoMetaSchema.safeParse(JSON.parse(fs.readFileSync(metaPath, 'utf8')));
+    return parsed.success ? parsed.data : createDefaultCodeGraphyRepoMeta();
   } catch {
     return createDefaultCodeGraphyRepoMeta();
   }

--- a/packages/extension/src/extension/repoSettings/store/model/persistedShape/cssSnippets.ts
+++ b/packages/extension/src/extension/repoSettings/store/model/persistedShape/cssSnippets.ts
@@ -1,20 +1,18 @@
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+import { unknownRecordSchema } from '../../../../../shared/values';
 
 export function normalizePersistedCssSnippets(normalized: Record<string, unknown>): void {
   if (!('cssSnippets' in normalized)) {
     return;
   }
 
-  const value = normalized.cssSnippets;
-  if (!isRecord(value)) {
+  const parsed = unknownRecordSchema.safeParse(normalized.cssSnippets);
+  if (!parsed.success) {
     delete normalized.cssSnippets;
     return;
   }
 
   const snippets: Record<string, boolean> = {};
-  for (const [path, enabled] of Object.entries(value)) {
+  for (const [path, enabled] of Object.entries(parsed.data)) {
     const snippetPath = path.trim();
     if (snippetPath.length === 0 || typeof enabled !== 'boolean') {
       continue;

--- a/packages/extension/src/extension/repoSettings/store/model/persistedShape/filterPatterns.ts
+++ b/packages/extension/src/extension/repoSettings/store/model/persistedShape/filterPatterns.ts
@@ -1,10 +1,10 @@
-import { readStringArray } from './stringArray';
+import { looseStringArraySchema } from '../../../../../shared/values';
 
 export function normalizePersistedFilterPatterns(normalized: Record<string, unknown>): void {
   if (!('filterPatterns' in normalized)) {
     return;
   }
 
-  const filterPatterns = readStringArray(normalized.filterPatterns);
+  const filterPatterns = looseStringArraySchema.parse(normalized.filterPatterns);
   normalized.filterPatterns = Array.from(new Set(filterPatterns));
 }

--- a/packages/extension/src/extension/repoSettings/store/model/persistedShape/plugins.ts
+++ b/packages/extension/src/extension/repoSettings/store/model/persistedShape/plugins.ts
@@ -2,8 +2,8 @@ import {
   CODEGRAPHY_MARKDOWN_PLUGIN_ID,
   CODEGRAPHY_MARKDOWN_PLUGIN_PACKAGE_NAME,
 } from '@codegraphy-dev/core';
+import { looseStringArraySchema } from '../../../../../shared/values';
 import { isPlainObject } from '../plainObject';
-import { readStringArray } from './stringArray';
 
 export function normalizePersistedPlugins(normalized: Record<string, unknown>): void {
   if (!Array.isArray(normalized.plugins)) {
@@ -43,7 +43,7 @@ function normalizePersistedPlugin(plugin: unknown): Record<string, unknown> | nu
     id,
     enabled,
   };
-  const disabledFilterPatterns = readStringArray(plugin.disabledFilterPatterns);
+  const disabledFilterPatterns = looseStringArraySchema.parse(plugin.disabledFilterPatterns);
   if (disabledFilterPatterns.length > 0) {
     normalizedPlugin.disabledFilterPatterns = Array.from(new Set(disabledFilterPatterns));
   }

--- a/packages/extension/src/extension/repoSettings/store/model/persistedShape/stringArray.ts
+++ b/packages/extension/src/extension/repoSettings/store/model/persistedShape/stringArray.ts
@@ -1,5 +1,0 @@
-export function readStringArray(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === 'string')
-    : [];
-}

--- a/packages/extension/src/extension/repoSettings/store/model/plainObject.ts
+++ b/packages/extension/src/extension/repoSettings/store/model/plainObject.ts
@@ -1,9 +1,11 @@
+import { isObjectRecord } from '../../../../shared/records';
+
 export function deepClone<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value)) as T;
+  return structuredClone(value);
 }
 
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  return isObjectRecord(value);
 }
 
 export function deepMerge<T>(base: T, overrides: unknown): T {

--- a/packages/extension/src/shared/records.ts
+++ b/packages/extension/src/shared/records.ts
@@ -1,0 +1,3 @@
+export function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/extension/src/shared/values.ts
+++ b/packages/extension/src/shared/values.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export const unknownRecordSchema = z.record(z.string(), z.unknown());

--- a/packages/extension/src/shared/values.ts
+++ b/packages/extension/src/shared/values.ts
@@ -1,3 +1,13 @@
 import { z } from 'zod';
 
+// Kept extension-local so webview/e2e code does not depend on core's public API surface.
 export const unknownRecordSchema = z.record(z.string(), z.unknown());
+
+export const looseStringArraySchema = z
+  .array(z.unknown())
+  .catch([])
+  .transform(entries => entries.filter((entry): entry is string => typeof entry === 'string'));
+
+export const nonEmptyStringSchema = z.string().min(1);
+
+export const trimmedNonEmptyStringSchema = z.string().trim().min(1);

--- a/packages/extension/src/webview/components/graph/contextMenu/graphView/selectedPositions.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/graphView/selectedPositions.ts
@@ -2,10 +2,7 @@ import type {
   GraphContextMenuNode,
   GraphContextSelection,
 } from '../contracts';
-
-function isFiniteNumber(value: unknown): value is number {
-  return Number.isFinite(value);
-}
+import { isFiniteNumber } from '../../runtime/physics/numeric';
 
 export function createSelectedNodePositions(
   selection: GraphContextSelection,

--- a/packages/extension/src/webview/components/graph/interactionRuntime/handlers/view/zoom/bounds/validation.ts
+++ b/packages/extension/src/webview/components/graph/interactionRuntime/handlers/view/zoom/bounds/validation.ts
@@ -1,11 +1,5 @@
 import type { GraphView3dBounds } from '../../../../fit/api/controls';
-import { isFiniteNumber } from '../coords';
-
-function isFinitePair(value: unknown): value is [number, number] {
-  return Array.isArray(value)
-    && value.length === 2
-    && value.every(isFiniteNumber);
-}
+import { isFinitePair } from '../../../../../runtime/physics/numeric';
 
 export function isBounds(value: unknown): value is GraphView3dBounds {
   if (typeof value !== 'object' || value === null) {

--- a/packages/extension/src/webview/components/graph/interactionRuntime/handlers/view/zoom/coords.ts
+++ b/packages/extension/src/webview/components/graph/interactionRuntime/handlers/view/zoom/coords.ts
@@ -1,8 +1,5 @@
 import type { GraphView3dCoords } from '../../../fit/api/controls';
-
-export function isFiniteNumber(value: number): boolean {
-  return Number.isFinite(value);
-}
+import { isFiniteNumber } from '../../../../runtime/physics/numeric';
 
 export function isCoord(value: unknown): value is GraphView3dCoords {
   const candidate = value as Partial<GraphView3dCoords> | undefined;

--- a/packages/extension/src/webview/components/graph/marqueeSelection/model.ts
+++ b/packages/extension/src/webview/components/graph/marqueeSelection/model.ts
@@ -1,4 +1,5 @@
 import type { FGNode } from '../model/build';
+import { isFiniteNumber } from '../runtime/physics/numeric';
 
 export interface MarqueePoint {
   x: number;
@@ -20,10 +21,6 @@ export interface GetMarqueeSelectedNodeIdsOptions {
 
 export interface GraphMarqueeSelectionState {
   bounds: MarqueeBounds;
-}
-
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value);
 }
 
 export function getMarqueeBounds(start: MarqueePoint, current: MarqueePoint): MarqueeBounds {

--- a/packages/extension/src/webview/components/graph/model/node/rectangularArea.ts
+++ b/packages/extension/src/webview/components/graph/model/node/rectangularArea.ts
@@ -1,10 +1,8 @@
+import { isFinitePositiveNumber } from '../../runtime/physics/numeric';
+
 export interface RectangularNodeArea2D {
   height: number;
   width: number;
-}
-
-function isFinitePositiveNumber(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 export function getRectangularNodeArea2D(area: unknown): RectangularNodeArea2D | undefined {

--- a/packages/extension/src/webview/components/graph/runtime/physics/numeric.ts
+++ b/packages/extension/src/webview/components/graph/runtime/physics/numeric.ts
@@ -2,6 +2,16 @@ export function isFiniteNumber(value: unknown): value is number {
 	return Number.isFinite(value);
 }
 
+export function isFinitePositiveNumber(value: unknown): value is number {
+	return isFiniteNumber(value) && value > 0;
+}
+
+export function isFinitePair(value: unknown): value is [number, number] {
+	return Array.isArray(value)
+		&& value.length === 2
+		&& value.every(isFiniteNumber);
+}
+
 export function clamp(value: number, minimum: number, maximum: number): number {
 	if (minimum > maximum) {
 		return (minimum + maximum) / 2;

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/positions.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/positions.ts
@@ -1,4 +1,5 @@
 import type { FGNode } from '../../../model/build';
+import { isFiniteNumber } from '../../physics/numeric';
 
 type GraphMode = '2d' | '3d';
 
@@ -9,10 +10,6 @@ export interface GraphNodePosition2D {
 
 export interface GraphNodePosition3D extends GraphNodePosition2D {
   z: number;
-}
-
-export function isFiniteNumber(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value);
 }
 
 export function readNodePosition(

--- a/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/coordinates.ts
+++ b/packages/extension/src/webview/components/graph/runtime/use/interaction/viewportPan/coordinates.ts
@@ -1,6 +1,6 @@
 import type { MarqueePoint } from '../../../../marqueeSelection/model';
 import type { GraphRuntime } from '../../state';
-import { isFiniteNumber } from '../positions';
+import { isFiniteNumber } from '../../../physics/numeric';
 import type { ViewportPanDragState } from './state';
 
 export function readViewportPanCenter(

--- a/packages/extension/src/webview/components/graph/support/guards.ts
+++ b/packages/extension/src/webview/components/graph/support/guards.ts
@@ -1,21 +1,16 @@
 import type { DistanceMaxForce, LinkDistanceForce, StrengthForce } from './contracts/forceGraph';
 
-export function isRecordLike(value: unknown): value is Record<string, unknown> {
-  return (typeof value === 'object' && value !== null) || typeof value === 'function';
-}
-
 export function hasStrength(force: unknown): force is StrengthForce {
-  if (!isRecordLike(force)) return false;
-  return typeof (force as { strength?: unknown }).strength === 'function';
+  const candidate = force as { strength?: unknown } | null | undefined;
+  return typeof candidate?.strength === 'function';
 }
 
 export function hasDistanceAndStrength(force: unknown): force is LinkDistanceForce {
-  if (!isRecordLike(force)) return false;
-  const candidate = force as { distance?: unknown; strength?: unknown };
-  return typeof candidate.distance === 'function' && typeof candidate.strength === 'function';
+  const candidate = force as { distance?: unknown; strength?: unknown } | null | undefined;
+  return typeof candidate?.distance === 'function' && typeof candidate?.strength === 'function';
 }
 
 export function hasDistanceMax(force: unknown): force is DistanceMaxForce {
-  if (!isRecordLike(force)) return false;
-  return typeof (force as { distanceMax?: unknown }).distanceMax === 'function';
+  const candidate = force as { distanceMax?: unknown } | null | undefined;
+  return typeof candidate?.distanceMax === 'function';
 }

--- a/packages/extension/src/webview/components/graph/support/linkTargets.ts
+++ b/packages/extension/src/webview/components/graph/support/linkTargets.ts
@@ -1,10 +1,8 @@
 import type { IGraphEdge } from '../../../../shared/graph/contracts';
-import { isRecordLike } from './guards';
 
 export function resolveLinkEndpointId(value: unknown): string | null {
   if (typeof value === 'string') return value;
-  if (!isRecordLike(value)) return null;
-  const maybeId = (value as { id?: unknown }).id;
+  const maybeId = (value as { id?: unknown } | null | undefined)?.id;
   return typeof maybeId === 'string' ? maybeId : null;
 }
 

--- a/packages/extension/src/webview/components/legends/panel/storage.ts
+++ b/packages/extension/src/webview/components/legends/panel/storage.ts
@@ -1,24 +1,30 @@
+import { unknownRecordSchema } from '../../../../shared/values';
 import * as vscodeApiModule from '../../../vscodeApi';
 
 export interface LegendPanelStorageState {
   legendPanelCollapsed?: Record<string, boolean>;
 }
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-export function readLegendPanelCollapsedState(): Record<string, boolean> {
-  const state = vscodeApiModule.getVsCodeApi?.()?.getState();
-  if (!isPlainObject(state) || !isPlainObject(state.legendPanelCollapsed)) {
+function readBooleanRecord(value: unknown): Record<string, boolean> {
+  const parsed = unknownRecordSchema.safeParse(value);
+  if (!parsed.success) {
     return {};
   }
 
   return Object.fromEntries(
-    Object.entries(state.legendPanelCollapsed).filter((entry): entry is [string, boolean] =>
+    Object.entries(parsed.data).filter((entry): entry is [string, boolean] =>
       typeof entry[1] === 'boolean'
     ),
   );
+}
+
+export function readLegendPanelCollapsedState(): Record<string, boolean> {
+  const state = unknownRecordSchema.safeParse(vscodeApiModule.getVsCodeApi?.()?.getState());
+  if (!state.success) {
+    return {};
+  }
+
+  return readBooleanRecord(state.data.legendPanelCollapsed);
 }
 
 export function writeLegendPanelCollapsedState(
@@ -29,8 +35,8 @@ export function writeLegendPanelCollapsedState(
     return;
   }
 
-  const existingState = vscode.getState();
-  const nextState = isPlainObject(existingState) ? existingState : {};
+  const existingState = unknownRecordSchema.safeParse(vscode.getState());
+  const nextState = existingState.success ? existingState.data : {};
   vscode.setState({
     ...nextState,
     legendPanelCollapsed,

--- a/packages/extension/src/webview/pluginRuntime/messageValidation.ts
+++ b/packages/extension/src/webview/pluginRuntime/messageValidation.ts
@@ -3,6 +3,9 @@
  * @module webview/pluginMessageValidation
  */
 
+import { z } from 'zod';
+import { looseStringArraySchema } from '../../shared/values';
+
 export interface PluginInjectPayload {
   pluginId: string;
   scripts: string[];
@@ -24,39 +27,38 @@ export interface PluginScopedMessage {
   message: { type: string; data: unknown };
 }
 
+const pluginWebviewAssetSchema = z.looseObject({
+  id: z.string(),
+  label: z.string(),
+  url: z.string(),
+}).transform((asset): PluginWebviewAsset => asset as PluginWebviewAsset);
+
+const pluginWebviewAssetsSchema = z
+  .array(z.unknown())
+  .catch([])
+  .transform((entries): PluginWebviewAsset[] => entries.flatMap((entry) => {
+    const parsed = pluginWebviewAssetSchema.safeParse(entry);
+    return parsed.success ? [parsed.data] : [];
+  }));
+
+const pluginInjectPayloadSchema = z.looseObject({
+  pluginId: z.string(),
+  scripts: looseStringArraySchema,
+  styles: looseStringArraySchema,
+  assets: pluginWebviewAssetsSchema,
+});
+
+const pluginScopedMessageSchema = z.object({
+  pluginId: z.string(),
+  message: z.object({
+    type: z.string(),
+    data: z.unknown(),
+  }),
+});
+
 export function normalizePluginInjectPayload(payload: unknown): PluginInjectPayload | null {
-  if (!payload || typeof payload !== 'object') {
-    return null;
-  }
-
-  const candidate = payload as { pluginId?: unknown; scripts?: unknown; styles?: unknown; assets?: unknown };
-  if (typeof candidate.pluginId !== 'string') {
-    return null;
-  }
-
-  return {
-    pluginId: candidate.pluginId,
-    scripts: Array.isArray(candidate.scripts)
-      ? candidate.scripts.filter((script): script is string => typeof script === 'string')
-      : [],
-    styles: Array.isArray(candidate.styles)
-      ? candidate.styles.filter((style): style is string => typeof style === 'string')
-      : [],
-    assets: Array.isArray(candidate.assets)
-      ? candidate.assets.filter(isPluginWebviewAsset)
-      : [],
-  };
-}
-
-function isPluginWebviewAsset(value: unknown): value is PluginWebviewAsset {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  const candidate = value as Partial<PluginWebviewAsset>;
-  return typeof candidate.id === 'string'
-    && typeof candidate.label === 'string'
-    && typeof candidate.url === 'string';
+  const parsed = pluginInjectPayloadSchema.safeParse(payload);
+  return parsed.success ? parsed.data : null;
 }
 
 export function parsePluginScopedMessage(type: string, data: unknown): PluginScopedMessage | null {
@@ -69,8 +71,10 @@ export function parsePluginScopedMessage(type: string, data: unknown): PluginSco
     return null;
   }
 
-  return {
+  const parsed = pluginScopedMessageSchema.safeParse({
     pluginId,
     message: { type: typeParts.join(':'), data },
-  };
+  });
+
+  return parsed.success ? parsed.data : null;
 }

--- a/packages/extension/src/webview/store/messageHandlers/equality/structures.ts
+++ b/packages/extension/src/webview/store/messageHandlers/equality/structures.ts
@@ -1,6 +1,4 @@
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+import { isObjectRecord } from '../../../../shared/records';
 
 export function arePlainObjectValuesEqual(left: unknown, right: unknown): boolean {
   if (Object.is(left, right)) {
@@ -12,7 +10,7 @@ export function arePlainObjectValuesEqual(left: unknown, right: unknown): boolea
       && left.every((item, index) => arePlainObjectValuesEqual(item, right[index]));
   }
 
-  if (isPlainObject(left) && isPlainObject(right)) {
+  if (isObjectRecord(left) && isObjectRecord(right)) {
     const leftKeys = Object.keys(left);
     const rightKeys = Object.keys(right);
 

--- a/packages/extension/tests/acceptance/graphView/plugins.ts
+++ b/packages/extension/tests/acceptance/graphView/plugins.ts
@@ -1,6 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { unknownRecordSchema } from '../../../src/shared/values';
+import {
+  looseStringArraySchema,
+  nonEmptyStringSchema,
+  unknownRecordSchema,
+} from '../../../src/shared/values';
 
 interface CodeGraphyPluginPackageJson {
   name?: unknown;
@@ -69,8 +73,8 @@ export function writeAcceptanceInstalledPluginCache(
 function readAcceptanceInstalledPluginRecord(packageRoot: string): AcceptanceInstalledPluginRecord {
   const packageJsonPath = path.join(packageRoot, 'package.json');
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as CodeGraphyPluginPackageJson;
-  const packageName = readRequiredString(packageJson.name, `${packageJsonPath} name`);
-  const version = readRequiredString(packageJson.version, `${packageJsonPath} version`);
+  const packageName = readRequiredNonEmptyString(packageJson.name, `${packageJsonPath} name`);
+  const version = readRequiredNonEmptyString(packageJson.version, `${packageJsonPath} version`);
   const codegraphy = packageJson.codegraphy;
   const displayFields = readAcceptancePluginDisplayFields(packageRoot);
 
@@ -81,9 +85,9 @@ function readAcceptanceInstalledPluginRecord(packageRoot: string): AcceptanceIns
   const record: AcceptanceInstalledPluginRecord = {
     package: packageName,
     version,
-    apiVersion: readRequiredString(codegraphy.apiVersion, `${packageJsonPath} codegraphy.apiVersion`),
+    apiVersion: readRequiredNonEmptyString(codegraphy.apiVersion, `${packageJsonPath} codegraphy.apiVersion`),
     packageRoot,
-    disclosures: readStringArray(codegraphy.disclosures),
+    disclosures: looseStringArraySchema.parse(codegraphy.disclosures),
     ...displayFields,
   };
 
@@ -102,13 +106,13 @@ function readAcceptancePluginDisplayFields(
   const descriptor = JSON.parse(
     fs.readFileSync(descriptorPath, 'utf-8'),
   ) as CodeGraphyPluginDescriptor;
-  const pluginId = readOptionalString(descriptor.id);
+  const pluginId = readOptionalNonEmptyString(descriptor.id);
   if (!pluginId) {
     throw new Error(`Acceptance plugin package is missing codegraphy.json id: ${packageRoot}`);
   }
 
-  const pluginName = readOptionalString(descriptor.name);
-  const supportedExtensions = readStringArray(descriptor.supportedExtensions);
+  const pluginName = readOptionalNonEmptyString(descriptor.name);
+  const supportedExtensions = looseStringArraySchema.parse(descriptor.supportedExtensions);
   return {
     pluginId,
     ...(pluginName ? { pluginName } : {}),
@@ -116,21 +120,17 @@ function readAcceptancePluginDisplayFields(
   };
 }
 
-function readRequiredString(value: unknown, label: string): string {
-  if (typeof value !== 'string' || value.length === 0) {
+function readRequiredNonEmptyString(value: unknown, label: string): string {
+  const parsed = nonEmptyStringSchema.safeParse(value);
+  if (!parsed.success) {
     throw new Error(`Expected ${label} to be a non-empty string`);
   }
 
-  return value;
+  return parsed.data;
 }
 
-function readOptionalString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function readStringArray(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((entry): entry is string => typeof entry === 'string')
-    : [];
+function readOptionalNonEmptyString(value: unknown): string | undefined {
+  const parsed = nonEmptyStringSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 

--- a/packages/extension/tests/acceptance/graphView/plugins.ts
+++ b/packages/extension/tests/acceptance/graphView/plugins.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { unknownRecordSchema } from '../../../src/shared/values';
 
 interface CodeGraphyPluginPackageJson {
   name?: unknown;
@@ -86,8 +87,9 @@ function readAcceptanceInstalledPluginRecord(packageRoot: string): AcceptanceIns
     ...displayFields,
   };
 
-  if (isRecord(codegraphy.defaultOptions)) {
-    record.defaultOptions = { ...codegraphy.defaultOptions };
+  const defaultOptions = unknownRecordSchema.safeParse(codegraphy.defaultOptions);
+  if (defaultOptions.success) {
+    record.defaultOptions = { ...defaultOptions.data };
   }
 
   return record;
@@ -132,6 +134,3 @@ function readStringArray(value: unknown): string[] {
     : [];
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}

--- a/packages/extension/tests/acceptance/graphView/workspace.ts
+++ b/packages/extension/tests/acceptance/graphView/workspace.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import ignore, { type Ignore } from 'ignore';
+import { unknownRecordSchema } from '../../../src/shared/values';
 import { DEFAULT_INCLUDE, DEFAULT_MAX_FILES } from '../../../../core/src/discovery/file/defaults';
 import {
   DEFAULT_EXCLUDE,
@@ -360,7 +361,9 @@ function readAcceptancePluginSettings(value: unknown): AcceptanceFilterSettings[
   }
 
   return value
-    .filter(isRecord)
+    .map(entry => unknownRecordSchema.safeParse(entry))
+    .filter(result => result.success)
+    .map(result => result.data)
     .map((entry) => {
       const packageName = typeof entry.package === 'string'
         ? entry.package.trim()
@@ -397,10 +400,6 @@ function readMaxFiles(value: unknown): number {
 
 function normalizeCopyPath(relativePath: string): string {
   return relativePath.split(path.sep).join('/');
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 interface AcceptanceDiscoveryOptions {

--- a/packages/extension/tests/acceptance/graphView/workspace.ts
+++ b/packages/extension/tests/acceptance/graphView/workspace.ts
@@ -2,7 +2,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import ignore, { type Ignore } from 'ignore';
-import { unknownRecordSchema } from '../../../src/shared/values';
+import {
+  looseStringArraySchema,
+  unknownRecordSchema,
+} from '../../../src/shared/values';
 import { DEFAULT_INCLUDE, DEFAULT_MAX_FILES } from '../../../../core/src/discovery/file/defaults';
 import {
   DEFAULT_EXCLUDE,
@@ -223,12 +226,12 @@ function readAcceptanceFilterSettings(workspacePath: string): AcceptanceFilterSe
       plugins?: unknown;
       respectGitignore?: unknown;
     };
-    const include = readStringArray(settings.include);
+    const include = readUniqueStringArray(settings.include);
 
     return {
-      disabledCustomFilterPatterns: readStringArray(settings.disabledCustomFilterPatterns),
-      disabledPluginFilterPatterns: readStringArray(settings.disabledPluginFilterPatterns),
-      filterPatterns: readStringArray(settings.filterPatterns),
+      disabledCustomFilterPatterns: readUniqueStringArray(settings.disabledCustomFilterPatterns),
+      disabledPluginFilterPatterns: readUniqueStringArray(settings.disabledPluginFilterPatterns),
+      filterPatterns: readUniqueStringArray(settings.filterPatterns),
       include: include.length > 0 ? include : [...DEFAULT_INCLUDE],
       maxFiles: readMaxFiles(settings.maxFiles),
       plugins: readAcceptancePluginSettings(settings.plugins),
@@ -374,7 +377,7 @@ function readAcceptancePluginSettings(value: unknown): AcceptanceFilterSettings[
         return undefined;
       }
 
-      const disabledFilterPatterns = readStringArray(entry.disabledFilterPatterns);
+      const disabledFilterPatterns = readUniqueStringArray(entry.disabledFilterPatterns);
       return {
         enabled: entry.enabled !== false,
         packageName,
@@ -386,10 +389,8 @@ function readAcceptancePluginSettings(value: unknown): AcceptanceFilterSettings[
     .filter((entry): entry is AcceptanceFilterSettings['plugins'][number] => entry !== undefined);
 }
 
-function readStringArray(value: unknown): string[] {
-  return Array.isArray(value)
-    ? [...new Set(value.filter((pattern): pattern is string => typeof pattern === 'string'))]
-    : [];
+function readUniqueStringArray(value: unknown): string[] {
+  return [...new Set(looseStringArraySchema.parse(value))];
 }
 
 function readMaxFiles(value: unknown): number {

--- a/packages/extension/tests/extension/gitHistory/cache/storage.test.ts
+++ b/packages/extension/tests/extension/gitHistory/cache/storage.test.ts
@@ -59,6 +59,40 @@ describe('gitHistory/cache/storage', () => {
     await expect(
       readCachedGraphData({ fsPath: '/tmp/storage' } as never, 'abc123', fsPromises as never)
     ).resolves.toEqual({ nodes: [], edges: [] });
+
+    fsPromises.access.mockResolvedValueOnce(undefined);
+    fsPromises.readFile.mockResolvedValueOnce('{bad json');
+    await expect(
+      readCachedGraphData({ fsPath: '/tmp/storage' } as never, 'abc123', fsPromises as never)
+    ).resolves.toEqual({ nodes: [], edges: [] });
+  });
+
+  it('returns empty graph data when cached JSON does not match the graph shape', async () => {
+    const fsPromises = createFsPromises();
+
+    fsPromises.access.mockResolvedValue(undefined);
+    fsPromises.readFile.mockResolvedValue(JSON.stringify({ nodes: [{ id: 'src/a.ts' }], edges: [] }));
+
+    await expect(
+      readCachedGraphData({ fsPath: '/tmp/storage' } as never, 'abc123', fsPromises as never)
+    ).resolves.toEqual({ nodes: [], edges: [] });
+  });
+
+  it('normalizes missing cached edge sources to an empty provenance list', async () => {
+    const fsPromises = createFsPromises();
+
+    fsPromises.access.mockResolvedValue(undefined);
+    fsPromises.readFile.mockResolvedValue(JSON.stringify({
+      nodes: [{ id: 'src/a.ts', label: 'a.ts', color: '#fff' }],
+      edges: [{ id: 'a->b#import', from: 'src/a.ts', to: 'src/b.ts', kind: 'import' }],
+    }));
+
+    await expect(
+      readCachedGraphData({ fsPath: '/tmp/storage' } as never, 'abc123', fsPromises as never)
+    ).resolves.toEqual({
+      nodes: [{ id: 'src/a.ts', label: 'a.ts', color: '#fff' }],
+      edges: [{ id: 'a->b#import', from: 'src/a.ts', to: 'src/b.ts', kind: 'import', sources: [] }],
+    });
   });
 
   it('returns empty graph data when storage is unavailable', async () => {

--- a/packages/extension/tests/extension/graphView/analysis/execution/publish/equality/collections.test.ts
+++ b/packages/extension/tests/extension/graphView/analysis/execution/publish/equality/collections.test.ts
@@ -31,6 +31,11 @@ describe('extension/graphView/analysis/execution/publish/equality/collections', 
     expect(compareGraphRecordValues({ id: 'src/a.ts' }, { id: 'src/a.ts', extra: true }, comparePrimitiveValue)).toBe(false);
   });
 
+  it('treats missing graph payload keys like explicit undefined values', () => {
+    expect(compareGraphRecordValues({}, { extra: undefined }, comparePrimitiveValue)).toBe(true);
+    expect(compareGraphRecordValues({ leftKey: undefined }, { rightKey: undefined }, comparePrimitiveValue)).toBe(true);
+  });
+
   it('rejects nulls and one-sided records', () => {
     expect(compareGraphRecordValues(null, {}, comparePrimitiveValue)).toBe(false);
     expect(compareGraphRecordValues({ id: 'src/a.ts' }, ['src/a.ts'], comparePrimitiveValue)).toBe(false);

--- a/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/manifest.test.ts
+++ b/packages/extension/tests/extension/graphView/groups/defaults/materialTheme/manifest.test.ts
@@ -87,4 +87,40 @@ describe('graphView/materialTheme/manifest', () => {
     }));
     expect(loadMaterialTheme(vscode.Uri.file(extensionRoot))?.manifest.fileExtensions?.js).toBe('javascript');
   });
+
+  it('caches malformed material icon manifests as unavailable', () => {
+    const extensionRoot = createTempDir();
+    const packageRoot = path.join(extensionRoot, 'packages', 'extension', 'node_modules', 'material-icon-theme');
+    fs.mkdirSync(path.join(packageRoot, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, 'package.json'), '{}');
+    fs.writeFileSync(path.join(packageRoot, 'dist', 'material-icons.json'), '{bad json');
+
+    expect(loadMaterialTheme(vscode.Uri.file(extensionRoot))).toBeNull();
+
+    fs.writeFileSync(path.join(packageRoot, 'dist', 'material-icons.json'), JSON.stringify({
+      fileExtensions: { ts: 'typescript' },
+    }));
+    expect(loadMaterialTheme(vscode.Uri.file(extensionRoot))).toBeNull();
+  });
+
+  it('filters malformed optional manifest maps', () => {
+    const extensionRoot = createTempDir();
+    const packageRoot = path.join(extensionRoot, 'packages', 'extension', 'node_modules', 'material-icon-theme');
+    fs.mkdirSync(path.join(packageRoot, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, 'package.json'), '{}');
+    fs.writeFileSync(path.join(packageRoot, 'dist', 'material-icons.json'), JSON.stringify({
+      fileExtensions: { ts: 'typescript', broken: 7 },
+      fileNames: 'invalid',
+      iconDefinitions: {
+        typescript: { iconPath: '../icons/typescript.svg' },
+        broken: { iconPath: 7 },
+      },
+    }));
+
+    expect(loadMaterialTheme(vscode.Uri.file(extensionRoot))?.manifest).toMatchObject({
+      fileExtensions: { ts: 'typescript' },
+      iconDefinitions: { typescript: { iconPath: '../icons/typescript.svg' } },
+    });
+    expect(loadMaterialTheme(vscode.Uri.file(extensionRoot))?.manifest.fileNames).toBeUndefined();
+  });
 });

--- a/packages/extension/tests/extension/repoSettings/meta.test.ts
+++ b/packages/extension/tests/extension/repoSettings/meta.test.ts
@@ -112,6 +112,35 @@ describe('extension/repoSettings/meta', () => {
     expect(readCodeGraphyRepoMeta(workspaceRoot).pendingChangedFiles).toEqual([]);
   });
 
+  it('filters invalid persisted metadata fields through the repo meta schema', () => {
+    const workspaceRoot = createTempWorkspace();
+    tempDirectories.push(workspaceRoot);
+    const metaPath = getCodeGraphyRepoMetaPath(workspaceRoot);
+
+    fs.mkdirSync(path.dirname(metaPath), { recursive: true });
+    fs.writeFileSync(
+      metaPath,
+      JSON.stringify({
+        version: 999,
+        lastIndexedAt: 42,
+        lastIndexedCommit: 'abc123',
+        pluginSignature: null,
+        settingsSignature: { sha: 'settings-sha' },
+        pendingChangedFiles: ['src/app.ts', 7, 'src/index.ts'],
+      }, null, 2),
+      'utf8',
+    );
+
+    expect(readCodeGraphyRepoMeta(workspaceRoot)).toEqual({
+      version: 1,
+      lastIndexedAt: null,
+      lastIndexedCommit: 'abc123',
+      pluginSignature: null,
+      settingsSignature: null,
+      pendingChangedFiles: ['src/app.ts', 'src/index.ts'],
+    });
+  });
+
   it('falls back to defaults when meta.json is invalid', () => {
     const workspaceRoot = createTempWorkspace();
     tempDirectories.push(workspaceRoot);

--- a/packages/extension/tests/extension/repoSettings/store/model/plainObject.test.ts
+++ b/packages/extension/tests/extension/repoSettings/store/model/plainObject.test.ts
@@ -6,8 +6,13 @@ import {
 } from '../../../../../src/extension/repoSettings/store/model/plainObject';
 describe('extension/repoSettings/store/model/plainObject', () => {
   it('deep clones nested objects and arrays without preserving references', () => {
-    const original = {
+    const original: {
+      legend: Array<{ color: string; id: string; pattern: string }>;
+      optional?: string;
+      timeline: { maxCommits: number; playbackSpeed: number };
+    } = {
       legend: [{ id: 'legend-rule', pattern: 'src/**', color: '#123456' }],
+      optional: undefined,
       timeline: { maxCommits: 500, playbackSpeed: 1 },
     };
 
@@ -17,10 +22,12 @@ describe('extension/repoSettings/store/model/plainObject', () => {
 
     expect(cloned).toEqual({
       legend: [{ id: 'legend-rule', pattern: 'src/**', color: '#abcdef' }],
+      optional: undefined,
       timeline: { maxCommits: 500, playbackSpeed: 2 },
     });
     expect(original).toEqual({
       legend: [{ id: 'legend-rule', pattern: 'src/**', color: '#123456' }],
+      optional: undefined,
       timeline: { maxCommits: 500, playbackSpeed: 1 },
     });
   });

--- a/packages/extension/tests/shared/records.test.ts
+++ b/packages/extension/tests/shared/records.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { isObjectRecord } from '../../src/shared/records';
+
+describe('shared/records', () => {
+  it('accepts non-null object records and rejects arrays and primitives', () => {
+    expect(isObjectRecord({ legend: [] })).toBe(true);
+    expect(isObjectRecord(new Date('2026-01-01T00:00:00.000Z'))).toBe(true);
+    expect(isObjectRecord(null)).toBe(false);
+    expect(isObjectRecord(['legend'])).toBe(false);
+    expect(isObjectRecord('settings')).toBe(false);
+    expect(isObjectRecord(42)).toBe(false);
+  });
+});

--- a/packages/extension/tests/shared/values.test.ts
+++ b/packages/extension/tests/shared/values.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  looseStringArraySchema,
+  nonEmptyStringSchema,
+  trimmedNonEmptyStringSchema,
+} from '../../src/shared/values';
+
+describe('shared/values', () => {
+  it('filters loose string arrays while defaulting non-arrays to empty arrays', () => {
+    expect(looseStringArraySchema.parse(['src/**', 7, 'tests/**'])).toEqual(['src/**', 'tests/**']);
+    expect(looseStringArraySchema.parse('src/**')).toEqual([]);
+  });
+
+  it('validates non-empty strings without trimming', () => {
+    expect(nonEmptyStringSchema.safeParse(' plugin ').success).toBe(true);
+    expect(nonEmptyStringSchema.safeParse('').success).toBe(false);
+  });
+
+  it('trims strings before requiring non-empty content', () => {
+    expect(trimmedNonEmptyStringSchema.parse(' plugin ')).toBe('plugin');
+    expect(trimmedNonEmptyStringSchema.safeParse('   ').success).toBe(false);
+  });
+});

--- a/packages/extension/tests/webview/components/graph/runtime/physics/numeric.test.ts
+++ b/packages/extension/tests/webview/components/graph/runtime/physics/numeric.test.ts
@@ -3,6 +3,8 @@ import {
   clamp,
   getFiniteVelocity,
   isFiniteNumber,
+  isFinitePair,
+  isFinitePositiveNumber,
   resolveNodeCoordinate,
 } from '../../../../../../src/webview/components/graph/runtime/physics/numeric';
 
@@ -12,6 +14,21 @@ describe('webview/components/graph/runtime/physics/numeric', () => {
     expect(isFiniteNumber(Number.POSITIVE_INFINITY)).toBe(false);
     expect(isFiniteNumber(Number.NaN)).toBe(false);
     expect(isFiniteNumber('4')).toBe(false);
+  });
+
+  it('accepts only positive finite numbers', () => {
+    expect(isFinitePositiveNumber(4)).toBe(true);
+    expect(isFinitePositiveNumber(0)).toBe(false);
+    expect(isFinitePositiveNumber(-1)).toBe(false);
+    expect(isFinitePositiveNumber(Number.NaN)).toBe(false);
+    expect(isFinitePositiveNumber('4')).toBe(false);
+  });
+
+  it('accepts only finite two-number pairs', () => {
+    expect(isFinitePair([0, 1])).toBe(true);
+    expect(isFinitePair([0, Number.NaN])).toBe(false);
+    expect(isFinitePair([0, 1, 2])).toBe(false);
+    expect(isFinitePair('pair')).toBe(false);
   });
 
   it('clamps values into the provided bounds', () => {

--- a/packages/extension/tests/webview/graph/support/index.test.ts
+++ b/packages/extension/tests/webview/graph/support/index.test.ts
@@ -6,7 +6,6 @@ import {
 import {
   hasDistanceAndStrength,
   hasStrength,
-  isRecordLike,
 } from '../../../../src/webview/components/graph/support/guards';
 import {
   resolveEdgeActionTargetId,
@@ -19,13 +18,6 @@ import {
 import type SpriteText from 'three-spritetext';
 
 describe('graph/support', () => {
-  it('recognizes objects and functions as record-like values', () => {
-    expect(isRecordLike({ key: 'value' })).toBe(true);
-    expect(isRecordLike(() => undefined)).toBe(true);
-    expect(isRecordLike(null)).toBe(false);
-    expect(isRecordLike('text')).toBe(false);
-  });
-
   it('detects force objects with a strength function', () => {
     expect(hasStrength({ strength: () => undefined })).toBe(true);
     expect(hasStrength({ strength: 'nope' })).toBe(false);

--- a/packages/extension/tests/webview/legends/panel/storage.test.ts
+++ b/packages/extension/tests/webview/legends/panel/storage.test.ts
@@ -37,6 +37,12 @@ describe('webview/components/legends/panel/storage', () => {
     });
   });
 
+  it('returns an empty collapsed state when persisted webview state is not a JSON record', () => {
+    mockState = new Date('2026-01-01T00:00:00.000Z');
+
+    expect(readLegendPanelCollapsedState()).toEqual({});
+  });
+
   it('merges collapsed entries back into the existing webview state', () => {
     mockState = { keep: 'value' };
 

--- a/packages/extension/tests/webview/pluginRuntime/messageValidation.test.ts
+++ b/packages/extension/tests/webview/pluginRuntime/messageValidation.test.ts
@@ -43,17 +43,47 @@ describe('normalizePluginInjectPayload', () => {
     });
   });
 
-  it('defaults scripts and styles to empty arrays when they are not arrays', () => {
+  it('defaults scripts, styles, and assets to empty arrays when they are not arrays', () => {
     expect(normalizePluginInjectPayload({
       pluginId: 'plugin.test',
       scripts: 'a.js',
       styles: { href: 'a.css' },
+      assets: 'fireflies',
     })).toEqual({
       pluginId: 'plugin.test',
       scripts: [],
       styles: [],
       assets: [],
     });
+  });
+
+  it('preserves valid webview asset optional and plugin-owned fields', () => {
+    expect(normalizePluginInjectPayload({
+      pluginId: 'plugin.test',
+      scripts: [],
+      styles: [],
+      assets: [
+        {
+          id: 'fireflies',
+          label: 'Fireflies',
+          url: 'webview://fireflies.js',
+          path: 'assets/fireflies.js',
+          kind: 'script',
+          metadata: { glow: true },
+          pluginOwned: 'kept',
+        },
+      ],
+    })?.assets).toEqual([
+      {
+        id: 'fireflies',
+        label: 'Fireflies',
+        url: 'webview://fireflies.js',
+        path: 'assets/fireflies.js',
+        kind: 'script',
+        metadata: { glow: true },
+        pluginOwned: 'kept',
+      },
+    ]);
   });
 });
 

--- a/packages/extension/tests/webview/store/messageHandlers/equality/structures.test.ts
+++ b/packages/extension/tests/webview/store/messageHandlers/equality/structures.test.ts
@@ -23,4 +23,9 @@ describe('webview/store/messageHandlers/equality/structures', () => {
     expect(arePlainObjectValuesEqual({ value: 1 }, ['value', 1])).toBe(false);
     expect(arePlainObjectValuesEqual({ value: 1 }, { value: 2 })).toBe(false);
   });
+
+  it('treats explicit undefined object keys as part of webview message state', () => {
+    expect(arePlainObjectValuesEqual({}, { extra: undefined })).toBe(false);
+    expect(arePlainObjectValuesEqual({ leftKey: undefined }, { rightKey: undefined })).toBe(true);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,9 @@ importers:
       tree-sitter-typescript:
         specifier: ^0.23.2
         version: 0.23.2(tree-sitter@0.25.0(patch_hash=581e1c376edeabe3d25b64ea7bac59e14cc731627b17b97acccf0cce1dd051cb))
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@18.3.28)(react@18.3.1)


### PR DESCRIPTION
## Summary
Follow-up to #302. That PR removed the hand-rolled `isRecord` guards; this one finishes the job (the extension-side commit missed the merge — cherry-picked here as the first commit) and cleans up the ten related code smells found in a monorepo-wide sweep.


## Progress update
✅ Items 1–2: consolidated object-record probes and JSON-state parsing; switched repo-settings clone to `structuredClone`.
✅ Item 3: kept host/webview equality comparators separate after documenting their `undefined` key semantics; shared the record guard plumbing.
✅ Item 4: consolidated finite-number, positive-number, and pair guards in graph physics numeric helpers.
✅ Item 5: moved string-array/string readers onto shared schema-backed value helpers while preserving boundary-specific string semantics.
✅ Item 6: replaced plugin-runtime message probing with zod schemas that keep lenient filtering behavior.
✅ Item 7: schema-validated the remaining unvalidated persisted JSON boundaries; left already-normalized parse sites unchanged.
✅ Item 8: covered by the repo-settings clone update in items 1–2.
✅ Item 9: centralized unavoidable Tree-sitter language casts in one helper path.
✅ Item 10: intentionally kept core and extension `unknownRecordSchema` package-local to avoid expanding core's public API for a generic zod helper.

## Plan of action

**0. Leftover `isRecord` from #302** ✅ (first commit, cherry-picked)
`e2e/workspacePlugins.ts`, `pluginData.ts`, `cssSnippets.ts`, webview `guards.ts`/`linkTargets.ts`, acceptance helpers — zod at JSON boundaries, direct property checks for live d3-force objects.

**1–2. `isPlainObject` / `isGraphRecord` clones (4 copies)**
`repoSettings/store/model/plainObject.ts`, `webview/store/messageHandlers/equality/structures.ts`, `webview/components/legends/panel/storage.ts`, `graphView/analysis/execution/publish/equality/collections.ts`.
Approach: where the value comes from JSON/persisted state, parse with the shared `unknownRecordSchema`; where it's a structural probe in equality code, keep ONE shared typed helper and delete the clones.

**3. Duplicate deep-equality implementations**
Extension-host `publish/equality/*` vs webview `messageHandlers/equality/structures.ts`. Approach: compare semantics; if identical, extract one comparator into `src/shared/`; if intentionally different (host compares graph payloads, webview compares message state), document why and still deduplicate the record/array plumbing. Conservative: no behavior change, existing tests must stay green.

**4. `isFiniteNumber` × 4+ webview copies (+ `isFinitePositiveNumber`, `isFinitePair`)**
Consolidate into one exported helper next to the existing `runtime/physics/numeric.ts`, update all import sites, delete clones.

**5. `readStringArray` / `readOptionalString` / `readRequiredString` re-implementations**
`repoSettings/store/model/persistedShape/stringArray.ts`, e2e + acceptance helpers, core `graphCache/database/records/values.ts`. Approach: move to the shared zod value schemas (`looseStringArraySchema` etc.) introduced in #302; core keeps its own copy in `core/src/values.ts`, extension uses `src/shared/values.ts`.

**6. Webview plugin-runtime message validation**
`webview/pluginRuntime/messageValidation.ts` hand-probes `payload as {...}` field by field. Replace with zod schemas producing `PluginInjectPayload` / `PluginWebviewAsset` / `PluginScopedMessage`, preserving current lenient semantics (filter bad entries, don't throw).

**7. Unvalidated `JSON.parse` + cast boundaries (audit + schema-fy)**
`repoSettings/store/persistence/diskState.ts`, `gitHistory/cache/storage.ts`, `graphView/groups/defaults/materialTheme/manifest.ts`, `repoSettings/meta.ts`, core `plugins/installedPluginCache/storage.ts`, `workspace/meta.ts`. Approach: audit each; where the parsed value is cast or property-probed, add a zod schema; where it's already routed through a normalizer, leave it.

**8. `deepClone` via `JSON.parse(JSON.stringify(...))`**
`repoSettings/store/model/plainObject.ts` — switch to `structuredClone` (Node 20+ / modern webview), verify no reliance on JSON's undefined-dropping behavior in call sites first.

**9. 19× `as unknown as Parser.Language` in `core/treeSitter/runtime/languages/load.ts`**
Extract a single typed `loadLanguageModule()` helper so the unavoidable cast appears once, documented.

**10. Duplicate `unknownRecordSchema` (core + extension)**
Decide single source: keep both (packages are published independently) OR export from `@codegraphy-dev/core`. Default plan: export from core's public API and delete the extension copy, unless bundle/API-surface concerns say otherwise.

## Method
- One commit per numbered item (or small cluster), pushed as completed
- No behavior changes intended; full unit suites + typecheck per package before each commit
- CRAP ≤ 8 / mutation thresholds respected for changed functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
