### PR TITLE
docs: add generated architecture board

### DIFF
--- a/boards/architecture.command.test.ts
+++ b/boards/architecture.command.test.ts
@@ -1,0 +1,69 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildArchitectureBoard,
+  serializeArchitectureBoard,
+} from "./architecture.command";
+
+describe("CodeGraphy architecture board generator", () => {
+  it("emits a tldraw v5-compatible .tldr document with unique records", () => {
+    const board = buildArchitectureBoard();
+    const ids = board.records.map((record) => record.id);
+
+    expect(board.tldrawFileFormatVersion).toBe(1);
+    expect(board.schema.schemaVersion).toBe(2);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(board.records.filter((record) => record.typeName === "shape").length).toBeGreaterThan(30);
+  });
+
+  it("captures the current product, Core, renderer, cache, and plugin boundaries", () => {
+    const serialized = serializeArchitectureBoard();
+
+    expect(serialized).toContain("VS Code extension host");
+    expect(serialized).toContain("Core package");
+    expect(serialized).toContain("Graph Query");
+    expect(serialized).toContain("SQLite Graph Cache");
+    expect(serialized).toContain("WebGPU drawing · WASM physics");
+    expect(serialized).toContain("Plugin API");
+    expect(serialized).toContain("Entrypoints");
+    expect(serialized).toContain("Plugin boundary");
+  });
+
+  it("records the three load-bearing architecture decisions", () => {
+    const serialized = serializeArchitectureBoard();
+
+    expect(serialized).toContain("No MCP path");
+    expect(serialized).toContain("SQLite persists snapshots");
+    expect(serialized).toContain("TypeScript resolution stays in plugin analysis");
+  });
+
+  it("constrains annotation text to its assigned board width", () => {
+    const textShapes = buildArchitectureBoard().records.filter(
+      (record) => record.typeName === "shape" && record.type === "text",
+    );
+
+    expect(textShapes).not.toHaveLength(0);
+    expect(
+      textShapes.every((record) => {
+        const props = record.props as { autoSize?: boolean };
+        return props.autoSize === false;
+      }),
+    ).toBe(true);
+  });
+
+  it("runs as a repository script", () => {
+    const require = createRequire(import.meta.url);
+    const scriptPath = fileURLToPath(new URL("architecture.command.ts", import.meta.url));
+    const result = spawnSync(process.execPath, [require.resolve("tsx/cli"), scriptPath], {
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("Generated ");
+    expect(result.stdout).toContain("boards/main.tldr");
+  });
+});

--- a/boards/architecture.command.test.ts
+++ b/boards/architecture.command.test.ts
@@ -29,8 +29,8 @@ describe("CodeGraphy architecture board generator", () => {
     expect(serialized).toContain("SQLite Graph Cache");
     expect(serialized).toContain("WebGPU drawing · WASM physics");
     expect(serialized).toContain("Plugin API");
-    expect(serialized).toContain("Entrypoints");
-    expect(serialized).toContain("Plugin boundary");
+    expect(serialized).toContain("PRODUCT SURFACES");
+    expect(serialized).toContain("CAPABILITY PROVIDERS");
   });
 
   it("records the three load-bearing architecture decisions", () => {

--- a/boards/architecture.command.ts
+++ b/boards/architecture.command.ts
@@ -1,0 +1,527 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export interface TldrawSchema {
+  schemaVersion: number;
+  sequences: Record<string, number>;
+}
+
+export interface TldrawRecord {
+  id: string;
+  typeName: string;
+  [key: string]: unknown;
+}
+
+export interface TldrawFile {
+  tldrawFileFormatVersion: number;
+  schema: TldrawSchema;
+  records: TldrawRecord[];
+}
+
+interface ShapeOptions {
+  color?: string;
+  dash?: string;
+  fill?: string;
+  geo?: string;
+  labelColor?: string;
+  opacity?: number;
+  size?: string;
+}
+
+interface TextOptions {
+  color?: string;
+  opacity?: number;
+  size?: string;
+  textAlign?: string;
+}
+
+interface ArrowOptions {
+  arrowheadEnd?: string;
+  arrowheadStart?: string;
+  bend?: number;
+  color?: string;
+  dash?: string;
+  labelColor?: string;
+  labelPosition?: number;
+  opacity?: number;
+  size?: string;
+}
+
+interface RichTextNode {
+  type: string;
+  attrs?: { dir: string };
+  content?: RichTextNode[];
+  text?: string;
+}
+
+const tldrawSchema: TldrawSchema = {
+  schemaVersion: 2,
+  sequences: {
+    "com.tldraw.store": 5,
+    "com.tldraw.asset": 1,
+    "com.tldraw.camera": 1,
+    "com.tldraw.document": 2,
+    "com.tldraw.instance": 26,
+    "com.tldraw.instance_page_state": 5,
+    "com.tldraw.page": 1,
+    "com.tldraw.instance_presence": 6,
+    "com.tldraw.pointer": 1,
+    "com.tldraw.shape": 4,
+    "com.tldraw.user": 1,
+    "com.tldraw.asset.image": 6,
+    "com.tldraw.asset.video": 5,
+    "com.tldraw.asset.bookmark": 2,
+    "com.tldraw.shape.group": 0,
+    "com.tldraw.shape.text": 4,
+    "com.tldraw.shape.bookmark": 2,
+    "com.tldraw.shape.draw": 5,
+    "com.tldraw.shape.geo": 11,
+    "com.tldraw.shape.note": 13,
+    "com.tldraw.shape.line": 5,
+    "com.tldraw.shape.frame": 1,
+    "com.tldraw.shape.arrow": 8,
+    "com.tldraw.shape.highlight": 4,
+    "com.tldraw.shape.embed": 4,
+    "com.tldraw.shape.image": 5,
+    "com.tldraw.shape.video": 4,
+    "com.tldraw.binding.arrow": 1,
+  },
+};
+
+const indexCharacters = "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+function createRichText(value: string): RichTextNode {
+  const lines = value === "" ? [""] : value.split("\n");
+  return {
+    type: "doc",
+    attrs: { dir: "auto" },
+    content: lines.map((line) => ({
+      type: "paragraph",
+      attrs: { dir: "auto" },
+      ...(line === ""
+        ? {}
+        : {
+            content: [
+              {
+                type: "text",
+                text: line,
+              },
+            ],
+          }),
+    })),
+  };
+}
+
+function createBaseRecords(): TldrawRecord[] {
+  return [
+    {
+      x: 0,
+      y: 0,
+      lastActivityTimestamp: 0,
+      meta: {},
+      id: "pointer:pointer",
+      typeName: "pointer",
+    },
+    {
+      x: 20,
+      y: 20,
+      z: 0.7,
+      meta: {},
+      id: "camera:page:page",
+      typeName: "camera",
+    },
+    {
+      editingShapeId: null,
+      croppingShapeId: null,
+      selectedShapeIds: [],
+      hoveredShapeId: null,
+      erasingShapeIds: [],
+      hintingShapeIds: [],
+      focusedGroupId: null,
+      meta: {},
+      id: "instance_page_state:page:page",
+      pageId: "page:page",
+      typeName: "instance_page_state",
+    },
+    {
+      meta: {},
+      id: "page:page",
+      name: "Architecture",
+      index: "a1",
+      typeName: "page",
+    },
+    {
+      gridSize: 10,
+      name: "CodeGraphy architecture",
+      meta: {},
+      id: "document:document",
+      typeName: "document",
+    },
+    {
+      followingUserId: null,
+      opacityForNextShape: 1,
+      stylesForNextShape: { "tldraw:geo": "rectangle" },
+      brush: null,
+      scribbles: [],
+      cursor: { type: "default", rotation: 0 },
+      isFocusMode: false,
+      exportBackground: true,
+      isDebugMode: false,
+      isToolLocked: false,
+      screenBounds: { x: 0, y: 0, w: 1440, h: 900 },
+      insets: [false, false, false, false],
+      zoomBrush: null,
+      isGridMode: false,
+      isPenMode: false,
+      chatMessage: "",
+      isChatting: false,
+      highlightedUserIds: [],
+      isFocused: true,
+      devicePixelRatio: 1,
+      isCoarsePointer: false,
+      isHoveringCanvas: false,
+      openMenus: [],
+      isChangingStyle: false,
+      isReadonly: false,
+      meta: {},
+      duplicateProps: null,
+      cameraState: "idle",
+      id: "instance:instance",
+      currentPageId: "page:page",
+      typeName: "instance",
+    },
+    {
+      name: "CodeGraphy",
+      color: "#64748B",
+      imageUrl: "",
+      meta: {},
+      id: "user:codegraphy",
+      typeName: "user",
+    },
+  ];
+}
+
+export function buildArchitectureBoard(): TldrawFile {
+  const records: TldrawRecord[] = [];
+  let indexCursor = 0;
+
+  function nextIndex(): string {
+    const character = indexCharacters[indexCursor];
+    if (character === undefined) {
+      throw new Error("The architecture board has more shapes than its index sequence supports.");
+    }
+    indexCursor += 1;
+    return "a" + character;
+  }
+
+  function addGeo(
+    id: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    label: string,
+    options: ShapeOptions = {},
+  ): void {
+    records.push({
+      x,
+      y,
+      rotation: 0,
+      isLocked: false,
+      opacity: options.opacity ?? 1,
+      meta: {},
+      id: "shape:" + id,
+      type: "geo",
+      props: {
+        w: width,
+        h: height,
+        geo: options.geo ?? "rectangle",
+        dash: options.dash ?? "solid",
+        growY: 0,
+        url: "",
+        scale: 1,
+        color: options.color ?? "grey",
+        labelColor: options.labelColor ?? "black",
+        fill: options.fill ?? "semi",
+        size: options.size ?? "m",
+        font: "sans",
+        align: "middle",
+        verticalAlign: "middle",
+        richText: createRichText(label),
+      },
+      parentId: "page:page",
+      index: nextIndex(),
+      typeName: "shape",
+    });
+  }
+
+  function addText(
+    id: string,
+    x: number,
+    y: number,
+    width: number,
+    label: string,
+    options: TextOptions = {},
+  ): void {
+    records.push({
+      x,
+      y,
+      rotation: 0,
+      isLocked: false,
+      opacity: options.opacity ?? 1,
+      meta: {},
+      id: "shape:" + id,
+      type: "text",
+      props: {
+        color: options.color ?? "black",
+        size: options.size ?? "m",
+        w: width,
+        font: "sans",
+        textAlign: options.textAlign ?? "start",
+        autoSize: false,
+        scale: 1,
+        richText: createRichText(label),
+      },
+      parentId: "page:page",
+      index: nextIndex(),
+      typeName: "shape",
+    });
+  }
+
+  function addArrow(
+    id: string,
+    x: number,
+    y: number,
+    endX: number,
+    endY: number,
+    label = "",
+    options: ArrowOptions = {},
+  ): void {
+    records.push({
+      x,
+      y,
+      rotation: 0,
+      isLocked: false,
+      opacity: options.opacity ?? 1,
+      meta: {},
+      id: "shape:" + id,
+      type: "arrow",
+      props: {
+        kind: "arc",
+        elbowMidPoint: 0.5,
+        dash: options.dash ?? "solid",
+        size: options.size ?? "s",
+        fill: "none",
+        color: options.color ?? "grey",
+        labelColor: options.labelColor ?? "grey",
+        bend: options.bend ?? 0,
+        start: { x: 0, y: 0 },
+        end: { x: endX - x, y: endY - y },
+        arrowheadStart: options.arrowheadStart ?? "none",
+        arrowheadEnd: options.arrowheadEnd ?? "arrow",
+        richText: createRichText(label),
+        labelPosition: options.labelPosition ?? 0.5,
+        font: "sans",
+        scale: 1,
+      },
+      parentId: "page:page",
+      index: nextIndex(),
+      typeName: "shape",
+    });
+  }
+
+  // Connectors are added first so they render beneath the nodes.
+  addArrow("user-to-host", 320, 285, 420, 285, "opens");
+  addArrow("host-to-webview", 720, 285, 1110, 285);
+  addArrow("webview-to-renderer", 1260, 365, 1260, 455, "render model");
+  addArrow("agent-to-core", 320, 675, 430, 745);
+  addArrow("host-to-core", 560, 365, 500, 700, "same Core APIs", { bend: -36 });
+  addArrow("core-to-discovery", 600, 755, 650, 755);
+  addArrow("discovery-to-analysis", 810, 755, 850, 755);
+  addArrow("analysis-to-projection", 1030, 755, 1070, 755);
+  addArrow("projection-to-cache", 1150, 810, 1110, 895, "persists");
+  addArrow("cache-to-query", 1000, 945, 740, 945, "loads snapshots");
+  addArrow("core-to-query", 520, 810, 590, 895, "query");
+  addArrow("api-to-language", 1430, 795, 1430, 885, "implemented by");
+  addArrow("language-to-analysis", 1260, 950, 1000, 810, "graph facts", { bend: 28 });
+  addArrow("particles-to-webview", 1320, 1080, 1360, 365, "effect runtime", { bend: 74 });
+  addArrow("settings-to-core", 360, 945, 430, 780, "workspace state");
+
+  addText("title", 80, 55, 760, "CodeGraphy architecture", { size: "xl" });
+  addText(
+    "subtitle",
+    82,
+    118,
+    1180,
+    "One Core-owned graph pipeline, shared by the VS Code product and the agent-facing CLI.",
+    { size: "m", color: "grey" },
+  );
+
+  addText("entry-heading", 80, 205, 260, "Entrypoints", { size: "l" });
+  addGeo("developer", 80, 250, 240, 115, "Developer\nVS Code", {
+    color: "light-blue",
+    fill: "semi",
+  });
+  addGeo("agent", 80, 615, 240, 120, "Agent / CI\nCodeGraphy Agent Skill", {
+    color: "light-green",
+    fill: "semi",
+  });
+  addText(
+    "no-mcp",
+    82,
+    755,
+    270,
+    "No MCP path. The skill teaches agents to call the Core-owned CLI.",
+    { size: "s", color: "grey" },
+  );
+
+  addText("product-heading", 420, 175, 700, "VS Code product boundary", { size: "l" });
+  addGeo(
+    "extension-host",
+    420,
+    220,
+    300,
+    145,
+    "VS Code extension host\nworkspace lifecycle · settings · plugins",
+    { color: "light-blue", fill: "semi", size: "s" },
+  );
+  addGeo("shared-protocol", 820, 235, 230, 100, "Shared protocol\nhost ↔ webview", {
+    color: "grey",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("graph-view", 1110, 220, 300, 145, "React webview\nGraph View · controls · state", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo(
+    "graph-renderer",
+    1110,
+    455,
+    300,
+    140,
+    "Graph renderer\nWebGPU drawing · WASM physics",
+    { color: "orange", fill: "semi", size: "s" },
+  );
+  addText(
+    "renderer-note",
+    1115,
+    610,
+    310,
+    "The extension owns lifecycle and interaction. The renderer owns an efficient drawing and layout runtime.",
+    { size: "s", color: "grey" },
+  );
+
+  addText("core-heading", 430, 635, 650, "Core owns graph truth", { size: "l" });
+  addGeo("core-api", 430, 700, 170, 110, "Core package\nindex + query API", {
+    color: "light-green",
+    fill: "solid",
+    size: "s",
+  });
+  addGeo("discovery", 650, 700, 160, 110, "File\ndiscovery", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("analysis", 850, 700, 180, 110, "Tree-sitter +\nplugin analysis", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("projection", 1070, 700, 160, 110, "Graph\nprojection", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("query", 520, 895, 220, 100, "Graph Query\nin-memory semantics", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("cache", 1000, 895, 220, 100, ".codegraphy/graph.sqlite\nSQLite Graph Cache", {
+    color: "grey",
+    fill: "semi",
+    size: "s",
+  });
+  addText(
+    "sqlite-note",
+    790,
+    1020,
+    430,
+    "SQLite persists snapshots. Traversal, scope, filtering, search, and projection remain Core-owned.",
+    { size: "s", color: "grey" },
+  );
+  addGeo(
+    "settings",
+    80,
+    900,
+    280,
+    90,
+    ".codegraphy/settings.json\nshared workspace state",
+    { color: "grey", fill: "semi", size: "s" },
+  );
+
+  addText("plugins-heading", 1260, 675, 330, "Plugin boundary", {
+    size: "l",
+  });
+  addGeo("plugin-api", 1305, 720, 250, 100, "Plugin API\ncontracts only", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo(
+    "language-plugins",
+    1260,
+    885,
+    350,
+    130,
+    "Analysis plugins\nTypeScript · Markdown · Vue · Svelte\nGodot · Unity",
+    { color: "orange", fill: "semi", size: "s" },
+  );
+  addGeo("particles", 1260, 1040, 350, 90, "Presentation plugin\nParticles", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addText(
+    "plugin-note",
+    1265,
+    1150,
+    380,
+    "TypeScript resolution stays in plugin analysis. Plugins contribute Nodes, Relationships, types, and evidence.",
+    { size: "s", color: "grey" },
+  );
+
+  return {
+    tldrawFileFormatVersion: 1,
+    schema: tldrawSchema,
+    records: [...createBaseRecords(), ...records],
+  };
+}
+
+export function serializeArchitectureBoard(): string {
+  return JSON.stringify(buildArchitectureBoard(), null, 2) + "\n";
+}
+
+export async function writeArchitectureBoard(
+  destination = fileURLToPath(new URL("main.tldr", import.meta.url)),
+): Promise<string> {
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, serializeArchitectureBoard(), "utf8");
+  return destination;
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath !== undefined && import.meta.url === pathToFileURL(invokedPath).href) {
+  void writeArchitectureBoard()
+    .then((destination) => {
+      process.stdout.write("Generated " + destination + "\n");
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.stack ?? error.message : String(error);
+      process.stderr.write(message + "\n");
+      process.exitCode = 1;
+    });
+}

--- a/boards/architecture.command.ts
+++ b/boards/architecture.command.ts
@@ -20,6 +20,7 @@ export interface TldrawFile {
 }
 
 interface ShapeOptions {
+  align?: string;
   color?: string;
   dash?: string;
   fill?: string;
@@ -27,6 +28,7 @@ interface ShapeOptions {
   labelColor?: string;
   opacity?: number;
   size?: string;
+  verticalAlign?: string;
 }
 
 interface TextOptions {
@@ -91,6 +93,19 @@ const tldrawSchema: TldrawSchema = {
 
 const indexCharacters = "123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
+const architecturePages = [
+  { key: "overview", name: "01 System overview" },
+  { key: "indexing", name: "02 Indexing and query" },
+  { key: "runtime", name: "03 VS Code runtime" },
+  { key: "plugins", name: "04 Plugin system" },
+] as const;
+
+type ArchitecturePageKey = (typeof architecturePages)[number]["key"];
+
+function architecturePageId(key: ArchitecturePageKey): string {
+  return "page:" + key;
+}
+
 function createRichText(value: string): RichTextNode {
   const lines = value === "" ? [""] : value.split("\n");
   return {
@@ -114,6 +129,40 @@ function createRichText(value: string): RichTextNode {
 }
 
 function createBaseRecords(): TldrawRecord[] {
+  const pageRecords = architecturePages.flatMap<TldrawRecord>(({ key, name }, pageIndex) => {
+    const pageId = architecturePageId(key);
+    return [
+      {
+        x: 20,
+        y: 20,
+        z: 0.7,
+        meta: {},
+        id: "camera:" + pageId,
+        typeName: "camera",
+      },
+      {
+        editingShapeId: null,
+        croppingShapeId: null,
+        selectedShapeIds: [],
+        hoveredShapeId: null,
+        erasingShapeIds: [],
+        hintingShapeIds: [],
+        focusedGroupId: null,
+        meta: {},
+        id: "instance_page_state:" + pageId,
+        pageId,
+        typeName: "instance_page_state",
+      },
+      {
+        meta: {},
+        id: pageId,
+        name,
+        index: "a" + String(pageIndex + 1),
+        typeName: "page",
+      },
+    ];
+  });
+
   return [
     {
       x: 0,
@@ -123,34 +172,7 @@ function createBaseRecords(): TldrawRecord[] {
       id: "pointer:pointer",
       typeName: "pointer",
     },
-    {
-      x: 20,
-      y: 20,
-      z: 0.7,
-      meta: {},
-      id: "camera:page:page",
-      typeName: "camera",
-    },
-    {
-      editingShapeId: null,
-      croppingShapeId: null,
-      selectedShapeIds: [],
-      hoveredShapeId: null,
-      erasingShapeIds: [],
-      hintingShapeIds: [],
-      focusedGroupId: null,
-      meta: {},
-      id: "instance_page_state:page:page",
-      pageId: "page:page",
-      typeName: "instance_page_state",
-    },
-    {
-      meta: {},
-      id: "page:page",
-      name: "Architecture",
-      index: "a1",
-      typeName: "page",
-    },
+    ...pageRecords,
     {
       gridSize: 10,
       name: "CodeGraphy architecture",
@@ -188,7 +210,7 @@ function createBaseRecords(): TldrawRecord[] {
       duplicateProps: null,
       cameraState: "idle",
       id: "instance:instance",
-      currentPageId: "page:page",
+      currentPageId: architecturePageId("overview"),
       typeName: "instance",
     },
     {
@@ -204,14 +226,20 @@ function createBaseRecords(): TldrawRecord[] {
 
 export function buildArchitectureBoard(): TldrawFile {
   const records: TldrawRecord[] = [];
-  let indexCursor = 0;
+  let activePageKey: ArchitecturePageKey = "overview";
+  const indexCursorByPage = new Map<ArchitecturePageKey, number>();
+
+  function beginPage(key: ArchitecturePageKey): void {
+    activePageKey = key;
+  }
 
   function nextIndex(): string {
+    const indexCursor = indexCursorByPage.get(activePageKey) ?? 0;
     const character = indexCharacters[indexCursor];
     if (character === undefined) {
       throw new Error("The architecture board has more shapes than its index sequence supports.");
     }
-    indexCursor += 1;
+    indexCursorByPage.set(activePageKey, indexCursor + 1);
     return "a" + character;
   }
 
@@ -231,7 +259,7 @@ export function buildArchitectureBoard(): TldrawFile {
       isLocked: false,
       opacity: options.opacity ?? 1,
       meta: {},
-      id: "shape:" + id,
+      id: "shape:" + activePageKey + ":" + id,
       type: "geo",
       props: {
         w: width,
@@ -246,11 +274,11 @@ export function buildArchitectureBoard(): TldrawFile {
         fill: options.fill ?? "semi",
         size: options.size ?? "m",
         font: "sans",
-        align: "middle",
-        verticalAlign: "middle",
+        align: options.align ?? "middle",
+        verticalAlign: options.verticalAlign ?? "middle",
         richText: createRichText(label),
       },
-      parentId: "page:page",
+      parentId: architecturePageId(activePageKey),
       index: nextIndex(),
       typeName: "shape",
     });
@@ -271,7 +299,7 @@ export function buildArchitectureBoard(): TldrawFile {
       isLocked: false,
       opacity: options.opacity ?? 1,
       meta: {},
-      id: "shape:" + id,
+      id: "shape:" + activePageKey + ":" + id,
       type: "text",
       props: {
         color: options.color ?? "black",
@@ -283,7 +311,7 @@ export function buildArchitectureBoard(): TldrawFile {
         scale: 1,
         richText: createRichText(label),
       },
-      parentId: "page:page",
+      parentId: architecturePageId(activePageKey),
       index: nextIndex(),
       typeName: "shape",
     });
@@ -305,7 +333,7 @@ export function buildArchitectureBoard(): TldrawFile {
       isLocked: false,
       opacity: options.opacity ?? 1,
       meta: {},
-      id: "shape:" + id,
+      id: "shape:" + activePageKey + ":" + id,
       type: "arrow",
       props: {
         kind: "arc",
@@ -325,174 +353,699 @@ export function buildArchitectureBoard(): TldrawFile {
         font: "sans",
         scale: 1,
       },
-      parentId: "page:page",
+      parentId: architecturePageId(activePageKey),
       index: nextIndex(),
       typeName: "shape",
     });
   }
 
-  // Connectors are added first so they render beneath the nodes.
-  addArrow("user-to-host", 320, 285, 420, 285, "opens");
-  addArrow("host-to-webview", 720, 285, 1110, 285);
-  addArrow("webview-to-renderer", 1260, 365, 1260, 455, "render model");
-  addArrow("agent-to-core", 320, 675, 430, 745);
-  addArrow("host-to-core", 560, 365, 500, 700, "same Core APIs", { bend: -36 });
-  addArrow("core-to-discovery", 600, 755, 650, 755);
-  addArrow("discovery-to-analysis", 810, 755, 850, 755);
-  addArrow("analysis-to-projection", 1030, 755, 1070, 755);
-  addArrow("projection-to-cache", 1150, 810, 1110, 895, "persists");
-  addArrow("cache-to-query", 1000, 945, 740, 945, "loads snapshots");
-  addArrow("core-to-query", 520, 810, 590, 895, "query");
-  addArrow("api-to-language", 1430, 795, 1430, 885, "implemented by");
-  addArrow("language-to-analysis", 1260, 950, 1000, 810, "graph facts", { bend: 28 });
-  addArrow("particles-to-webview", 1320, 1080, 1360, 365, "effect runtime", { bend: 74 });
-  addArrow("settings-to-core", 360, 945, 430, 780, "workspace state");
+  beginPage("overview");
 
-  addText("title", 80, 55, 760, "CodeGraphy architecture", { size: "xl" });
+  // Quiet lane surfaces establish the reading order without a full-page grid.
+  addGeo("surface-lane", 80, 245, 1440, 200, "", {
+    color: "light-blue",
+    fill: "solid",
+    opacity: 0.12,
+  });
+  addGeo("core-lane", 80, 500, 1440, 285, "", {
+    color: "light-green",
+    fill: "solid",
+    opacity: 0.12,
+  });
+  addGeo("provider-lane", 80, 790, 1440, 180, "", {
+    color: "orange",
+    fill: "solid",
+    opacity: 0.1,
+  });
+
+  // Connectors render below modules and stay within their own architectural stratum.
+  addArrow("vscode-to-host", 330, 345, 400, 345);
+  addArrow("host-to-webview", 670, 345, 740, 345);
+  addArrow("agent-to-cli", 1230, 345, 1290, 345);
+  addArrow("settings-to-discovery", 300, 680, 350, 680);
+  addArrow("discovery-to-analysis", 540, 680, 590, 680);
+  addArrow("analysis-to-projection", 800, 680, 850, 680);
+  addArrow("projection-to-memory", 1040, 680, 1090, 680);
+  addArrow("memory-to-query", 1280, 680, 1330, 680);
+  addArrow("projection-to-cache", 945, 720, 1070, 755, "", { bend: 16 });
+
+  addGeo("atlas-label", 80, 45, 390, 48, "CODEGRAPHY / ARCHITECTURE ATLAS", {
+    color: "black",
+    fill: "solid",
+    labelColor: "white",
+    size: "s",
+  });
+  addText("page-number", 1390, 56, 130, "01", {
+    color: "grey",
+    size: "xl",
+    textAlign: "end",
+  });
+  addText("title", 80, 112, 820, "System overview", { size: "xl" });
   addText(
     "subtitle",
     82,
-    118,
-    1180,
-    "One Core-owned graph pipeline, shared by the VS Code product and the agent-facing CLI.",
+    170,
+    1050,
+    "Two product surfaces share one Core-owned indexing and query path.",
     { size: "m", color: "grey" },
   );
-
-  addText("entry-heading", 80, 205, 260, "Entrypoints", { size: "l" });
-  addGeo("developer", 80, 250, 240, 115, "Developer\nVS Code", {
-    color: "light-blue",
-    fill: "semi",
-  });
-  addGeo("agent", 80, 615, 240, 120, "Agent / CI\nCodeGraphy Agent Skill", {
+  addGeo("one-path", 1160, 125, 360, 82, "One implementation path\nExtension and CLI share Core", {
     color: "light-green",
     fill: "semi",
+    size: "s",
   });
-  addText(
-    "no-mcp",
-    82,
-    755,
-    270,
-    "No MCP path. The skill teaches agents to call the Core-owned CLI.",
-    { size: "s", color: "grey" },
-  );
 
-  addText("product-heading", 420, 175, 700, "VS Code product boundary", { size: "l" });
-  addGeo(
-    "extension-host",
-    420,
-    220,
-    300,
-    145,
-    "VS Code extension host\nworkspace lifecycle · settings · plugins",
-    { color: "light-blue", fill: "semi", size: "s" },
-  );
-  addGeo("shared-protocol", 820, 235, 230, 100, "Shared protocol\nhost ↔ webview", {
+  addText("surface-heading", 100, 262, 300, "PRODUCT SURFACES", {
+    color: "blue",
+    size: "s",
+  });
+  addGeo("vscode", 120, 310, 210, 92, "VS Code\nDeveloper surface", {
+    color: "light-blue",
+    fill: "solid",
+    size: "m",
+  });
+  addGeo("extension-host", 400, 300, 270, 112, "VS Code extension host\nlifecycle · settings · plugins", {
+    color: "light-blue",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("react-webview", 740, 300, 290, 112, "React webview\nGraph View · controls · state", {
+    color: "light-blue",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("agent", 1070, 310, 160, 92, "Agent / CI\nAgent Skill", {
+    color: "light-green",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("cli", 1290, 310, 190, 92, "CodeGraphy CLI\nJSON output", {
+    color: "light-green",
+    fill: "solid",
+    size: "m",
+  });
+  addText("no-mcp", 1072, 415, 410, "No MCP path. The Agent Skill teaches the Core-owned CLI.", {
+    color: "grey",
+    size: "s",
+  });
+
+  addText("core-heading", 100, 518, 300, "CORE-OWNED PATH", {
+    color: "green",
+    size: "s",
+  });
+  addGeo("core-package", 610, 525, 380, 82, "Core package\none index + query API", {
+    color: "light-green",
+    fill: "solid",
+    size: "m",
+  });
+  addGeo("settings", 120, 640, 180, 80, ".codegraphy/\nsettings.json", {
+    color: "grey",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("discovery", 350, 640, 190, 80, "File discovery", {
+    color: "light-green",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("analysis", 590, 630, 210, 100, "Tree-sitter +\nplugin analysis", {
+    color: "light-green",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("projection", 850, 640, 190, 80, "Graph projection", {
+    color: "light-green",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("memory", 1090, 630, 190, 100, "Relationship Graph\nin memory", {
+    color: "light-green",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("query", 1330, 640, 150, 80, "Graph Query", {
+    color: "light-green",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("cache", 1060, 742, 250, 58, "SQLite Graph Cache", {
     color: "grey",
     fill: "semi",
     size: "s",
   });
-  addGeo("graph-view", 1110, 220, 300, 145, "React webview\nGraph View · controls · state", {
+
+  addText("provider-heading", 100, 806, 340, "CAPABILITY PROVIDERS", {
+    color: "orange",
+    size: "s",
+  });
+  addGeo("plugin-api", 120, 840, 230, 82, "Plugin API\ncontracts only", {
+    color: "orange",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("analysis-plugins", 400, 830, 330, 102, "Analysis plugins\nTypeScript · Markdown · Vue · Svelte\nGodot · Unity", {
+    color: "orange",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("renderer", 780, 830, 300, 102, "Graph renderer\nWebGPU drawing · WASM physics\nprimary + minimap passes", {
+    color: "orange",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("view-plugins", 1130, 830, 350, 102, "Graph View contributions\nruntime nodes · projections · UI · forces", {
+    color: "orange",
+    fill: "semi",
+    size: "m",
+  });
+  addText("cache-guardrail", 120, 945, 400, "SQLite persists snapshots; query semantics stay in Core.", {
+    color: "grey",
+    size: "s",
+  });
+  addText("typescript-guardrail", 590, 945, 410, "TypeScript resolution stays in plugin analysis.", {
+    color: "grey",
+    size: "s",
+  });
+  addText("renderer-guardrail", 1080, 945, 400, "The extension owns policy; the renderer owns drawing and layout.", {
+    color: "grey",
+    size: "s",
+    textAlign: "end",
+  });
+
+  beginPage("indexing");
+
+  addGeo("full-lane", 80, 245, 1440, 285, "", {
+    color: "light-green",
+    fill: "solid",
+    opacity: 0.12,
+  });
+  addGeo("incremental-lane", 80, 575, 1440, 205, "", {
+    color: "light-blue",
+    fill: "solid",
+    opacity: 0.1,
+  });
+  addGeo("query-lane", 80, 825, 1440, 230, "", {
+    color: "grey",
+    fill: "solid",
+    opacity: 0.08,
+  });
+
+  addArrow("settings-to-discovery", 300, 405, 340, 405);
+  addArrow("discovery-to-preanalysis", 530, 405, 570, 405);
+  addArrow("preanalysis-to-analysis", 760, 405, 800, 405);
+  addArrow("analysis-to-projection", 1010, 405, 1050, 405);
+  addArrow("projection-to-cache", 1240, 405, 1280, 405);
+  addArrow("changes-to-engine", 300, 690, 350, 690);
+  addArrow("engine-to-impact", 550, 690, 600, 690);
+  addArrow("impact-to-analysis", 820, 690, 870, 690);
+  addArrow("analysis-to-patch", 1090, 690, 1140, 690);
+  addArrow("caller-to-load", 310, 940, 360, 940);
+  addArrow("load-to-memory", 560, 940, 610, 940);
+  addArrow("memory-to-query", 830, 940, 880, 940);
+  addArrow("query-to-reports", 1100, 940, 1150, 940);
+
+  addGeo("atlas-label", 80, 45, 390, 48, "CODEGRAPHY / ARCHITECTURE ATLAS", {
+    color: "black",
+    fill: "solid",
+    labelColor: "white",
+    size: "s",
+  });
+  addText("page-number", 1390, 56, 130, "02", {
+    color: "grey",
+    size: "xl",
+    textAlign: "end",
+  });
+  addText("title", 80, 112, 920, "Indexing and query", { size: "xl" });
+  addText(
+    "subtitle",
+    82,
+    170,
+    1050,
+    "One workspace engine handles full builds, changed-file reconciliation, and bounded reads.",
+    { color: "grey", size: "m" },
+  );
+  addGeo("storage-rule", 1160, 125, 360, 82, "Persistence, not a query engine\nSQLite stores snapshots; Core answers", {
+    color: "grey",
+    fill: "semi",
+    size: "s",
+  });
+
+  addText("full-heading", 100, 262, 300, "FULL INDEX", {
+    color: "green",
+    size: "s",
+  });
+  addGeo("workspace-settings", 120, 350, 180, 110, "Workspace settings\ninclude · filters · plugins", {
+    color: "grey",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("discovery", 340, 350, 190, 110, "File Discovery\ngitignore · maxFiles", {
+    color: "light-green",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("preanalysis", 570, 340, 190, 130, "Pre-analysis\ncore + plugin bulk setup", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("analysis", 800, 340, 210, 130, "Per-file analysis\nTree-sitter + plugin hooks\nsymbols · relations · evidence", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("projection", 1050, 350, 190, 110, "Graph projection\nNodes · Relationships", {
+    color: "light-green",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("cache", 1280, 340, 200, 130, "SQLite Graph Cache\nsnapshot · metadata\nplugin signature", {
+    color: "grey",
+    fill: "semi",
+    size: "s",
+  });
+  addText("full-detail", 120, 485, 1360, "index() returns the Relationship Graph, analysis cache, discovered files, directories, and full/incremental accounting.", {
+    color: "grey",
+    size: "s",
+  });
+
+  addText("incremental-heading", 100, 592, 350, "INCREMENTAL UPDATE", {
+    color: "blue",
+    size: "s",
+  });
+  addGeo("file-events", 120, 645, 180, 90, "Workspace file changes\ncreate · edit · delete", {
     color: "light-blue",
     fill: "semi",
     size: "s",
   });
-  addGeo(
-    "graph-renderer",
-    1110,
-    455,
-    300,
-    140,
-    "Graph renderer\nWebGPU drawing · WASM physics",
-    { color: "orange", fill: "semi", size: "s" },
-  );
-  addText(
-    "renderer-note",
-    1115,
-    610,
-    310,
-    "The extension owns lifecycle and interaction. The renderer owns an efficient drawing and layout runtime.",
-    { size: "s", color: "grey" },
-  );
+  addGeo("changed-engine", 350, 645, 200, 90, "applyChangedFiles()\nchanged path selection", {
+    color: "light-blue",
+    fill: "solid",
+    size: "s",
+  });
+  addGeo("plugin-impact", 600, 635, 220, 110, "Plugin invalidation\nonFilesChanged() may add\naffected workspace files", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("affected-analysis", 870, 635, 220, 110, "Affected-file analysis\nreuse unchanged cache tiers", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("patch", 1140, 635, 340, 110, "Patch + rebuild\ndelete stale facts · merge results\npatch SQLite · rebuild graph", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
 
-  addText("core-heading", 430, 635, 650, "Core owns graph truth", { size: "l" });
-  addGeo("core-api", 430, 700, 170, 110, "Core package\nindex + query API", {
+  addText("query-heading", 100, 842, 300, "QUERY PATH", {
+    color: "grey",
+    size: "s",
+  });
+  addGeo("caller", 120, 895, 190, 90, "Extension or CLI\nsame Core APIs", {
     color: "light-green",
     fill: "solid",
     size: "s",
   });
-  addGeo("discovery", 650, 700, 160, 110, "File\ndiscovery", {
-    color: "light-green",
-    fill: "semi",
-    size: "s",
-  });
-  addGeo("analysis", 850, 700, 180, 110, "Tree-sitter +\nplugin analysis", {
-    color: "light-green",
-    fill: "semi",
-    size: "s",
-  });
-  addGeo("projection", 1070, 700, 160, 110, "Graph\nprojection", {
-    color: "light-green",
-    fill: "semi",
-    size: "s",
-  });
-  addGeo("query", 520, 895, 220, 100, "Graph Query\nin-memory semantics", {
-    color: "light-green",
-    fill: "semi",
-    size: "s",
-  });
-  addGeo("cache", 1000, 895, 220, 100, ".codegraphy/graph.sqlite\nSQLite Graph Cache", {
+  addGeo("load", 360, 885, 200, 110, "Load snapshot\nGraph + symbols + relations", {
     color: "grey",
     fill: "semi",
     size: "s",
   });
-  addText(
-    "sqlite-note",
-    790,
-    1020,
-    430,
-    "SQLite persists snapshots. Traversal, scope, filtering, search, and projection remain Core-owned.",
-    { size: "s", color: "grey" },
-  );
-  addGeo(
-    "settings",
-    80,
-    900,
-    280,
-    90,
-    ".codegraphy/settings.json\nshared workspace state",
-    { color: "grey", fill: "semi", size: "s" },
-  );
+  addGeo("query-data", 610, 885, 220, 110, "In-memory data\nRelationship Graph + evidence", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("query-semantics", 880, 875, 220, 130, "Graph Query\nscope · filter · search\ntraversal · projection", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("reports", 1150, 875, 330, 130, "Bounded JSON reports\nnodes · search · edges\ndependencies · dependents · path", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addText("visible-order", 120, 1025, 1360, "Visible Graph order: Graph Scope → structural projection → Filter → Search → Show Orphans → Collapse Projection.", {
+    color: "grey",
+    size: "s",
+  });
 
-  addText("plugins-heading", 1260, 675, 330, "Plugin boundary", {
-    size: "l",
+  beginPage("runtime");
+
+  addGeo("host-panel", 80, 245, 430, 505, "", {
+    color: "light-blue",
+    fill: "solid",
+    opacity: 0.12,
   });
-  addGeo("plugin-api", 1305, 720, 250, 100, "Plugin API\ncontracts only", {
+  addGeo("protocol-panel", 555, 245, 280, 505, "", {
+    color: "grey",
+    fill: "solid",
+    opacity: 0.08,
+  });
+  addGeo("webview-panel", 880, 245, 640, 505, "", {
+    color: "light-blue",
+    fill: "solid",
+    opacity: 0.12,
+  });
+  addGeo("render-panel", 80, 800, 1440, 245, "", {
     color: "orange",
-    fill: "semi",
+    fill: "solid",
+    opacity: 0.1,
+  });
+
+  addArrow("host-activate-to-engine", 295, 395, 295, 440);
+  addArrow("host-engine-to-services", 295, 550, 295, 595);
+  addArrow("host-to-protocol", 510, 480, 555, 480, "", {
+    arrowheadStart: "arrow",
+  });
+  addArrow("protocol-to-webview", 835, 480, 880, 480, "", {
+    arrowheadStart: "arrow",
+  });
+  addArrow("webview-app-to-store", 1015, 395, 1015, 440);
+  addArrow("webview-store-to-visible", 1015, 540, 1015, 585);
+  addArrow("webview-visible-to-ui", 1195, 630, 1240, 630);
+  addArrow("frame-visible-to-runtime", 300, 925, 340, 925);
+  addArrow("frame-runtime-to-layout", 560, 925, 600, 925);
+  addArrow("frame-layout-to-buffers", 820, 925, 860, 925);
+  addArrow("frame-buffers-to-renderer", 1080, 925, 1120, 925);
+  addArrow("frame-renderer-to-surfaces", 1310, 925, 1335, 925);
+
+  addGeo("atlas-label", 80, 45, 390, 48, "CODEGRAPHY / ARCHITECTURE ATLAS", {
+    color: "black",
+    fill: "solid",
+    labelColor: "white",
     size: "s",
   });
-  addGeo(
-    "language-plugins",
-    1260,
-    885,
-    350,
-    130,
-    "Analysis plugins\nTypeScript · Markdown · Vue · Svelte\nGodot · Unity",
-    { color: "orange", fill: "semi", size: "s" },
-  );
-  addGeo("particles", 1260, 1040, 350, 90, "Presentation plugin\nParticles", {
-    color: "orange",
-    fill: "semi",
-    size: "s",
+  addText("page-number", 1390, 56, 130, "03", {
+    color: "grey",
+    size: "xl",
+    textAlign: "end",
   });
+  addText("title", 80, 112, 920, "VS Code runtime", { size: "xl" });
   addText(
-    "plugin-note",
-    1265,
-    1150,
-    380,
-    "TypeScript resolution stays in plugin analysis. Plugins contribute Nodes, Relationships, types, and evidence.",
-    { size: "s", color: "grey" },
+    "subtitle",
+    82,
+    170,
+    1070,
+    "The extension orchestrates product state; the webview derives presentation; the renderer executes frames.",
+    { color: "grey", size: "m" },
   );
+  addGeo("ownership-rule", 1160, 125, 360, 82, "Policy stays above the renderer\nHost + webview own product behavior", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
+
+  addText("host-heading", 100, 262, 300, "HOST OWNERSHIP", {
+    color: "blue",
+    size: "s",
+  });
+  addGeo("activation", 120, 315, 350, 80, "Extension activation\nworkspace + Graph View provider", {
+    color: "light-blue",
+    fill: "solid",
+    size: "m",
+  });
+  addGeo("workspace-engine", 120, 440, 350, 110, "Core workspace engine\nindex · changed files · Graph Cache\nRelationship Graph snapshot", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("host-services", 120, 595, 350, 110, "Provider services\nsettings · plugins · commands\nfile actions · exports · diagnostics", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
+  addText("host-note", 120, 715, 350, "Owns workspace lifecycle, persisted settings, editor integration, and message dispatch.", {
+    color: "grey",
+    size: "s",
+  });
+
+  addText("protocol-heading", 575, 262, 240, "TYPED PROTOCOL", {
+    color: "grey",
+    size: "s",
+  });
+  addGeo("extension-messages", 585, 330, 220, 130, "Extension → Webview\ngraph · controls · settings\nplugins · theme · commands", {
+    color: "grey",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("webview-messages", 585, 520, 220, 130, "Webview → Extension\nselection · files · indexing\nsettings · exports · interactions", {
+    color: "grey",
+    fill: "semi",
+    size: "s",
+  });
+  addText("protocol-note", 585, 675, 220, "Shared records keep the Electron host and browser runtime synchronized.", {
+    color: "grey",
+    size: "s",
+  });
+
+  addText("webview-heading", 900, 262, 300, "WEBVIEW STATE", {
+    color: "blue",
+    size: "s",
+  });
+  addGeo("app-shell", 920, 315, 190, 80, "React AppShell\nGraph View surface", {
+    color: "light-blue",
+    fill: "solid",
+    size: "m",
+  });
+  addGeo("store", 920, 440, 190, 100, "Zustand store\ngraph · controls · plugins\nselection · viewport", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("visible-graph", 920, 585, 230, 110, "deriveVisibleGraph()\nscope → structure → filter\nsearch → orphans → collapse", {
+    color: "light-green",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("graph-ui", 1240, 305, 240, 110, "Graph View UI\nsearch · scope · legends\nsettings · panels · toolbars", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("interactions", 1240, 455, 240, 100, "Interaction state\nfocus · selection · depth\nfile preview · context menu", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("renderer-adapter", 1240, 595, 240, 100, "Renderer adapter\nframes · camera · hit testing\nplugin runtime contributions", {
+    color: "light-blue",
+    fill: "semi",
+    size: "s",
+  });
+  addText("webview-note", 920, 715, 560, "Owns Graph View policy and interaction. It sends resolved frame data into the renderer package.", {
+    color: "grey",
+    size: "s",
+  });
+
+  addText("render-heading", 100, 817, 300, "RENDER LOOP", {
+    color: "orange",
+    size: "s",
+  });
+  addGeo("frame-input", 120, 875, 180, 100, "Visible Graph\nresolved styles + camera", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("runtime-contributions", 340, 865, 220, 120, "Graph View contributions\nruntime nodes · edges\nprojections · forces", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("layout", 600, 865, 220, 120, "TypedGraphLayoutEngine\nWASM physics · pin/release\npositions + velocities", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("buffers", 860, 875, 220, 100, "Typed arrays + GPU buffers\npositions · styles · edges", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("webgpu", 1120, 865, 190, 120, "WebGpuGraphRenderer\nframe queue · camera\nnode/link/arrow passes", {
+    color: "orange",
+    fill: "solid",
+    size: "s",
+  });
+  addGeo("surfaces", 1335, 875, 155, 100, "Primary + secondary\nsurface", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addText("render-note", 120, 1005, 1360, "The secondary surface reuses primary positions and geometry, but owns its camera and compact style buffers for the minimap.", {
+    color: "grey",
+    size: "s",
+  });
+
+  beginPage("plugins");
+
+  addGeo("contract-panel", 80, 245, 1440, 315, "", {
+    color: "orange",
+    fill: "solid",
+    opacity: 0.1,
+  });
+  addGeo("packages-panel", 80, 605, 1440, 190, "", {
+    color: "light-blue",
+    fill: "solid",
+    opacity: 0.1,
+  });
+  addGeo("impact-panel", 80, 840, 1440, 220, "", {
+    color: "grey",
+    fill: "solid",
+    opacity: 0.08,
+  });
+
+  addArrow("package-to-validation", 870, 700, 920, 700);
+  addArrow("validation-to-registry", 1130, 700, 1180, 700);
+  addArrow("ts-config-to-resolution", 1010, 955, 1050, 955);
+  addArrow("ts-resolution-to-relation", 1240, 955, 1280, 955);
+
+  addGeo("atlas-label", 80, 45, 390, 48, "CODEGRAPHY / ARCHITECTURE ATLAS", {
+    color: "black",
+    fill: "solid",
+    labelColor: "white",
+    size: "s",
+  });
+  addText("page-number", 1390, 56, 130, "04", {
+    color: "grey",
+    size: "xl",
+    textAlign: "end",
+  });
+  addText("title", 80, 112, 920, "Plugin system", { size: "xl" });
+  addText(
+    "subtitle",
+    82,
+    170,
+    1050,
+    "One validated contract lets packages add analysis, graph semantics, and Graph View behavior.",
+    { color: "grey", size: "m" },
+  );
+  addGeo("boundary-rule", 1160, 125, 360, 82, "Semantics stay with their owner\nCore supplies substrate, not ecosystem rules", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+
+  addText("contract-heading", 100, 262, 320, "CONTRACT SURFACE", {
+    color: "orange",
+    size: "s",
+  });
+  addGeo("plugin-contract", 600, 280, 400, 90, "IPlugin / API v3\nvalidated at registration", {
+    color: "orange",
+    fill: "solid",
+    size: "m",
+  });
+  addGeo("identity", 110, 405, 200, 110, "Identity + lifecycle\nid · version · apiVersion\ninitialize · unload", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("analysis", 335, 395, 200, 130, "Analysis hooks\nanalyzeFile() · pre-analyze\nonFilesChanged() · post-analyze", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("graph-types", 560, 405, 200, 110, "Graph facts\nnodes · symbols · relations\nNode Types · Edge Types", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("capabilities", 785, 395, 230, 130, "Graph Scope capabilities\nworkspace applicability\nfile colors · filters · sources", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("graph-view", 1040, 395, 250, 130, "graphView\nruntime nodes · edges · projections · forces · UI\ncontext menu · drag end", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("host-services", 1315, 405, 195, 110, "Host services\nGraph · webview messages\nexports · toolbar · data", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addText("contract-note", 110, 535, 1400, "The contract carries evidence and ownership into Core, CLI reports, Graph Scope, exports, and the Graph View runtime.", {
+    color: "grey",
+    size: "s",
+  });
+
+  addText("packages-heading", 100, 622, 300, "PLUGIN PACKAGES", {
+    color: "blue",
+    size: "s",
+  });
+  addGeo("analysis-packages", 120, 665, 400, 90, "Analysis plugins\nTypeScript · Markdown · Vue · Svelte · Godot · Unity", {
+    color: "light-blue",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("particles", 560, 665, 310, 90, "Particles presentation plugin\nGraph View effect runtime", {
+    color: "light-blue",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("plugin-package", 920, 665, 210, 70, "Plugin package\nfactory + manifest", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("validation", 1180, 665, 150, 70, "API validation", {
+    color: "grey",
+    fill: "semi",
+    size: "m",
+  });
+  addGeo("registry", 1380, 665, 110, 70, "Core\nregistry", {
+    color: "light-green",
+    fill: "solid",
+    size: "m",
+  });
+  addText("packages-note", 920, 750, 570, "Enablement + workspace applicability decide which capabilities become available.", {
+    color: "grey",
+    size: "s",
+    textAlign: "end",
+  });
+
+  addText("impact-heading", 100, 857, 300, "CHANGE IMPACT", {
+    color: "grey",
+    size: "s",
+  });
+  addGeo("impact-policy", 120, 900, 550, 120, "IPluginUpdateImpactPolicy\nview-only · settings-only · projection-only\nreanalyze-plugin-files · requires-full-index", {
+    color: "grey",
+    fill: "semi",
+    size: "m",
+  });
+  addText("impact-note", 120, 1025, 550, "A toggle declares the smallest correct amount of graph work; the host does not guess.", {
+    color: "grey",
+    size: "s",
+  });
+
+  addText("typescript-heading", 760, 857, 520, "TYPESCRIPT PROJECT RESOLUTION", {
+    color: "orange",
+    size: "s",
+  });
+  addGeo("ts-config", 760, 910, 250, 90, "nearest tsconfig.json\nwithin workspace root", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("ts-resolution", 1050, 900, 190, 110, "extends chain\nbaseUrl · paths\nexact + wildcard aliases", {
+    color: "orange",
+    fill: "semi",
+    size: "s",
+  });
+  addGeo("ts-edge", 1280, 910, 220, 90, "TypeScript Alias Import\nplugin-owned Relationship", {
+    color: "orange",
+    fill: "solid",
+    size: "s",
+  });
+  addText("typescript-note", 760, 1025, 740, "Project-aware resolution stays in plugin analysis; Core merges and projects the resulting evidence normally.", {
+    color: "grey",
+    size: "s",
+    textAlign: "end",
+  });
 
   return {
     tldrawFileFormatVersion: 1,

--- a/boards/main.tldr
+++ b/boards/main.tldr
@@ -47,7 +47,7 @@
       "y": 20,
       "z": 0.7,
       "meta": {},
-      "id": "camera:page:page",
+      "id": "camera:page:overview",
       "typeName": "camera"
     },
     {
@@ -59,15 +59,99 @@
       "hintingShapeIds": [],
       "focusedGroupId": null,
       "meta": {},
-      "id": "instance_page_state:page:page",
-      "pageId": "page:page",
+      "id": "instance_page_state:page:overview",
+      "pageId": "page:overview",
       "typeName": "instance_page_state"
     },
     {
       "meta": {},
-      "id": "page:page",
-      "name": "Architecture",
+      "id": "page:overview",
+      "name": "01 System overview",
       "index": "a1",
+      "typeName": "page"
+    },
+    {
+      "x": 20,
+      "y": 20,
+      "z": 0.7,
+      "meta": {},
+      "id": "camera:page:indexing",
+      "typeName": "camera"
+    },
+    {
+      "editingShapeId": null,
+      "croppingShapeId": null,
+      "selectedShapeIds": [],
+      "hoveredShapeId": null,
+      "erasingShapeIds": [],
+      "hintingShapeIds": [],
+      "focusedGroupId": null,
+      "meta": {},
+      "id": "instance_page_state:page:indexing",
+      "pageId": "page:indexing",
+      "typeName": "instance_page_state"
+    },
+    {
+      "meta": {},
+      "id": "page:indexing",
+      "name": "02 Indexing and query",
+      "index": "a2",
+      "typeName": "page"
+    },
+    {
+      "x": 20,
+      "y": 20,
+      "z": 0.7,
+      "meta": {},
+      "id": "camera:page:runtime",
+      "typeName": "camera"
+    },
+    {
+      "editingShapeId": null,
+      "croppingShapeId": null,
+      "selectedShapeIds": [],
+      "hoveredShapeId": null,
+      "erasingShapeIds": [],
+      "hintingShapeIds": [],
+      "focusedGroupId": null,
+      "meta": {},
+      "id": "instance_page_state:page:runtime",
+      "pageId": "page:runtime",
+      "typeName": "instance_page_state"
+    },
+    {
+      "meta": {},
+      "id": "page:runtime",
+      "name": "03 VS Code runtime",
+      "index": "a3",
+      "typeName": "page"
+    },
+    {
+      "x": 20,
+      "y": 20,
+      "z": 0.7,
+      "meta": {},
+      "id": "camera:page:plugins",
+      "typeName": "camera"
+    },
+    {
+      "editingShapeId": null,
+      "croppingShapeId": null,
+      "selectedShapeIds": [],
+      "hoveredShapeId": null,
+      "erasingShapeIds": [],
+      "hintingShapeIds": [],
+      "focusedGroupId": null,
+      "meta": {},
+      "id": "instance_page_state:page:plugins",
+      "pageId": "page:plugins",
+      "typeName": "instance_page_state"
+    },
+    {
+      "meta": {},
+      "id": "page:plugins",
+      "name": "04 Plugin system",
+      "index": "a4",
       "typeName": "page"
     },
     {
@@ -122,7 +206,7 @@
       "duplicateProps": null,
       "cameraState": "idle",
       "id": "instance:instance",
-      "currentPageId": "page:page",
+      "currentPageId": "page:overview",
       "typeName": "instance"
     },
     {
@@ -134,33 +218,29 @@
       "typeName": "user"
     },
     {
-      "x": 320,
-      "y": 285,
+      "x": 80,
+      "y": 245,
       "rotation": 0,
       "isLocked": false,
-      "opacity": 1,
+      "opacity": 0.12,
       "meta": {},
-      "id": "shape:user-to-host",
-      "type": "arrow",
+      "id": "shape:overview:surface-lane",
+      "type": "geo",
       "props": {
-        "kind": "arc",
-        "elbowMidPoint": 0.5,
+        "w": 1440,
+        "h": 200,
+        "geo": "rectangle",
         "dash": "solid",
-        "size": "s",
-        "fill": "none",
-        "color": "grey",
-        "labelColor": "grey",
-        "bend": 0,
-        "start": {
-          "x": 0,
-          "y": 0
-        },
-        "end": {
-          "x": 100,
-          "y": 0
-        },
-        "arrowheadStart": "none",
-        "arrowheadEnd": "arrow",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
         "richText": {
           "type": "doc",
           "attrs": {
@@ -171,52 +251,39 @@
               "type": "paragraph",
               "attrs": {
                 "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "opens"
-                }
-              ]
+              }
             }
           ]
-        },
-        "labelPosition": 0.5,
-        "font": "sans",
-        "scale": 1
+        }
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "a1",
       "typeName": "shape"
     },
     {
-      "x": 720,
-      "y": 285,
+      "x": 80,
+      "y": 500,
       "rotation": 0,
       "isLocked": false,
-      "opacity": 1,
+      "opacity": 0.12,
       "meta": {},
-      "id": "shape:host-to-webview",
-      "type": "arrow",
+      "id": "shape:overview:core-lane",
+      "type": "geo",
       "props": {
-        "kind": "arc",
-        "elbowMidPoint": 0.5,
+        "w": 1440,
+        "h": 285,
+        "geo": "rectangle",
         "dash": "solid",
-        "size": "s",
-        "fill": "none",
-        "color": "grey",
-        "labelColor": "grey",
-        "bend": 0,
-        "start": {
-          "x": 0,
-          "y": 0
-        },
-        "end": {
-          "x": 390,
-          "y": 0
-        },
-        "arrowheadStart": "none",
-        "arrowheadEnd": "arrow",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
         "richText": {
           "type": "doc",
           "attrs": {
@@ -230,43 +297,36 @@
               }
             }
           ]
-        },
-        "labelPosition": 0.5,
-        "font": "sans",
-        "scale": 1
+        }
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "a2",
       "typeName": "shape"
     },
     {
-      "x": 1260,
-      "y": 365,
+      "x": 80,
+      "y": 790,
       "rotation": 0,
       "isLocked": false,
-      "opacity": 1,
+      "opacity": 0.1,
       "meta": {},
-      "id": "shape:webview-to-renderer",
-      "type": "arrow",
+      "id": "shape:overview:provider-lane",
+      "type": "geo",
       "props": {
-        "kind": "arc",
-        "elbowMidPoint": 0.5,
+        "w": 1440,
+        "h": 180,
+        "geo": "rectangle",
         "dash": "solid",
-        "size": "s",
-        "fill": "none",
-        "color": "grey",
-        "labelColor": "grey",
-        "bend": 0,
-        "start": {
-          "x": 0,
-          "y": 0
-        },
-        "end": {
-          "x": 0,
-          "y": 90
-        },
-        "arrowheadStart": "none",
-        "arrowheadEnd": "arrow",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
         "richText": {
           "type": "doc",
           "attrs": {
@@ -277,32 +337,23 @@
               "type": "paragraph",
               "attrs": {
                 "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "render model"
-                }
-              ]
+              }
             }
           ]
-        },
-        "labelPosition": 0.5,
-        "font": "sans",
-        "scale": 1
+        }
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "a3",
       "typeName": "shape"
     },
     {
-      "x": 320,
-      "y": 675,
+      "x": 330,
+      "y": 345,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:agent-to-core",
+      "id": "shape:overview:vscode-to-host",
       "type": "arrow",
       "props": {
         "kind": "arc",
@@ -318,8 +369,8 @@
           "y": 0
         },
         "end": {
-          "x": 110,
-          "y": 70
+          "x": 70,
+          "y": 0
         },
         "arrowheadStart": "none",
         "arrowheadEnd": "arrow",
@@ -341,18 +392,18 @@
         "font": "sans",
         "scale": 1
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "a4",
       "typeName": "shape"
     },
     {
-      "x": 560,
-      "y": 365,
+      "x": 670,
+      "y": 345,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:host-to-core",
+      "id": "shape:overview:host-to-webview",
       "type": "arrow",
       "props": {
         "kind": "arc",
@@ -362,14 +413,14 @@
         "fill": "none",
         "color": "grey",
         "labelColor": "grey",
-        "bend": -36,
+        "bend": 0,
         "start": {
           "x": 0,
           "y": 0
         },
         "end": {
-          "x": -60,
-          "y": 335
+          "x": 70,
+          "y": 0
         },
         "arrowheadStart": "none",
         "arrowheadEnd": "arrow",
@@ -383,13 +434,7 @@
               "type": "paragraph",
               "attrs": {
                 "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "same Core APIs"
-                }
-              ]
+              }
             }
           ]
         },
@@ -397,18 +442,68 @@
         "font": "sans",
         "scale": 1
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "a5",
       "typeName": "shape"
     },
     {
-      "x": 600,
-      "y": 755,
+      "x": 1230,
+      "y": 345,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:core-to-discovery",
+      "id": "shape:overview:agent-to-cli",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 60,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:overview",
+      "index": "a6",
+      "typeName": "shape"
+    },
+    {
+      "x": 300,
+      "y": 680,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:settings-to-discovery",
       "type": "arrow",
       "props": {
         "kind": "arc",
@@ -447,68 +542,18 @@
         "font": "sans",
         "scale": 1
       },
-      "parentId": "page:page",
-      "index": "a6",
-      "typeName": "shape"
-    },
-    {
-      "x": 810,
-      "y": 755,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:discovery-to-analysis",
-      "type": "arrow",
-      "props": {
-        "kind": "arc",
-        "elbowMidPoint": 0.5,
-        "dash": "solid",
-        "size": "s",
-        "fill": "none",
-        "color": "grey",
-        "labelColor": "grey",
-        "bend": 0,
-        "start": {
-          "x": 0,
-          "y": 0
-        },
-        "end": {
-          "x": 40,
-          "y": 0
-        },
-        "arrowheadStart": "none",
-        "arrowheadEnd": "arrow",
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              }
-            }
-          ]
-        },
-        "labelPosition": 0.5,
-        "font": "sans",
-        "scale": 1
-      },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "a7",
       "typeName": "shape"
     },
     {
-      "x": 1030,
-      "y": 755,
+      "x": 540,
+      "y": 680,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:analysis-to-projection",
+      "id": "shape:overview:discovery-to-analysis",
       "type": "arrow",
       "props": {
         "kind": "arc",
@@ -524,7 +569,7 @@
           "y": 0
         },
         "end": {
-          "x": 40,
+          "x": 50,
           "y": 0
         },
         "arrowheadStart": "none",
@@ -547,18 +592,18 @@
         "font": "sans",
         "scale": 1
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "a8",
       "typeName": "shape"
     },
     {
-      "x": 1150,
-      "y": 810,
+      "x": 800,
+      "y": 680,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:projection-to-cache",
+      "id": "shape:overview:analysis-to-projection",
       "type": "arrow",
       "props": {
         "kind": "arc",
@@ -574,8 +619,8 @@
           "y": 0
         },
         "end": {
-          "x": -40,
-          "y": 85
+          "x": 50,
+          "y": 0
         },
         "arrowheadStart": "none",
         "arrowheadEnd": "arrow",
@@ -589,13 +634,7 @@
               "type": "paragraph",
               "attrs": {
                 "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "persists"
-                }
-              ]
+              }
             }
           ]
         },
@@ -603,18 +642,18 @@
         "font": "sans",
         "scale": 1
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "a9",
       "typeName": "shape"
     },
     {
-      "x": 1000,
-      "y": 945,
+      "x": 1040,
+      "y": 680,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:cache-to-query",
+      "id": "shape:overview:projection-to-memory",
       "type": "arrow",
       "props": {
         "kind": "arc",
@@ -630,7 +669,7 @@
           "y": 0
         },
         "end": {
-          "x": -260,
+          "x": 50,
           "y": 0
         },
         "arrowheadStart": "none",
@@ -645,13 +684,7 @@
               "type": "paragraph",
               "attrs": {
                 "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "loads snapshots"
-                }
-              ]
+              }
             }
           ]
         },
@@ -659,18 +692,18 @@
         "font": "sans",
         "scale": 1
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "aA",
       "typeName": "shape"
     },
     {
-      "x": 520,
-      "y": 810,
+      "x": 1280,
+      "y": 680,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:core-to-query",
+      "id": "shape:overview:memory-to-query",
       "type": "arrow",
       "props": {
         "kind": "arc",
@@ -686,8 +719,8 @@
           "y": 0
         },
         "end": {
-          "x": 70,
-          "y": 85
+          "x": 50,
+          "y": 0
         },
         "arrowheadStart": "none",
         "arrowheadEnd": "arrow",
@@ -701,13 +734,7 @@
               "type": "paragraph",
               "attrs": {
                 "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "query"
-                }
-              ]
+              }
             }
           ]
         },
@@ -715,18 +742,18 @@
         "font": "sans",
         "scale": 1
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "aB",
       "typeName": "shape"
     },
     {
-      "x": 1430,
-      "y": 795,
+      "x": 945,
+      "y": 720,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:api-to-language",
+      "id": "shape:overview:projection-to-cache",
       "type": "arrow",
       "props": {
         "kind": "arc",
@@ -736,14 +763,14 @@
         "fill": "none",
         "color": "grey",
         "labelColor": "grey",
-        "bend": 0,
+        "bend": 16,
         "start": {
           "x": 0,
           "y": 0
         },
         "end": {
-          "x": 0,
-          "y": 90
+          "x": 125,
+          "y": 35
         },
         "arrowheadStart": "none",
         "arrowheadEnd": "arrow",
@@ -757,13 +784,7 @@
               "type": "paragraph",
               "attrs": {
                 "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "implemented by"
-                }
-              ]
+              }
             }
           ]
         },
@@ -771,38 +792,34 @@
         "font": "sans",
         "scale": 1
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "aC",
       "typeName": "shape"
     },
     {
-      "x": 1260,
-      "y": 950,
+      "x": 80,
+      "y": 45,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:language-to-analysis",
-      "type": "arrow",
+      "id": "shape:overview:atlas-label",
+      "type": "geo",
       "props": {
-        "kind": "arc",
-        "elbowMidPoint": 0.5,
+        "w": 390,
+        "h": 48,
+        "geo": "rectangle",
         "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "black",
+        "labelColor": "white",
+        "fill": "solid",
         "size": "s",
-        "fill": "none",
-        "color": "grey",
-        "labelColor": "grey",
-        "bend": 28,
-        "start": {
-          "x": 0,
-          "y": 0
-        },
-        "end": {
-          "x": -260,
-          "y": -140
-        },
-        "arrowheadStart": "none",
-        "arrowheadEnd": "arrow",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
         "richText": {
           "type": "doc",
           "attrs": {
@@ -817,48 +834,34 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "graph facts"
+                  "text": "CODEGRAPHY / ARCHITECTURE ATLAS"
                 }
               ]
             }
           ]
-        },
-        "labelPosition": 0.5,
-        "font": "sans",
-        "scale": 1
+        }
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "aD",
       "typeName": "shape"
     },
     {
-      "x": 1320,
-      "y": 1080,
+      "x": 1390,
+      "y": 56,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:particles-to-webview",
-      "type": "arrow",
+      "id": "shape:overview:page-number",
+      "type": "text",
       "props": {
-        "kind": "arc",
-        "elbowMidPoint": 0.5,
-        "dash": "solid",
-        "size": "s",
-        "fill": "none",
         "color": "grey",
-        "labelColor": "grey",
-        "bend": 74,
-        "start": {
-          "x": 0,
-          "y": 0
-        },
-        "end": {
-          "x": 40,
-          "y": -715
-        },
-        "arrowheadStart": "none",
-        "arrowheadEnd": "arrow",
+        "size": "xl",
+        "w": 130,
+        "font": "sans",
+        "textAlign": "end",
+        "autoSize": false,
+        "scale": 1,
         "richText": {
           "type": "doc",
           "attrs": {
@@ -873,89 +876,30 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "effect runtime"
+                  "text": "01"
                 }
               ]
             }
           ]
-        },
-        "labelPosition": 0.5,
-        "font": "sans",
-        "scale": 1
+        }
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "aE",
       "typeName": "shape"
     },
     {
-      "x": 360,
-      "y": 945,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:settings-to-core",
-      "type": "arrow",
-      "props": {
-        "kind": "arc",
-        "elbowMidPoint": 0.5,
-        "dash": "solid",
-        "size": "s",
-        "fill": "none",
-        "color": "grey",
-        "labelColor": "grey",
-        "bend": 0,
-        "start": {
-          "x": 0,
-          "y": 0
-        },
-        "end": {
-          "x": 70,
-          "y": -165
-        },
-        "arrowheadStart": "none",
-        "arrowheadEnd": "arrow",
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "workspace state"
-                }
-              ]
-            }
-          ]
-        },
-        "labelPosition": 0.5,
-        "font": "sans",
-        "scale": 1
-      },
-      "parentId": "page:page",
-      "index": "aF",
-      "typeName": "shape"
-    },
-    {
       "x": 80,
-      "y": 55,
+      "y": 112,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:title",
+      "id": "shape:overview:title",
       "type": "text",
       "props": {
         "color": "black",
         "size": "xl",
-        "w": 760,
+        "w": 820,
         "font": "sans",
         "textAlign": "start",
         "autoSize": false,
@@ -974,30 +918,30 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "CodeGraphy architecture"
+                  "text": "System overview"
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "aG",
+      "parentId": "page:overview",
+      "index": "aF",
       "typeName": "shape"
     },
     {
       "x": 82,
-      "y": 118,
+      "y": 170,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:subtitle",
+      "id": "shape:overview:subtitle",
       "type": "text",
       "props": {
         "color": "grey",
         "size": "m",
-        "w": 1180,
+        "w": 1050,
         "font": "sans",
         "textAlign": "start",
         "autoSize": false,
@@ -1016,30 +960,91 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "One Core-owned graph pipeline, shared by the VS Code product and the agent-facing CLI."
+                  "text": "Two product surfaces share one Core-owned indexing and query path."
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
+      "index": "aG",
+      "typeName": "shape"
+    },
+    {
+      "x": 1160,
+      "y": 125,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:one-path",
+      "type": "geo",
+      "props": {
+        "w": 360,
+        "h": 82,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "One implementation path"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Extension and CLI share Core"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
       "index": "aH",
       "typeName": "shape"
     },
     {
-      "x": 80,
-      "y": 205,
+      "x": 100,
+      "y": 262,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:entry-heading",
+      "id": "shape:overview:surface-heading",
       "type": "text",
       "props": {
-        "color": "black",
-        "size": "l",
-        "w": 260,
+        "color": "blue",
+        "size": "s",
+        "w": 300,
         "font": "sans",
         "textAlign": "start",
         "autoSize": false,
@@ -1058,29 +1063,90 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "Entrypoints"
+                  "text": "PRODUCT SURFACES"
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "aI",
       "typeName": "shape"
     },
     {
-      "x": 80,
-      "y": 250,
+      "x": 120,
+      "y": 310,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:developer",
+      "id": "shape:overview:vscode",
       "type": "geo",
       "props": {
-        "w": 240,
-        "h": 115,
+        "w": 210,
+        "h": 92,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "VS Code"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Developer surface"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "aJ",
+      "typeName": "shape"
+    },
+    {
+      "x": 400,
+      "y": 300,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:extension-host",
+      "type": "geo",
+      "props": {
+        "w": 270,
+        "h": 112,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
@@ -1107,7 +1173,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "Developer"
+                  "text": "VS Code extension host"
                 }
               ]
             },
@@ -1119,29 +1185,90 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "VS Code"
+                  "text": "lifecycle · settings · plugins"
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "aJ",
+      "parentId": "page:overview",
+      "index": "aK",
       "typeName": "shape"
     },
     {
-      "x": 80,
-      "y": 615,
+      "x": 740,
+      "y": 300,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:agent",
+      "id": "shape:overview:react-webview",
       "type": "geo",
       "props": {
-        "w": 240,
-        "h": 120,
+        "w": 290,
+        "h": 112,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "React webview"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph View · controls · state"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "aL",
+      "typeName": "shape"
+    },
+    {
+      "x": 1070,
+      "y": 310,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:agent",
+      "type": "geo",
+      "props": {
+        "w": 160,
+        "h": 92,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
@@ -1180,441 +1307,29 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "CodeGraphy Agent Skill"
+                  "text": "Agent Skill"
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "aK",
-      "typeName": "shape"
-    },
-    {
-      "x": 82,
-      "y": 755,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:no-mcp",
-      "type": "text",
-      "props": {
-        "color": "grey",
-        "size": "s",
-        "w": 270,
-        "font": "sans",
-        "textAlign": "start",
-        "autoSize": false,
-        "scale": 1,
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "No MCP path. The skill teaches agents to call the Core-owned CLI."
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "aL",
-      "typeName": "shape"
-    },
-    {
-      "x": 420,
-      "y": 175,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:product-heading",
-      "type": "text",
-      "props": {
-        "color": "black",
-        "size": "l",
-        "w": 700,
-        "font": "sans",
-        "textAlign": "start",
-        "autoSize": false,
-        "scale": 1,
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "VS Code product boundary"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
+      "parentId": "page:overview",
       "index": "aM",
       "typeName": "shape"
     },
     {
-      "x": 420,
-      "y": 220,
+      "x": 1290,
+      "y": 310,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:extension-host",
+      "id": "shape:overview:cli",
       "type": "geo",
       "props": {
-        "w": 300,
-        "h": 145,
-        "geo": "rectangle",
-        "dash": "solid",
-        "growY": 0,
-        "url": "",
-        "scale": 1,
-        "color": "light-blue",
-        "labelColor": "black",
-        "fill": "semi",
-        "size": "s",
-        "font": "sans",
-        "align": "middle",
-        "verticalAlign": "middle",
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "VS Code extension host"
-                }
-              ]
-            },
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "workspace lifecycle · settings · plugins"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "aN",
-      "typeName": "shape"
-    },
-    {
-      "x": 820,
-      "y": 235,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:shared-protocol",
-      "type": "geo",
-      "props": {
-        "w": 230,
-        "h": 100,
-        "geo": "rectangle",
-        "dash": "solid",
-        "growY": 0,
-        "url": "",
-        "scale": 1,
-        "color": "grey",
-        "labelColor": "black",
-        "fill": "semi",
-        "size": "s",
-        "font": "sans",
-        "align": "middle",
-        "verticalAlign": "middle",
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "Shared protocol"
-                }
-              ]
-            },
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "host ↔ webview"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "aO",
-      "typeName": "shape"
-    },
-    {
-      "x": 1110,
-      "y": 220,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:graph-view",
-      "type": "geo",
-      "props": {
-        "w": 300,
-        "h": 145,
-        "geo": "rectangle",
-        "dash": "solid",
-        "growY": 0,
-        "url": "",
-        "scale": 1,
-        "color": "light-blue",
-        "labelColor": "black",
-        "fill": "semi",
-        "size": "s",
-        "font": "sans",
-        "align": "middle",
-        "verticalAlign": "middle",
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "React webview"
-                }
-              ]
-            },
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "Graph View · controls · state"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "aP",
-      "typeName": "shape"
-    },
-    {
-      "x": 1110,
-      "y": 455,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:graph-renderer",
-      "type": "geo",
-      "props": {
-        "w": 300,
-        "h": 140,
-        "geo": "rectangle",
-        "dash": "solid",
-        "growY": 0,
-        "url": "",
-        "scale": 1,
-        "color": "orange",
-        "labelColor": "black",
-        "fill": "semi",
-        "size": "s",
-        "font": "sans",
-        "align": "middle",
-        "verticalAlign": "middle",
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "Graph renderer"
-                }
-              ]
-            },
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "WebGPU drawing · WASM physics"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "aQ",
-      "typeName": "shape"
-    },
-    {
-      "x": 1115,
-      "y": 610,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:renderer-note",
-      "type": "text",
-      "props": {
-        "color": "grey",
-        "size": "s",
-        "w": 310,
-        "font": "sans",
-        "textAlign": "start",
-        "autoSize": false,
-        "scale": 1,
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "The extension owns lifecycle and interaction. The renderer owns an efficient drawing and layout runtime."
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "aR",
-      "typeName": "shape"
-    },
-    {
-      "x": 430,
-      "y": 635,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:core-heading",
-      "type": "text",
-      "props": {
-        "color": "black",
-        "size": "l",
-        "w": 650,
-        "font": "sans",
-        "textAlign": "start",
-        "autoSize": false,
-        "scale": 1,
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "Core owns graph truth"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "aS",
-      "typeName": "shape"
-    },
-    {
-      "x": 430,
-      "y": 700,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:core-api",
-      "type": "geo",
-      "props": {
-        "w": 170,
-        "h": 110,
+        "w": 190,
+        "h": 92,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
@@ -1623,7 +1338,152 @@
         "color": "light-green",
         "labelColor": "black",
         "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CodeGraphy CLI"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "JSON output"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "aN",
+      "typeName": "shape"
+    },
+    {
+      "x": 1072,
+      "y": 415,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:no-mcp",
+      "type": "text",
+      "props": {
+        "color": "grey",
         "size": "s",
+        "w": 410,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "No MCP path. The Agent Skill teaches the Core-owned CLI."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "aO",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 518,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:core-heading",
+      "type": "text",
+      "props": {
+        "color": "green",
+        "size": "s",
+        "w": 300,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CORE-OWNED PATH"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "aP",
+      "typeName": "shape"
+    },
+    {
+      "x": 610,
+      "y": 525,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:core-package",
+      "type": "geo",
+      "props": {
+        "w": 380,
+        "h": 82,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
         "font": "sans",
         "align": "middle",
         "verticalAlign": "middle",
@@ -1653,38 +1513,38 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "index + query API"
+                  "text": "one index + query API"
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "aT",
+      "parentId": "page:overview",
+      "index": "aQ",
       "typeName": "shape"
     },
     {
-      "x": 650,
-      "y": 700,
+      "x": 120,
+      "y": 640,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:discovery",
+      "id": "shape:overview:settings",
       "type": "geo",
       "props": {
-        "w": 160,
-        "h": 110,
+        "w": 180,
+        "h": 80,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
         "url": "",
         "scale": 1,
-        "color": "light-green",
+        "color": "grey",
         "labelColor": "black",
         "fill": "semi",
-        "size": "s",
+        "size": "m",
         "font": "sans",
         "align": "middle",
         "verticalAlign": "middle",
@@ -1702,7 +1562,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "File"
+                  "text": ".codegraphy/"
                 }
               ]
             },
@@ -1714,29 +1574,29 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "discovery"
+                  "text": "settings.json"
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "aU",
+      "parentId": "page:overview",
+      "index": "aR",
       "typeName": "shape"
     },
     {
-      "x": 850,
-      "y": 700,
+      "x": 350,
+      "y": 640,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:analysis",
+      "id": "shape:overview:discovery",
       "type": "geo",
       "props": {
-        "w": 180,
-        "h": 110,
+        "w": 190,
+        "h": 80,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
@@ -1745,7 +1605,56 @@
         "color": "light-green",
         "labelColor": "black",
         "fill": "semi",
-        "size": "s",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "File discovery"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "aS",
+      "typeName": "shape"
+    },
+    {
+      "x": 590,
+      "y": 630,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:analysis",
+      "type": "geo",
+      "props": {
+        "w": 210,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
         "font": "sans",
         "align": "middle",
         "verticalAlign": "middle",
@@ -1782,22 +1691,22 @@
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "aV",
+      "parentId": "page:overview",
+      "index": "aT",
       "typeName": "shape"
     },
     {
-      "x": 1070,
-      "y": 700,
+      "x": 850,
+      "y": 640,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:projection",
+      "id": "shape:overview:projection",
       "type": "geo",
       "props": {
-        "w": 160,
-        "h": 110,
+        "w": 190,
+        "h": 80,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
@@ -1806,7 +1715,7 @@
         "color": "light-green",
         "labelColor": "black",
         "fill": "semi",
-        "size": "s",
+        "size": "m",
         "font": "sans",
         "align": "middle",
         "verticalAlign": "middle",
@@ -1824,7 +1733,56 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "Graph"
+                  "text": "Graph projection"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "aU",
+      "typeName": "shape"
+    },
+    {
+      "x": 1090,
+      "y": 630,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:memory",
+      "type": "geo",
+      "props": {
+        "w": 190,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Relationship Graph"
                 }
               ]
             },
@@ -1836,29 +1794,29 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "projection"
+                  "text": "in memory"
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "aW",
+      "parentId": "page:overview",
+      "index": "aV",
       "typeName": "shape"
     },
     {
-      "x": 520,
-      "y": 895,
+      "x": 1330,
+      "y": 640,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:query",
+      "id": "shape:overview:query",
       "type": "geo",
       "props": {
-        "w": 220,
-        "h": 100,
+        "w": 150,
+        "h": 80,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
@@ -1867,7 +1825,7 @@
         "color": "light-green",
         "labelColor": "black",
         "fill": "semi",
-        "size": "s",
+        "size": "m",
         "font": "sans",
         "align": "middle",
         "verticalAlign": "middle",
@@ -1888,38 +1846,26 @@
                   "text": "Graph Query"
                 }
               ]
-            },
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "in-memory semantics"
-                }
-              ]
             }
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "aX",
+      "parentId": "page:overview",
+      "index": "aW",
       "typeName": "shape"
     },
     {
-      "x": 1000,
-      "y": 895,
+      "x": 1060,
+      "y": 742,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:cache",
+      "id": "shape:overview:cache",
       "type": "geo",
       "props": {
-        "w": 220,
-        "h": 100,
+        "w": 250,
+        "h": 58,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
@@ -1938,18 +1884,6 @@
             "dir": "auto"
           },
           "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": ".codegraphy/graph.sqlite"
-                }
-              ]
-            },
             {
               "type": "paragraph",
               "attrs": {
@@ -1965,167 +1899,64 @@
           ]
         }
       },
-      "parentId": "page:page",
+      "parentId": "page:overview",
+      "index": "aX",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 806,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:provider-heading",
+      "type": "text",
+      "props": {
+        "color": "orange",
+        "size": "s",
+        "w": 340,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CAPABILITY PROVIDERS"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
       "index": "aY",
       "typeName": "shape"
     },
     {
-      "x": 790,
-      "y": 1020,
+      "x": 120,
+      "y": 840,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:sqlite-note",
-      "type": "text",
-      "props": {
-        "color": "grey",
-        "size": "s",
-        "w": 430,
-        "font": "sans",
-        "textAlign": "start",
-        "autoSize": false,
-        "scale": 1,
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "SQLite persists snapshots. Traversal, scope, filtering, search, and projection remain Core-owned."
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "aZ",
-      "typeName": "shape"
-    },
-    {
-      "x": 80,
-      "y": 900,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:settings",
+      "id": "shape:overview:plugin-api",
       "type": "geo",
       "props": {
-        "w": 280,
-        "h": 90,
-        "geo": "rectangle",
-        "dash": "solid",
-        "growY": 0,
-        "url": "",
-        "scale": 1,
-        "color": "grey",
-        "labelColor": "black",
-        "fill": "semi",
-        "size": "s",
-        "font": "sans",
-        "align": "middle",
-        "verticalAlign": "middle",
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": ".codegraphy/settings.json"
-                }
-              ]
-            },
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "shared workspace state"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "aa",
-      "typeName": "shape"
-    },
-    {
-      "x": 1260,
-      "y": 675,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:plugins-heading",
-      "type": "text",
-      "props": {
-        "color": "black",
-        "size": "l",
-        "w": 330,
-        "font": "sans",
-        "textAlign": "start",
-        "autoSize": false,
-        "scale": 1,
-        "richText": {
-          "type": "doc",
-          "attrs": {
-            "dir": "auto"
-          },
-          "content": [
-            {
-              "type": "paragraph",
-              "attrs": {
-                "dir": "auto"
-              },
-              "content": [
-                {
-                  "type": "text",
-                  "text": "Plugin boundary"
-                }
-              ]
-            }
-          ]
-        }
-      },
-      "parentId": "page:page",
-      "index": "ab",
-      "typeName": "shape"
-    },
-    {
-      "x": 1305,
-      "y": 720,
-      "rotation": 0,
-      "isLocked": false,
-      "opacity": 1,
-      "meta": {},
-      "id": "shape:plugin-api",
-      "type": "geo",
-      "props": {
-        "w": 250,
-        "h": 100,
+        "w": 230,
+        "h": 82,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
@@ -2134,7 +1965,7 @@
         "color": "orange",
         "labelColor": "black",
         "fill": "semi",
-        "size": "s",
+        "size": "m",
         "font": "sans",
         "align": "middle",
         "verticalAlign": "middle",
@@ -2171,22 +2002,22 @@
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "ac",
+      "parentId": "page:overview",
+      "index": "aZ",
       "typeName": "shape"
     },
     {
-      "x": 1260,
-      "y": 885,
+      "x": 400,
+      "y": 830,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:language-plugins",
+      "id": "shape:overview:analysis-plugins",
       "type": "geo",
       "props": {
-        "w": 350,
-        "h": 130,
+        "w": 330,
+        "h": 102,
         "geo": "rectangle",
         "dash": "solid",
         "growY": 0,
@@ -2195,7 +2026,7 @@
         "color": "orange",
         "labelColor": "black",
         "fill": "semi",
-        "size": "s",
+        "size": "m",
         "font": "sans",
         "align": "middle",
         "verticalAlign": "middle",
@@ -2244,21 +2075,6803 @@
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "ad",
+      "parentId": "page:overview",
+      "index": "aa",
       "typeName": "shape"
     },
     {
-      "x": 1260,
-      "y": 1040,
+      "x": 780,
+      "y": 830,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:particles",
+      "id": "shape:overview:renderer",
+      "type": "geo",
+      "props": {
+        "w": 300,
+        "h": 102,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph renderer"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "WebGPU drawing · WASM physics"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "primary + minimap passes"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "ab",
+      "typeName": "shape"
+    },
+    {
+      "x": 1130,
+      "y": 830,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:view-plugins",
       "type": "geo",
       "props": {
         "w": 350,
+        "h": 102,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph View contributions"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "runtime nodes · projections · UI · forces"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "ac",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 945,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:cache-guardrail",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 400,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "SQLite persists snapshots; query semantics stay in Core."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "ad",
+      "typeName": "shape"
+    },
+    {
+      "x": 590,
+      "y": 945,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:typescript-guardrail",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 410,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "TypeScript resolution stays in plugin analysis."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "ae",
+      "typeName": "shape"
+    },
+    {
+      "x": 1080,
+      "y": 945,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:overview:renderer-guardrail",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 400,
+        "font": "sans",
+        "textAlign": "end",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "The extension owns policy; the renderer owns drawing and layout."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:overview",
+      "index": "af",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 245,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.12,
+      "meta": {},
+      "id": "shape:indexing:full-lane",
+      "type": "geo",
+      "props": {
+        "w": 1440,
+        "h": 285,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "a1",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 575,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.1,
+      "meta": {},
+      "id": "shape:indexing:incremental-lane",
+      "type": "geo",
+      "props": {
+        "w": 1440,
+        "h": 205,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "a2",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 825,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.08,
+      "meta": {},
+      "id": "shape:indexing:query-lane",
+      "type": "geo",
+      "props": {
+        "w": 1440,
+        "h": 230,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "a3",
+      "typeName": "shape"
+    },
+    {
+      "x": 300,
+      "y": 405,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:settings-to-discovery",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "a4",
+      "typeName": "shape"
+    },
+    {
+      "x": 530,
+      "y": 405,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:discovery-to-preanalysis",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "a5",
+      "typeName": "shape"
+    },
+    {
+      "x": 760,
+      "y": 405,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:preanalysis-to-analysis",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "a6",
+      "typeName": "shape"
+    },
+    {
+      "x": 1010,
+      "y": 405,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:analysis-to-projection",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "a7",
+      "typeName": "shape"
+    },
+    {
+      "x": 1240,
+      "y": 405,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:projection-to-cache",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "a8",
+      "typeName": "shape"
+    },
+    {
+      "x": 300,
+      "y": 690,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:changes-to-engine",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "a9",
+      "typeName": "shape"
+    },
+    {
+      "x": 550,
+      "y": 690,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:engine-to-impact",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "aA",
+      "typeName": "shape"
+    },
+    {
+      "x": 820,
+      "y": 690,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:impact-to-analysis",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "aB",
+      "typeName": "shape"
+    },
+    {
+      "x": 1090,
+      "y": 690,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:analysis-to-patch",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "aC",
+      "typeName": "shape"
+    },
+    {
+      "x": 310,
+      "y": 940,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:caller-to-load",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "aD",
+      "typeName": "shape"
+    },
+    {
+      "x": 560,
+      "y": 940,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:load-to-memory",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "aE",
+      "typeName": "shape"
+    },
+    {
+      "x": 830,
+      "y": 940,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:memory-to-query",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "aF",
+      "typeName": "shape"
+    },
+    {
+      "x": 1100,
+      "y": 940,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:query-to-reports",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:indexing",
+      "index": "aG",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 45,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:atlas-label",
+      "type": "geo",
+      "props": {
+        "w": 390,
+        "h": 48,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "black",
+        "labelColor": "white",
+        "fill": "solid",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CODEGRAPHY / ARCHITECTURE ATLAS"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aH",
+      "typeName": "shape"
+    },
+    {
+      "x": 1390,
+      "y": 56,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:page-number",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "xl",
+        "w": 130,
+        "font": "sans",
+        "textAlign": "end",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "02"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aI",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 112,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:title",
+      "type": "text",
+      "props": {
+        "color": "black",
+        "size": "xl",
+        "w": 920,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Indexing and query"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aJ",
+      "typeName": "shape"
+    },
+    {
+      "x": 82,
+      "y": 170,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:subtitle",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "m",
+        "w": 1050,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "One workspace engine handles full builds, changed-file reconciliation, and bounded reads."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aK",
+      "typeName": "shape"
+    },
+    {
+      "x": 1160,
+      "y": 125,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:storage-rule",
+      "type": "geo",
+      "props": {
+        "w": 360,
+        "h": 82,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Persistence, not a query engine"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "SQLite stores snapshots; Core answers"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aL",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 262,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:full-heading",
+      "type": "text",
+      "props": {
+        "color": "green",
+        "size": "s",
+        "w": 300,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "FULL INDEX"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aM",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 350,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:workspace-settings",
+      "type": "geo",
+      "props": {
+        "w": 180,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Workspace settings"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "include · filters · plugins"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aN",
+      "typeName": "shape"
+    },
+    {
+      "x": 340,
+      "y": 350,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:discovery",
+      "type": "geo",
+      "props": {
+        "w": 190,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "File Discovery"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "gitignore · maxFiles"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aO",
+      "typeName": "shape"
+    },
+    {
+      "x": 570,
+      "y": 340,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:preanalysis",
+      "type": "geo",
+      "props": {
+        "w": 190,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Pre-analysis"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "core + plugin bulk setup"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aP",
+      "typeName": "shape"
+    },
+    {
+      "x": 800,
+      "y": 340,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:analysis",
+      "type": "geo",
+      "props": {
+        "w": 210,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Per-file analysis"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Tree-sitter + plugin hooks"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "symbols · relations · evidence"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aQ",
+      "typeName": "shape"
+    },
+    {
+      "x": 1050,
+      "y": 350,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:projection",
+      "type": "geo",
+      "props": {
+        "w": 190,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph projection"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Nodes · Relationships"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aR",
+      "typeName": "shape"
+    },
+    {
+      "x": 1280,
+      "y": 340,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:cache",
+      "type": "geo",
+      "props": {
+        "w": 200,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "SQLite Graph Cache"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "snapshot · metadata"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "plugin signature"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aS",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 485,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:full-detail",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 1360,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "index() returns the Relationship Graph, analysis cache, discovered files, directories, and full/incremental accounting."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aT",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 592,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:incremental-heading",
+      "type": "text",
+      "props": {
+        "color": "blue",
+        "size": "s",
+        "w": 350,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "INCREMENTAL UPDATE"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aU",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 645,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:file-events",
+      "type": "geo",
+      "props": {
+        "w": 180,
+        "h": 90,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Workspace file changes"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "create · edit · delete"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aV",
+      "typeName": "shape"
+    },
+    {
+      "x": 350,
+      "y": 645,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:changed-engine",
+      "type": "geo",
+      "props": {
+        "w": 200,
+        "h": 90,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "applyChangedFiles()"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "changed path selection"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aW",
+      "typeName": "shape"
+    },
+    {
+      "x": 600,
+      "y": 635,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:plugin-impact",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Plugin invalidation"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "onFilesChanged() may add"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "affected workspace files"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aX",
+      "typeName": "shape"
+    },
+    {
+      "x": 870,
+      "y": 635,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:affected-analysis",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Affected-file analysis"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "reuse unchanged cache tiers"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aY",
+      "typeName": "shape"
+    },
+    {
+      "x": 1140,
+      "y": 635,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:patch",
+      "type": "geo",
+      "props": {
+        "w": 340,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Patch + rebuild"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "delete stale facts · merge results"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "patch SQLite · rebuild graph"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aZ",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 842,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:query-heading",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 300,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "QUERY PATH"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "aa",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 895,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:caller",
+      "type": "geo",
+      "props": {
+        "w": 190,
+        "h": 90,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Extension or CLI"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "same Core APIs"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "ab",
+      "typeName": "shape"
+    },
+    {
+      "x": 360,
+      "y": 885,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:load",
+      "type": "geo",
+      "props": {
+        "w": 200,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Load snapshot"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph + symbols + relations"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "ac",
+      "typeName": "shape"
+    },
+    {
+      "x": 610,
+      "y": 885,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:query-data",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "In-memory data"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Relationship Graph + evidence"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "ad",
+      "typeName": "shape"
+    },
+    {
+      "x": 880,
+      "y": 875,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:query-semantics",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph Query"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "scope · filter · search"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "traversal · projection"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "ae",
+      "typeName": "shape"
+    },
+    {
+      "x": 1150,
+      "y": 875,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:reports",
+      "type": "geo",
+      "props": {
+        "w": 330,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Bounded JSON reports"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "nodes · search · edges"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "dependencies · dependents · path"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "af",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 1025,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:indexing:visible-order",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 1360,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Visible Graph order: Graph Scope → structural projection → Filter → Search → Show Orphans → Collapse Projection."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:indexing",
+      "index": "ag",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 245,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.12,
+      "meta": {},
+      "id": "shape:runtime:host-panel",
+      "type": "geo",
+      "props": {
+        "w": 430,
+        "h": 505,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "a1",
+      "typeName": "shape"
+    },
+    {
+      "x": 555,
+      "y": 245,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.08,
+      "meta": {},
+      "id": "shape:runtime:protocol-panel",
+      "type": "geo",
+      "props": {
+        "w": 280,
+        "h": 505,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "a2",
+      "typeName": "shape"
+    },
+    {
+      "x": 880,
+      "y": 245,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.12,
+      "meta": {},
+      "id": "shape:runtime:webview-panel",
+      "type": "geo",
+      "props": {
+        "w": 640,
+        "h": 505,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "a3",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 800,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.1,
+      "meta": {},
+      "id": "shape:runtime:render-panel",
+      "type": "geo",
+      "props": {
+        "w": 1440,
+        "h": 245,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "a4",
+      "typeName": "shape"
+    },
+    {
+      "x": 295,
+      "y": 395,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:host-activate-to-engine",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 0,
+          "y": 45
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "a5",
+      "typeName": "shape"
+    },
+    {
+      "x": 295,
+      "y": 550,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:host-engine-to-services",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 0,
+          "y": 45
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "a6",
+      "typeName": "shape"
+    },
+    {
+      "x": 510,
+      "y": 480,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:host-to-protocol",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 45,
+          "y": 0
+        },
+        "arrowheadStart": "arrow",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "a7",
+      "typeName": "shape"
+    },
+    {
+      "x": 835,
+      "y": 480,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:protocol-to-webview",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 45,
+          "y": 0
+        },
+        "arrowheadStart": "arrow",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "a8",
+      "typeName": "shape"
+    },
+    {
+      "x": 1015,
+      "y": 395,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:webview-app-to-store",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 0,
+          "y": 45
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "a9",
+      "typeName": "shape"
+    },
+    {
+      "x": 1015,
+      "y": 540,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:webview-store-to-visible",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 0,
+          "y": 45
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "aA",
+      "typeName": "shape"
+    },
+    {
+      "x": 1195,
+      "y": 630,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:webview-visible-to-ui",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 45,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "aB",
+      "typeName": "shape"
+    },
+    {
+      "x": 300,
+      "y": 925,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:frame-visible-to-runtime",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "aC",
+      "typeName": "shape"
+    },
+    {
+      "x": 560,
+      "y": 925,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:frame-runtime-to-layout",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "aD",
+      "typeName": "shape"
+    },
+    {
+      "x": 820,
+      "y": 925,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:frame-layout-to-buffers",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "aE",
+      "typeName": "shape"
+    },
+    {
+      "x": 1080,
+      "y": 925,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:frame-buffers-to-renderer",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "aF",
+      "typeName": "shape"
+    },
+    {
+      "x": 1310,
+      "y": 925,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:frame-renderer-to-surfaces",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 25,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:runtime",
+      "index": "aG",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 45,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:atlas-label",
+      "type": "geo",
+      "props": {
+        "w": 390,
+        "h": 48,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "black",
+        "labelColor": "white",
+        "fill": "solid",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CODEGRAPHY / ARCHITECTURE ATLAS"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aH",
+      "typeName": "shape"
+    },
+    {
+      "x": 1390,
+      "y": 56,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:page-number",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "xl",
+        "w": 130,
+        "font": "sans",
+        "textAlign": "end",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "03"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aI",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 112,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:title",
+      "type": "text",
+      "props": {
+        "color": "black",
+        "size": "xl",
+        "w": 920,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "VS Code runtime"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aJ",
+      "typeName": "shape"
+    },
+    {
+      "x": 82,
+      "y": 170,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:subtitle",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "m",
+        "w": 1070,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "The extension orchestrates product state; the webview derives presentation; the renderer executes frames."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aK",
+      "typeName": "shape"
+    },
+    {
+      "x": 1160,
+      "y": 125,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:ownership-rule",
+      "type": "geo",
+      "props": {
+        "w": 360,
+        "h": 82,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Policy stays above the renderer"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Host + webview own product behavior"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aL",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 262,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:host-heading",
+      "type": "text",
+      "props": {
+        "color": "blue",
+        "size": "s",
+        "w": 300,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "HOST OWNERSHIP"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aM",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 315,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:activation",
+      "type": "geo",
+      "props": {
+        "w": 350,
+        "h": 80,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Extension activation"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "workspace + Graph View provider"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aN",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 440,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:workspace-engine",
+      "type": "geo",
+      "props": {
+        "w": 350,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Core workspace engine"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "index · changed files · Graph Cache"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Relationship Graph snapshot"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aO",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 595,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:host-services",
+      "type": "geo",
+      "props": {
+        "w": 350,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Provider services"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "settings · plugins · commands"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "file actions · exports · diagnostics"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aP",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 715,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:host-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 350,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Owns workspace lifecycle, persisted settings, editor integration, and message dispatch."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aQ",
+      "typeName": "shape"
+    },
+    {
+      "x": 575,
+      "y": 262,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:protocol-heading",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 240,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "TYPED PROTOCOL"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aR",
+      "typeName": "shape"
+    },
+    {
+      "x": 585,
+      "y": 330,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:extension-messages",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Extension → Webview"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "graph · controls · settings"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "plugins · theme · commands"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aS",
+      "typeName": "shape"
+    },
+    {
+      "x": 585,
+      "y": 520,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:webview-messages",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Webview → Extension"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "selection · files · indexing"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "settings · exports · interactions"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aT",
+      "typeName": "shape"
+    },
+    {
+      "x": 585,
+      "y": 675,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:protocol-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 220,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Shared records keep the Electron host and browser runtime synchronized."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aU",
+      "typeName": "shape"
+    },
+    {
+      "x": 900,
+      "y": 262,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:webview-heading",
+      "type": "text",
+      "props": {
+        "color": "blue",
+        "size": "s",
+        "w": 300,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "WEBVIEW STATE"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aV",
+      "typeName": "shape"
+    },
+    {
+      "x": 920,
+      "y": 315,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:app-shell",
+      "type": "geo",
+      "props": {
+        "w": 190,
+        "h": 80,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "React AppShell"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph View surface"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aW",
+      "typeName": "shape"
+    },
+    {
+      "x": 920,
+      "y": 440,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:store",
+      "type": "geo",
+      "props": {
+        "w": 190,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Zustand store"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "graph · controls · plugins"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "selection · viewport"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aX",
+      "typeName": "shape"
+    },
+    {
+      "x": 920,
+      "y": 585,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:visible-graph",
+      "type": "geo",
+      "props": {
+        "w": 230,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "deriveVisibleGraph()"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "scope → structure → filter"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "search → orphans → collapse"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aY",
+      "typeName": "shape"
+    },
+    {
+      "x": 1240,
+      "y": 305,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:graph-ui",
+      "type": "geo",
+      "props": {
+        "w": 240,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph View UI"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "search · scope · legends"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "settings · panels · toolbars"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aZ",
+      "typeName": "shape"
+    },
+    {
+      "x": 1240,
+      "y": 455,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:interactions",
+      "type": "geo",
+      "props": {
+        "w": 240,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Interaction state"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "focus · selection · depth"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "file preview · context menu"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aa",
+      "typeName": "shape"
+    },
+    {
+      "x": 1240,
+      "y": 595,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:renderer-adapter",
+      "type": "geo",
+      "props": {
+        "w": 240,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Renderer adapter"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "frames · camera · hit testing"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "plugin runtime contributions"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "ab",
+      "typeName": "shape"
+    },
+    {
+      "x": 920,
+      "y": 715,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:webview-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 560,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Owns Graph View policy and interaction. It sends resolved frame data into the renderer package."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "ac",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 817,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:render-heading",
+      "type": "text",
+      "props": {
+        "color": "orange",
+        "size": "s",
+        "w": 300,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "RENDER LOOP"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "ad",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 875,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:frame-input",
+      "type": "geo",
+      "props": {
+        "w": 180,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Visible Graph"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "resolved styles + camera"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "ae",
+      "typeName": "shape"
+    },
+    {
+      "x": 340,
+      "y": 865,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:runtime-contributions",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 120,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph View contributions"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "runtime nodes · edges"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "projections · forces"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "af",
+      "typeName": "shape"
+    },
+    {
+      "x": 600,
+      "y": 865,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:layout",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 120,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "TypedGraphLayoutEngine"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "WASM physics · pin/release"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "positions + velocities"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "ag",
+      "typeName": "shape"
+    },
+    {
+      "x": 860,
+      "y": 875,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:buffers",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Typed arrays + GPU buffers"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "positions · styles · edges"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "ah",
+      "typeName": "shape"
+    },
+    {
+      "x": 1120,
+      "y": 865,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:webgpu",
+      "type": "geo",
+      "props": {
+        "w": 190,
+        "h": 120,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "WebGpuGraphRenderer"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "frame queue · camera"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "node/link/arrow passes"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "ai",
+      "typeName": "shape"
+    },
+    {
+      "x": 1335,
+      "y": 875,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:surfaces",
+      "type": "geo",
+      "props": {
+        "w": 155,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Primary + secondary"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "surface"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "aj",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 1005,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:runtime:render-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 1360,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "The secondary surface reuses primary positions and geometry, but owns its camera and compact style buffers for the minimap."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:runtime",
+      "index": "ak",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 245,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.1,
+      "meta": {},
+      "id": "shape:plugins:contract-panel",
+      "type": "geo",
+      "props": {
+        "w": 1440,
+        "h": 315,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "a1",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 605,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.1,
+      "meta": {},
+      "id": "shape:plugins:packages-panel",
+      "type": "geo",
+      "props": {
+        "w": 1440,
+        "h": 190,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "a2",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 840,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 0.08,
+      "meta": {},
+      "id": "shape:plugins:impact-panel",
+      "type": "geo",
+      "props": {
+        "w": 1440,
+        "h": 220,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "a3",
+      "typeName": "shape"
+    },
+    {
+      "x": 870,
+      "y": 700,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:package-to-validation",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:plugins",
+      "index": "a4",
+      "typeName": "shape"
+    },
+    {
+      "x": 1130,
+      "y": 700,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:validation-to-registry",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:plugins",
+      "index": "a5",
+      "typeName": "shape"
+    },
+    {
+      "x": 1010,
+      "y": 955,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:ts-config-to-resolution",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:plugins",
+      "index": "a6",
+      "typeName": "shape"
+    },
+    {
+      "x": 1240,
+      "y": 955,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:ts-resolution-to-relation",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:plugins",
+      "index": "a7",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 45,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:atlas-label",
+      "type": "geo",
+      "props": {
+        "w": 390,
+        "h": 48,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "black",
+        "labelColor": "white",
+        "fill": "solid",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CODEGRAPHY / ARCHITECTURE ATLAS"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "a8",
+      "typeName": "shape"
+    },
+    {
+      "x": 1390,
+      "y": 56,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:page-number",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "xl",
+        "w": 130,
+        "font": "sans",
+        "textAlign": "end",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "04"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "a9",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 112,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:title",
+      "type": "text",
+      "props": {
+        "color": "black",
+        "size": "xl",
+        "w": 920,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Plugin system"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aA",
+      "typeName": "shape"
+    },
+    {
+      "x": 82,
+      "y": 170,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:subtitle",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "m",
+        "w": 1050,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "One validated contract lets packages add analysis, graph semantics, and Graph View behavior."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aB",
+      "typeName": "shape"
+    },
+    {
+      "x": 1160,
+      "y": 125,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:boundary-rule",
+      "type": "geo",
+      "props": {
+        "w": 360,
+        "h": 82,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Semantics stay with their owner"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Core supplies substrate, not ecosystem rules"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aC",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 262,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:contract-heading",
+      "type": "text",
+      "props": {
+        "color": "orange",
+        "size": "s",
+        "w": 320,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CONTRACT SURFACE"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aD",
+      "typeName": "shape"
+    },
+    {
+      "x": 600,
+      "y": 280,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:plugin-contract",
+      "type": "geo",
+      "props": {
+        "w": 400,
+        "h": 90,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "IPlugin / API v3"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "validated at registration"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aE",
+      "typeName": "shape"
+    },
+    {
+      "x": 110,
+      "y": 405,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:identity",
+      "type": "geo",
+      "props": {
+        "w": 200,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Identity + lifecycle"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "id · version · apiVersion"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "initialize · unload"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aF",
+      "typeName": "shape"
+    },
+    {
+      "x": 335,
+      "y": 395,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:analysis",
+      "type": "geo",
+      "props": {
+        "w": 200,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Analysis hooks"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "analyzeFile() · pre-analyze"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "onFilesChanged() · post-analyze"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aG",
+      "typeName": "shape"
+    },
+    {
+      "x": 560,
+      "y": 405,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:graph-types",
+      "type": "geo",
+      "props": {
+        "w": 200,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph facts"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "nodes · symbols · relations"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Node Types · Edge Types"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aH",
+      "typeName": "shape"
+    },
+    {
+      "x": 785,
+      "y": 395,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:capabilities",
+      "type": "geo",
+      "props": {
+        "w": 230,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph Scope capabilities"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "workspace applicability"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "file colors · filters · sources"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aI",
+      "typeName": "shape"
+    },
+    {
+      "x": 1040,
+      "y": 395,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:graph-view",
+      "type": "geo",
+      "props": {
+        "w": 250,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "graphView"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "runtime nodes · edges · projections · forces · UI"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "context menu · drag end"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aJ",
+      "typeName": "shape"
+    },
+    {
+      "x": 1315,
+      "y": 405,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:host-services",
+      "type": "geo",
+      "props": {
+        "w": 195,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Host services"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph · webview messages"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "exports · toolbar · data"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aK",
+      "typeName": "shape"
+    },
+    {
+      "x": 110,
+      "y": 535,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:contract-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 1400,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "The contract carries evidence and ownership into Core, CLI reports, Graph Scope, exports, and the Graph View runtime."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aL",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 622,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:packages-heading",
+      "type": "text",
+      "props": {
+        "color": "blue",
+        "size": "s",
+        "w": 300,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "PLUGIN PACKAGES"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aM",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 665,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:analysis-packages",
+      "type": "geo",
+      "props": {
+        "w": 400,
+        "h": 90,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Analysis plugins"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "TypeScript · Markdown · Vue · Svelte · Godot · Unity"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aN",
+      "typeName": "shape"
+    },
+    {
+      "x": 560,
+      "y": 665,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:particles",
+      "type": "geo",
+      "props": {
+        "w": 310,
+        "h": 90,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Particles presentation plugin"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph View effect runtime"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aO",
+      "typeName": "shape"
+    },
+    {
+      "x": 920,
+      "y": 665,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:plugin-package",
+      "type": "geo",
+      "props": {
+        "w": 210,
+        "h": 70,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Plugin package"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "factory + manifest"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aP",
+      "typeName": "shape"
+    },
+    {
+      "x": 1180,
+      "y": 665,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:validation",
+      "type": "geo",
+      "props": {
+        "w": 150,
+        "h": 70,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "API validation"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aQ",
+      "typeName": "shape"
+    },
+    {
+      "x": 1380,
+      "y": 665,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:registry",
+      "type": "geo",
+      "props": {
+        "w": 110,
+        "h": 70,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Core"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "registry"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aR",
+      "typeName": "shape"
+    },
+    {
+      "x": 920,
+      "y": 750,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:packages-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 570,
+        "font": "sans",
+        "textAlign": "end",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Enablement + workspace applicability decide which capabilities become available."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aS",
+      "typeName": "shape"
+    },
+    {
+      "x": 100,
+      "y": 857,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:impact-heading",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 300,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CHANGE IMPACT"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aT",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 900,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:impact-policy",
+      "type": "geo",
+      "props": {
+        "w": 550,
+        "h": 120,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "IPluginUpdateImpactPolicy"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "view-only · settings-only · projection-only"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "reanalyze-plugin-files · requires-full-index"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aU",
+      "typeName": "shape"
+    },
+    {
+      "x": 120,
+      "y": 1025,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:impact-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 550,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "A toggle declares the smallest correct amount of graph work; the host does not guess."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aV",
+      "typeName": "shape"
+    },
+    {
+      "x": 760,
+      "y": 857,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:typescript-heading",
+      "type": "text",
+      "props": {
+        "color": "orange",
+        "size": "s",
+        "w": 520,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "TYPESCRIPT PROJECT RESOLUTION"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aW",
+      "typeName": "shape"
+    },
+    {
+      "x": 760,
+      "y": 910,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:ts-config",
+      "type": "geo",
+      "props": {
+        "w": 250,
         "h": 90,
         "geo": "rectangle",
         "dash": "solid",
@@ -2286,7 +8899,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "Presentation plugin"
+                  "text": "nearest tsconfig.json"
                 }
               ]
             },
@@ -2298,32 +8911,166 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "Particles"
+                  "text": "within workspace root"
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "ae",
+      "parentId": "page:plugins",
+      "index": "aX",
       "typeName": "shape"
     },
     {
-      "x": 1265,
-      "y": 1150,
+      "x": 1050,
+      "y": 900,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
       "meta": {},
-      "id": "shape:plugin-note",
+      "id": "shape:plugins:ts-resolution",
+      "type": "geo",
+      "props": {
+        "w": 190,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "extends chain"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "baseUrl · paths"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "exact + wildcard aliases"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aY",
+      "typeName": "shape"
+    },
+    {
+      "x": 1280,
+      "y": 910,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:ts-edge",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 90,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "TypeScript Alias Import"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "plugin-owned Relationship"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:plugins",
+      "index": "aZ",
+      "typeName": "shape"
+    },
+    {
+      "x": 760,
+      "y": 1025,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins:typescript-note",
       "type": "text",
       "props": {
         "color": "grey",
         "size": "s",
-        "w": 380,
+        "w": 740,
         "font": "sans",
-        "textAlign": "start",
+        "textAlign": "end",
         "autoSize": false,
         "scale": 1,
         "richText": {
@@ -2340,15 +9087,15 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "TypeScript resolution stays in plugin analysis. Plugins contribute Nodes, Relationships, types, and evidence."
+                  "text": "Project-aware resolution stays in plugin analysis; Core merges and projects the resulting evidence normally."
                 }
               ]
             }
           ]
         }
       },
-      "parentId": "page:page",
-      "index": "af",
+      "parentId": "page:plugins",
+      "index": "aa",
       "typeName": "shape"
     }
   ]

--- a/boards/main.tldr
+++ b/boards/main.tldr
@@ -1,0 +1,2355 @@
+{
+  "tldrawFileFormatVersion": 1,
+  "schema": {
+    "schemaVersion": 2,
+    "sequences": {
+      "com.tldraw.store": 5,
+      "com.tldraw.asset": 1,
+      "com.tldraw.camera": 1,
+      "com.tldraw.document": 2,
+      "com.tldraw.instance": 26,
+      "com.tldraw.instance_page_state": 5,
+      "com.tldraw.page": 1,
+      "com.tldraw.instance_presence": 6,
+      "com.tldraw.pointer": 1,
+      "com.tldraw.shape": 4,
+      "com.tldraw.user": 1,
+      "com.tldraw.asset.image": 6,
+      "com.tldraw.asset.video": 5,
+      "com.tldraw.asset.bookmark": 2,
+      "com.tldraw.shape.group": 0,
+      "com.tldraw.shape.text": 4,
+      "com.tldraw.shape.bookmark": 2,
+      "com.tldraw.shape.draw": 5,
+      "com.tldraw.shape.geo": 11,
+      "com.tldraw.shape.note": 13,
+      "com.tldraw.shape.line": 5,
+      "com.tldraw.shape.frame": 1,
+      "com.tldraw.shape.arrow": 8,
+      "com.tldraw.shape.highlight": 4,
+      "com.tldraw.shape.embed": 4,
+      "com.tldraw.shape.image": 5,
+      "com.tldraw.shape.video": 4,
+      "com.tldraw.binding.arrow": 1
+    }
+  },
+  "records": [
+    {
+      "x": 0,
+      "y": 0,
+      "lastActivityTimestamp": 0,
+      "meta": {},
+      "id": "pointer:pointer",
+      "typeName": "pointer"
+    },
+    {
+      "x": 20,
+      "y": 20,
+      "z": 0.7,
+      "meta": {},
+      "id": "camera:page:page",
+      "typeName": "camera"
+    },
+    {
+      "editingShapeId": null,
+      "croppingShapeId": null,
+      "selectedShapeIds": [],
+      "hoveredShapeId": null,
+      "erasingShapeIds": [],
+      "hintingShapeIds": [],
+      "focusedGroupId": null,
+      "meta": {},
+      "id": "instance_page_state:page:page",
+      "pageId": "page:page",
+      "typeName": "instance_page_state"
+    },
+    {
+      "meta": {},
+      "id": "page:page",
+      "name": "Architecture",
+      "index": "a1",
+      "typeName": "page"
+    },
+    {
+      "gridSize": 10,
+      "name": "CodeGraphy architecture",
+      "meta": {},
+      "id": "document:document",
+      "typeName": "document"
+    },
+    {
+      "followingUserId": null,
+      "opacityForNextShape": 1,
+      "stylesForNextShape": {
+        "tldraw:geo": "rectangle"
+      },
+      "brush": null,
+      "scribbles": [],
+      "cursor": {
+        "type": "default",
+        "rotation": 0
+      },
+      "isFocusMode": false,
+      "exportBackground": true,
+      "isDebugMode": false,
+      "isToolLocked": false,
+      "screenBounds": {
+        "x": 0,
+        "y": 0,
+        "w": 1440,
+        "h": 900
+      },
+      "insets": [
+        false,
+        false,
+        false,
+        false
+      ],
+      "zoomBrush": null,
+      "isGridMode": false,
+      "isPenMode": false,
+      "chatMessage": "",
+      "isChatting": false,
+      "highlightedUserIds": [],
+      "isFocused": true,
+      "devicePixelRatio": 1,
+      "isCoarsePointer": false,
+      "isHoveringCanvas": false,
+      "openMenus": [],
+      "isChangingStyle": false,
+      "isReadonly": false,
+      "meta": {},
+      "duplicateProps": null,
+      "cameraState": "idle",
+      "id": "instance:instance",
+      "currentPageId": "page:page",
+      "typeName": "instance"
+    },
+    {
+      "name": "CodeGraphy",
+      "color": "#64748B",
+      "imageUrl": "",
+      "meta": {},
+      "id": "user:codegraphy",
+      "typeName": "user"
+    },
+    {
+      "x": 320,
+      "y": 285,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:user-to-host",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 100,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "opens"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "a1",
+      "typeName": "shape"
+    },
+    {
+      "x": 720,
+      "y": 285,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:host-to-webview",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 390,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "a2",
+      "typeName": "shape"
+    },
+    {
+      "x": 1260,
+      "y": 365,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:webview-to-renderer",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 0,
+          "y": 90
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "render model"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "a3",
+      "typeName": "shape"
+    },
+    {
+      "x": 320,
+      "y": 675,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:agent-to-core",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 110,
+          "y": 70
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "a4",
+      "typeName": "shape"
+    },
+    {
+      "x": 560,
+      "y": 365,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:host-to-core",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": -36,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": -60,
+          "y": 335
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "same Core APIs"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "a5",
+      "typeName": "shape"
+    },
+    {
+      "x": 600,
+      "y": 755,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:core-to-discovery",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 50,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "a6",
+      "typeName": "shape"
+    },
+    {
+      "x": 810,
+      "y": 755,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:discovery-to-analysis",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "a7",
+      "typeName": "shape"
+    },
+    {
+      "x": 1030,
+      "y": 755,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:analysis-to-projection",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              }
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "a8",
+      "typeName": "shape"
+    },
+    {
+      "x": 1150,
+      "y": 810,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:projection-to-cache",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": -40,
+          "y": 85
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "persists"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "a9",
+      "typeName": "shape"
+    },
+    {
+      "x": 1000,
+      "y": 945,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:cache-to-query",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": -260,
+          "y": 0
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "loads snapshots"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "aA",
+      "typeName": "shape"
+    },
+    {
+      "x": 520,
+      "y": 810,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:core-to-query",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 70,
+          "y": 85
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "query"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "aB",
+      "typeName": "shape"
+    },
+    {
+      "x": 1430,
+      "y": 795,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:api-to-language",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 0,
+          "y": 90
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "implemented by"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "aC",
+      "typeName": "shape"
+    },
+    {
+      "x": 1260,
+      "y": 950,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:language-to-analysis",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 28,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": -260,
+          "y": -140
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "graph facts"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "aD",
+      "typeName": "shape"
+    },
+    {
+      "x": 1320,
+      "y": 1080,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:particles-to-webview",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 74,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 40,
+          "y": -715
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "effect runtime"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "aE",
+      "typeName": "shape"
+    },
+    {
+      "x": 360,
+      "y": 945,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:settings-to-core",
+      "type": "arrow",
+      "props": {
+        "kind": "arc",
+        "elbowMidPoint": 0.5,
+        "dash": "solid",
+        "size": "s",
+        "fill": "none",
+        "color": "grey",
+        "labelColor": "grey",
+        "bend": 0,
+        "start": {
+          "x": 0,
+          "y": 0
+        },
+        "end": {
+          "x": 70,
+          "y": -165
+        },
+        "arrowheadStart": "none",
+        "arrowheadEnd": "arrow",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "workspace state"
+                }
+              ]
+            }
+          ]
+        },
+        "labelPosition": 0.5,
+        "font": "sans",
+        "scale": 1
+      },
+      "parentId": "page:page",
+      "index": "aF",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 55,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:title",
+      "type": "text",
+      "props": {
+        "color": "black",
+        "size": "xl",
+        "w": 760,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CodeGraphy architecture"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aG",
+      "typeName": "shape"
+    },
+    {
+      "x": 82,
+      "y": 118,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:subtitle",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "m",
+        "w": 1180,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "One Core-owned graph pipeline, shared by the VS Code product and the agent-facing CLI."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aH",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 205,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:entry-heading",
+      "type": "text",
+      "props": {
+        "color": "black",
+        "size": "l",
+        "w": 260,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Entrypoints"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aI",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 250,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:developer",
+      "type": "geo",
+      "props": {
+        "w": 240,
+        "h": 115,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Developer"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "VS Code"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aJ",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 615,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:agent",
+      "type": "geo",
+      "props": {
+        "w": 240,
+        "h": 120,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "m",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Agent / CI"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "CodeGraphy Agent Skill"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aK",
+      "typeName": "shape"
+    },
+    {
+      "x": 82,
+      "y": 755,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:no-mcp",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 270,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "No MCP path. The skill teaches agents to call the Core-owned CLI."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aL",
+      "typeName": "shape"
+    },
+    {
+      "x": 420,
+      "y": 175,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:product-heading",
+      "type": "text",
+      "props": {
+        "color": "black",
+        "size": "l",
+        "w": 700,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "VS Code product boundary"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aM",
+      "typeName": "shape"
+    },
+    {
+      "x": 420,
+      "y": 220,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:extension-host",
+      "type": "geo",
+      "props": {
+        "w": 300,
+        "h": 145,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "VS Code extension host"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "workspace lifecycle · settings · plugins"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aN",
+      "typeName": "shape"
+    },
+    {
+      "x": 820,
+      "y": 235,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:shared-protocol",
+      "type": "geo",
+      "props": {
+        "w": 230,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Shared protocol"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "host ↔ webview"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aO",
+      "typeName": "shape"
+    },
+    {
+      "x": 1110,
+      "y": 220,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:graph-view",
+      "type": "geo",
+      "props": {
+        "w": 300,
+        "h": 145,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-blue",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "React webview"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph View · controls · state"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aP",
+      "typeName": "shape"
+    },
+    {
+      "x": 1110,
+      "y": 455,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:graph-renderer",
+      "type": "geo",
+      "props": {
+        "w": 300,
+        "h": 140,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph renderer"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "WebGPU drawing · WASM physics"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aQ",
+      "typeName": "shape"
+    },
+    {
+      "x": 1115,
+      "y": 610,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:renderer-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 310,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "The extension owns lifecycle and interaction. The renderer owns an efficient drawing and layout runtime."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aR",
+      "typeName": "shape"
+    },
+    {
+      "x": 430,
+      "y": 635,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:core-heading",
+      "type": "text",
+      "props": {
+        "color": "black",
+        "size": "l",
+        "w": 650,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Core owns graph truth"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aS",
+      "typeName": "shape"
+    },
+    {
+      "x": 430,
+      "y": 700,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:core-api",
+      "type": "geo",
+      "props": {
+        "w": 170,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "solid",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Core package"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "index + query API"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aT",
+      "typeName": "shape"
+    },
+    {
+      "x": 650,
+      "y": 700,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:discovery",
+      "type": "geo",
+      "props": {
+        "w": 160,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "File"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "discovery"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aU",
+      "typeName": "shape"
+    },
+    {
+      "x": 850,
+      "y": 700,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:analysis",
+      "type": "geo",
+      "props": {
+        "w": 180,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Tree-sitter +"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "plugin analysis"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aV",
+      "typeName": "shape"
+    },
+    {
+      "x": 1070,
+      "y": 700,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:projection",
+      "type": "geo",
+      "props": {
+        "w": 160,
+        "h": 110,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "projection"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aW",
+      "typeName": "shape"
+    },
+    {
+      "x": 520,
+      "y": 895,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:query",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "light-green",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Graph Query"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "in-memory semantics"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aX",
+      "typeName": "shape"
+    },
+    {
+      "x": 1000,
+      "y": 895,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:cache",
+      "type": "geo",
+      "props": {
+        "w": 220,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": ".codegraphy/graph.sqlite"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "SQLite Graph Cache"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aY",
+      "typeName": "shape"
+    },
+    {
+      "x": 790,
+      "y": 1020,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:sqlite-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 430,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "SQLite persists snapshots. Traversal, scope, filtering, search, and projection remain Core-owned."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aZ",
+      "typeName": "shape"
+    },
+    {
+      "x": 80,
+      "y": 900,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:settings",
+      "type": "geo",
+      "props": {
+        "w": 280,
+        "h": 90,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "grey",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": ".codegraphy/settings.json"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "shared workspace state"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "aa",
+      "typeName": "shape"
+    },
+    {
+      "x": 1260,
+      "y": 675,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugins-heading",
+      "type": "text",
+      "props": {
+        "color": "black",
+        "size": "l",
+        "w": 330,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Plugin boundary"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "ab",
+      "typeName": "shape"
+    },
+    {
+      "x": 1305,
+      "y": 720,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugin-api",
+      "type": "geo",
+      "props": {
+        "w": 250,
+        "h": 100,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Plugin API"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "contracts only"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "ac",
+      "typeName": "shape"
+    },
+    {
+      "x": 1260,
+      "y": 885,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:language-plugins",
+      "type": "geo",
+      "props": {
+        "w": 350,
+        "h": 130,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Analysis plugins"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "TypeScript · Markdown · Vue · Svelte"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Godot · Unity"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "ad",
+      "typeName": "shape"
+    },
+    {
+      "x": 1260,
+      "y": 1040,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:particles",
+      "type": "geo",
+      "props": {
+        "w": 350,
+        "h": 90,
+        "geo": "rectangle",
+        "dash": "solid",
+        "growY": 0,
+        "url": "",
+        "scale": 1,
+        "color": "orange",
+        "labelColor": "black",
+        "fill": "semi",
+        "size": "s",
+        "font": "sans",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Presentation plugin"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Particles"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "ae",
+      "typeName": "shape"
+    },
+    {
+      "x": 1265,
+      "y": 1150,
+      "rotation": 0,
+      "isLocked": false,
+      "opacity": 1,
+      "meta": {},
+      "id": "shape:plugin-note",
+      "type": "text",
+      "props": {
+        "color": "grey",
+        "size": "s",
+        "w": 380,
+        "font": "sans",
+        "textAlign": "start",
+        "autoSize": false,
+        "scale": 1,
+        "richText": {
+          "type": "doc",
+          "attrs": {
+            "dir": "auto"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "dir": "auto"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "TypeScript resolution stays in plugin analysis. Plugins contribute Nodes, Relationships, types, and evidence."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "parentId": "page:page",
+      "index": "af",
+      "typeName": "shape"
+    }
+  ]
+}

--- a/boards/tsconfig.json
+++ b/boards/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../scripts/tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a typed offline generator for the CodeGraphy architecture board
- commit the generated boards/main.tldr artifact for direct import into tldraw offline
- cover schema compatibility, architecture content, text sizing, and CLI execution with Vitest

## Verification
- pnpm exec eslint boards/architecture.command.ts boards/architecture.command.test.ts
- pnpm exec tsc -p boards/tsconfig.json
- pnpm exec vitest run boards/architecture.command.test.ts
- pnpm run typecheck
- pnpm test
- imported and visually checked boards/main.tldr in tldraw offline

No changeset: documentation and developer tooling only.