### PR TITLE
fix(extension): re-index after clearing graph cache

### DIFF
--- a/.changeset/tidy-graphs-reindex.md
+++ b/.changeset/tidy-graphs-reindex.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Re-index the workspace after clearing the Graph Cache so the Graph View does not become empty.

--- a/packages/extension/src/extension/graphView/provider/refresh/factory.ts
+++ b/packages/extension/src/extension/graphView/provider/refresh/factory.ts
@@ -68,7 +68,7 @@ export function createGraphViewProviderRefreshMethods(
     clearCacheAndRefresh: async () => {
       source._analyzer?.clearCache();
       state.hydratedAnalysisCacheTiers.clear();
-      await refresh();
+      await refreshIndex();
     },
     _rebuildAndSend,
     _smartRebuild,

--- a/packages/extension/tests/extension/graphView/provider/refresh.smartrebuildfallsbacktotousesthedefaultshoworphans.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/refresh.smartrebuildfallsbacktotousesthedefaultshoworphans.test.ts
@@ -49,6 +49,7 @@ function createSource(
     _loadDisabledRulesAndPlugins: vi.fn(() => true),
     _loadGroupsAndFilterPatterns: vi.fn(),
     _loadAndSendData: vi.fn(async () => undefined),
+    _refreshAndSendData: vi.fn(async () => undefined),
     _sendAllSettings: vi.fn(),
     _sendFavorites: vi.fn(),
     _computeMergedGroups: vi.fn(),
@@ -117,7 +118,7 @@ describe('graphView/provider/refresh', () => {
 
 
 
-    it('clearCacheAndRefresh clears analyzer cache before a cache-only reload', async () => {
+    it('clearCacheAndRefresh clears analyzer cache before explicit indexing', async () => {
       const clearCache = vi.fn();
       const source = createSource({
         _analyzer: { clearCache, hasIndex: vi.fn(() => true) },
@@ -133,7 +134,7 @@ describe('graphView/provider/refresh', () => {
       methods.refreshSettings();
 
       expect(clearCache).toHaveBeenCalledOnce();
-      expect(source._loadAndSendData).toHaveBeenCalledOnce();
+      expect(source._refreshAndSendData).toHaveBeenCalledOnce();
       expect(source._sendPhysicsSettings).toHaveBeenCalledOnce();
       expect(source._sendSettings).toHaveBeenCalledOnce();
     });

--- a/packages/extension/tests/extension/graphViewProvider.lifecycle.test.ts
+++ b/packages/extension/tests/extension/graphViewProvider.lifecycle.test.ts
@@ -125,15 +125,15 @@ describe('GraphViewProvider lifecycle', () => {
     expect(rebuildSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('clearCacheAndRefresh clears analyzer cache before a cache-only reload', async () => {
+  it('clearCacheAndRefresh clears analyzer cache before explicit indexing', async () => {
     const provider = new GraphViewProvider(
       vscode.Uri.file('/test/extension'),
       createContext() as unknown as vscode.ExtensionContext
     );
     const clearCache = vi.fn();
     const internals = getGraphViewProviderInternals(provider);
-    const loadSpy = vi
-      .spyOn(internals._analysisMethods, '_loadAndSendData')
+    const refreshSpy = vi
+      .spyOn(internals._analysisMethods, '_refreshAndSendData')
       .mockResolvedValue();
     vi.spyOn(internals._settingsStateMethods, '_sendAllSettings').mockImplementation(() => {});
     vi.spyOn(internals._fileInfoMethods, '_sendFavorites').mockImplementation(() => {});
@@ -145,7 +145,7 @@ describe('GraphViewProvider lifecycle', () => {
     await provider.clearCacheAndRefresh();
 
     expect(clearCache).toHaveBeenCalledTimes(1);
-    expect(loadSpy).toHaveBeenCalledTimes(1);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
   });
 
   it('recreates the Graph Cache and Tree-sitter edges after a deleted cache is refreshed then indexed', async () => {
@@ -247,20 +247,20 @@ describe('GraphViewProvider lifecycle', () => {
     expect(sendDepthStateSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('clearCacheAndRefresh still publishes a cache-only reload without an analyzer', async () => {
+  it('clearCacheAndRefresh still runs explicit indexing without an analyzer', async () => {
     const provider = new GraphViewProvider(
       vscode.Uri.file('/test/extension'),
       createContext() as unknown as vscode.ExtensionContext
     );
     const internals = getGraphViewProviderInternals(provider);
-    const loadSpy = vi
-      .spyOn(internals._analysisMethods, '_loadAndSendData')
+    const refreshSpy = vi
+      .spyOn(internals._analysisMethods, '_refreshAndSendData')
       .mockResolvedValue();
 
     (provider as unknown as { _analyzer?: unknown })._analyzer = undefined;
 
     await provider.clearCacheAndRefresh();
 
-    expect(loadSpy).toHaveBeenCalledTimes(1);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Cause

PR #324 changed Graph View refreshes to replay the Graph Cache. The clear-cache command kept using that path, so Re-index Workspace deleted the cache and then loaded the empty cache without indexing.

## Fix

- Route clearCacheAndRefresh through the existing explicit indexing path.
- Update existing lifecycle expectations to require explicit indexing.
- Add an extension patch changeset.

## Verification

- Focused Vitest: 3 files, 17 tests passed.
- Extension build:vscode passed.
- Scoped VS Code Playwright run loaded the Graph View and visibly rendered 24 nodes and 12 connections after explicit indexing. A later runtime-debug-snapshot assertion timed out, so the full scenario did not pass.
- git diff --check passed.

No new regression test files were added.