### PR TITLE
fix(core): exclude generated Claude worktrees

### DIFF
--- a/.changeset/calm-worktrees-stay-generated.md
+++ b/.changeset/calm-worktrees-stay-generated.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/core": patch
+---
+
+Exclude generated Claude worktrees from workspace discovery so they cannot exhaust the Max Files limit before the primary workspace is indexed.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -48,7 +48,7 @@ The extension normalizes missing values against current defaults and preserves r
 | `version` | number | `4` | Persisted extension settings schema. |
 | `maxFiles` | number | `1000` | Maximum files discovered during Indexing. |
 | `include` | string[] | `["**/*"]` | Workspace-relative discovery globs. |
-| `respectGitignore` | boolean | `true` | Exclude paths Git reports as ignored. |
+| `respectGitignore` | boolean | `true` | Detect paths Git reports as ignored so interfaces can dim them. |
 | `filterPatterns` | string[] | `[]` | Enabled custom exclusion patterns. |
 | `disabledCustomFilterPatterns` | string[] | `[]` | Custom filter patterns retained in a disabled state. |
 | `disabledPluginFilterPatterns` | string[] | `[]` | Disabled source-owned plugin filter patterns. |
@@ -119,7 +119,7 @@ The Settings > Forces controls apply these values to the live WebAssembly layout
 }
 ```
 
-Core also excludes common generated directories and artifacts such as `node_modules`, `dist`, `build`, `.git`, coverage output, minified JavaScript, and bundles. When `respectGitignore` is true, Git-ignored paths do not enter File Discovery.
+Core also excludes common generated directories and artifacts such as `node_modules`, `dist`, `build`, `.git`, `.worktrees`, `.claude/worktrees`, coverage output, minified JavaScript, and bundles. When `respectGitignore` is true, Git-ignored paths remain indexed and are annotated so interfaces can dim them.
 
 CodeGraphy normalizes an empty `include` to `["**/*"]` and removes duplicate filters.
 

--- a/packages/core/src/discovery/pathExclusions.ts
+++ b/packages/core/src/discovery/pathExclusions.ts
@@ -9,6 +9,8 @@ export const DEFAULT_EXCLUDE = [
   '**/.turbo/**',
   '**/.worktrees',
   '**/.worktrees/**',
+  '**/.claude/worktrees',
+  '**/.claude/worktrees/**',
   '**/coverage/**',
   '**/.DS_Store',
   '**/*.min.js',

--- a/packages/core/tests/discovery/defaultExcludedPath.test.ts
+++ b/packages/core/tests/discovery/defaultExcludedPath.test.ts
@@ -15,6 +15,8 @@ describe('discovery/defaultExcludedPath', () => {
       '**/.turbo/**',
       '**/.worktrees',
       '**/.worktrees/**',
+      '**/.claude/worktrees',
+      '**/.claude/worktrees/**',
       '**/coverage/**',
       '**/.DS_Store',
       '**/*.min.js',

--- a/packages/core/tests/discovery/file/discovery.generatedWorktrees.test.ts
+++ b/packages/core/tests/discovery/file/discovery.generatedWorktrees.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FileDiscovery } from '../../../src/discovery/file/service';
+
+describe('FileDiscovery generated worktrees', () => {
+  let tempDir: string;
+
+  function createFile(relativePath: string): void {
+    const fullPath = path.join(tempDir, relativePath);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, '');
+  }
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codegraphy-generated-worktree-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('does not spend the file limit on generated Claude worktrees', async () => {
+    createFile('.claude/worktrees/generated/src/app.ts');
+    createFile('.claude/worktrees/generated/src/model.ts');
+    createFile('src/app.ts');
+
+    const result = await new FileDiscovery().discover({
+      rootPath: tempDir,
+      maxFiles: 1,
+    });
+
+    expect(result.files.map((file) => file.relativePath)).toEqual([path.join('src', 'app.ts')]);
+    expect(result.limitReached).toBe(false);
+  });
+});

--- a/packages/core/tests/discovery/pathExclusions.test.ts
+++ b/packages/core/tests/discovery/pathExclusions.test.ts
@@ -14,6 +14,8 @@ describe('discovery/pathExclusions', () => {
       '**/.turbo/**',
       '**/.worktrees',
       '**/.worktrees/**',
+      '**/.claude/worktrees',
+      '**/.claude/worktrees/**',
       '**/coverage/**',
       '**/.DS_Store',
       '**/*.min.js',

--- a/packages/core/tests/discovery/pathMatching.test.ts
+++ b/packages/core/tests/discovery/pathMatching.test.ts
@@ -20,6 +20,8 @@ describe('pathMatching', () => {
       '**/.turbo/**',
       '**/.worktrees',
       '**/.worktrees/**',
+      '**/.claude/worktrees',
+      '**/.claude/worktrees/**',
       '**/coverage/**',
       '**/.DS_Store',
       '**/*.min.js',

--- a/packages/core/tests/workspace/status.test.ts
+++ b/packages/core/tests/workspace/status.test.ts
@@ -137,6 +137,7 @@ describe('CodeGraphy Workspace status', () => {
       pendingChangedFiles: [
         path.join(workspaceRoot, 'packages/plugin-typescript/.turbo'),
         path.join(workspaceRoot, '.worktrees/speed-up-codegraphy/packages/core/src/index.ts'),
+        path.join(workspaceRoot, '.claude/worktrees/generated/packages/core/src/index.ts'),
       ],
     });
 

--- a/packages/extension/tests/extension/workspaceFiles/ignore.test.ts
+++ b/packages/extension/tests/extension/workspaceFiles/ignore.test.ts
@@ -33,6 +33,7 @@ describe('extension/workspaceFiles/ignore', () => {
     '/workspace/.turbo/cache/abc-meta.json',
     '/workspace/packages/plugin-typescript/.turbo',
     '/workspace/.worktrees/speed-up-codegraphy/packages/extension/src/extension.ts',
+    '/workspace/.claude/worktrees/generated/packages/extension/src/extension.ts',
     '/workspace/coverage/report.json',
     '/workspace/assets/app.min.js',
     '/workspace/assets/app.bundle.js',


### PR DESCRIPTION
## Summary

- Exclude `.claude/worktrees/**` from canonical workspace discovery.
- Keep generated worktree paths out of workspace freshness checks and extension file-watch refreshes.
- Correct the settings reference to distinguish discovery exclusions from Git-ignored path annotations.
- Add a Core patch changeset.

## Root cause

The local cache was healthy, but File Discovery reached `maxFiles: 3000` after indexing 2,998 files from a generated Claude worktree. The graph filter then hid those generated paths, so the webview received only the two remaining workspace nodes.

This keeps Graph Scope and Filter behavior unchanged. It only prevents the generated `.claude/worktrees` container from consuming the discovery budget, consistent with the existing `.worktrees` exclusion.

## Verification

- `pnpm test:unit`
- Focused Core regression suite: 48 tests passed
- Extension workspace-file ignore suite: 21 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm changeset status --since=origin/main`
- `git diff --check`

Per request, the local Playwright run was stopped after 6 of 122 cases passed; CI will run the full acceptance matrix.

## Quality reports

- `pnpm run mutate -- core src/discovery/pathExclusions.ts`: the constant-only module produced 18 candidates but no runtime-covered mutants, so the mutation score is not applicable; the 50-site limit passed.
- `pnpm run crap -- core`: the report lists 56 existing Core functions above 8. The changed constant-only module adds no functions and has full test coverage.