### PR TITLE
Add Vercel Analytics and Speed Insights

### DIFF
--- a/.changeset/tidy-rivers-observe.md
+++ b/.changeset/tidy-rivers-observe.md
@@ -1,0 +1,5 @@
+---
+'@codegraphy/web': patch
+---
+
+Add site-wide Vercel Web Analytics and Speed Insights.

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import { DM_Sans, Fira_Code, Newsreader } from 'next/font/google';
+import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Footer } from '@/components/footer';
 import { Navbar } from '@/components/nav/navbar';
 import { ThemeProvider } from '@/components/theme-provider';
@@ -77,6 +79,8 @@ export default function RootLayout({
             <Footer />
           </div>
         </ThemeProvider>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,8 @@
 		"@base-ui/react": "^1.6.0",
 		"@codegraphy-dev/graph-renderer": "workspace:*",
 		"@material-symbols-svg/react": "^0.11.0",
+		"@vercel/analytics": "^2.0.1",
+		"@vercel/speed-insights": "^2.0.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"next": "16.2.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,12 @@ importers:
       '@material-symbols-svg/react':
         specifier: ^0.11.0
         version: 0.11.0(react@19.2.7)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.2(@typescript-eslint/types@8.57.0))(vue@3.5.35(typescript@5.9.3))
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.2(@typescript-eslint/types@8.57.0))(vue@3.5.35(typescript@5.9.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3989,6 +3995,61 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -11054,6 +11115,20 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vercel/analytics@2.0.1(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.2(@typescript-eslint/types@8.57.0))(vue@3.5.35(typescript@5.9.3))':
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      svelte: 5.56.2(@typescript-eslint/types@8.57.0)
+      vue: 3.5.35(typescript@5.9.3)
+
+  '@vercel/speed-insights@2.0.0(next@16.2.9(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.2(@typescript-eslint/types@8.57.0))(vue@3.5.35(typescript@5.9.3))':
+    optionalDependencies:
+      next: 16.2.9(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      svelte: 5.56.2(@typescript-eslint/types@8.57.0)
+      vue: 3.5.35(typescript@5.9.3)
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.37)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:


### PR DESCRIPTION
## Summary

- install `@vercel/analytics` and `@vercel/speed-insights` in the website package
- mount both Next.js components in the root layout so they cover every public route
- add a patch changeset for the website

## Impact

Vercel deployments can collect page traffic in Web Analytics and Core Web Vitals in Speed Insights after this change is deployed. Local development does not send telemetry.

## Verification

- `pnpm --filter @codegraphy/web lint`
- `pnpm --filter @codegraphy/web typecheck`
- `pnpm --filter @codegraphy/web build`
- `pnpm exec changeset status`
- `git diff --check`
- production server returned `200` for `/` and `/docs`; built Next.js manifests include both `Analytics` and `SpeedInsights`