### PR TITLE
feat: add Core agent transports and MCP server

### DIFF
--- a/.changeset/quiet-tools-connect.md
+++ b/.changeset/quiet-tools-connect.md
@@ -1,0 +1,10 @@
+---
+"@codegraphy-dev/core": minor
+"@codegraphy-dev/extension": minor
+"@codegraphy-dev/mcp": minor
+---
+
+Use one Core response contract for local agent requests, with explicit Graph
+Cache freshness and result completeness. The VS Code URI bridge now supports
+status and delegates Indexing and Graph Query behavior to Core. The new optional
+MCP server exposes the same Core operations as discoverable structured tools.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -114,6 +114,8 @@ The separate `codegraphy watch` CLI command is an explicit foreground workflow f
 | **CodeGraphy Settings CLI** | `settings`, `settings get`, `settings set`, and `settings unset` read or safely mutate supported workspace settings without silently repairing corrupt persisted input. |
 | **Graph Query CLI** | `nodes`, `edges`, `dependencies`, `dependents`, and `path`, all with bounded JSON output over the shaped Relationship Graph. |
 | **CodeGraphy Agent Skill** | Generalized instructions that explain the Relationship Graph, lifecycle, query surfaces, machine-readable output, freshness, shaping, and limits so a shell-capable agent can choose its own navigation strategy. |
+| **CodeGraphy MCP Server** | `@codegraphy-dev/mcp` is an optional stdio transport. It maps discoverable typed tools one-to-one onto Core status, Indexing, and Graph Query operations. It does not own analysis or a separate graph contract. |
+| **VS Code URI Bridge** | A local request and response file transport for agent calls into an open VS Code Workspace. It validates the open Workspace and delegates status, Indexing, and Graph Query behavior to the Core workspace command contract. |
 | **Core Plugin API** | `@codegraphy-dev/plugin-api` contracts for headless Core analysis and semantic graph extensions. |
 | **Extension Plugin API** | `@codegraphy-dev/extension-plugin-api` contracts for VS Code Extension and Graph View extensions. |
 
@@ -161,6 +163,7 @@ Extension chrome inherits the active VS Code theme. Graph Data Color may encode 
 ## Package Boundaries
 
 - `packages/core` owns shared engine behavior and the CLI.
+- `packages/mcp` owns the optional MCP stdio adapter over Core workspace commands.
 - `packages/extension` owns the VS Code product surface.
 - `packages/tldraw` owns the tldraw offline product surface and launcher.
 - `packages/graph-renderer` owns graph drawing and physics.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ CodeGraphy indexes a folder and projects its files and declarations into Nodes. 
 | Graph Cache | Workspace-local SQLite storage shared by the extension and CLI. |
 | tldraw interface | A native, editable tldraw canvas with shared force physics and live refresh. |
 | Plugins | Headless npm packages for deeper analysis and Graph View contributions. |
-| Agent access | Bounded JSON queries through the Core CLI and a reusable Agent Skill source. |
+| Agent access | Bounded Core queries through the CLI, Agent Skill, optional MCP server, and VS Code URI bridge. |
 
 ## Gallery
 
@@ -176,15 +176,36 @@ npx skills@latest add ./skills/codegraphy
 
 A public `codegraphy/skills` repository will host the skill once published.
 
+### MCP Server
+
+Install the optional MCP server when an agent client benefits from tool discovery,
+validated input schemas, structured results, and a persistent stdio connection:
+
+```bash
+npm install -g @codegraphy-dev/mcp
+```
+
+Configure the client to launch `codegraphy-mcp` from the CodeGraphy Workspace.
+The server exposes status, explicit Indexing, discovery, inventory, and navigation
+tools as thin adapters over the same Core operations as the CLI. Every response
+includes Graph Cache freshness and result completeness metadata.
+
+Use the [Agent Skill](./skills/codegraphy/SKILL.md) plus the Core CLI when an
+agent already has a shell or needs the full CLI surface. MCP adds client
+integration, not new analysis. See the
+[`@codegraphy-dev/mcp` guide](./packages/mcp/README.md) for the exact tools and
+tradeoffs.
+
 ## Architecture
 
 ![CodeGraphy package and data flow](./docs/media/readme/codegraphy-architecture.png)
 
-`@codegraphy-dev/core` owns File Discovery, built-in analysis, optional foreground Graph Cache watching, plugin discovery and activation, SQLite Graph Cache storage, Graph Query, and the CLI. It does not own rendering. The VS Code extension connects Core to the editor lifecycle and React Graph View; it changes cached source facts only after an explicit Index or Re-index Workspace action. The tldraw interface connects Core data and shared physics to native tldraw shapes. `@codegraphy-dev/graph-renderer` owns WebGPU drawing and WebAssembly physics. Core plugins use `@codegraphy-dev/plugin-api`. VS Code Extension plugins use `@codegraphy-dev/extension-plugin-api`.
+`@codegraphy-dev/core` owns File Discovery, built-in analysis, optional foreground Graph Cache watching, plugin discovery and activation, SQLite Graph Cache storage, Graph Query, the transport-neutral workspace command contract, and the CLI. It does not own rendering. The VS Code extension connects Core to the editor lifecycle and React Graph View; it changes cached source facts only after an explicit Index or Re-index Workspace action. The optional MCP server and VS Code URI bridge adapt the Core command contract without defining parallel graph behavior. The tldraw interface connects Core data and shared physics to native tldraw shapes. `@codegraphy-dev/graph-renderer` owns WebGPU drawing and WebAssembly physics. Core plugins use `@codegraphy-dev/plugin-api`. VS Code Extension plugins use `@codegraphy-dev/extension-plugin-api`.
 
 | Package | Role |
 |---|---|
 | [`@codegraphy-dev/core`](./packages/core/README.md) | Shared indexing, cache, plugin, query, and CLI engine. |
+| [`@codegraphy-dev/mcp`](./packages/mcp/README.md) | Optional MCP transport over Core status, Indexing, and Graph Query operations. |
 | [`@codegraphy-dev/extension`](./packages/extension/docs/README.md) | VS Code host and Graph View product integration. |
 | [`@codegraphy-dev/tldraw`](./packages/tldraw/README.md) | macOS launcher and native tldraw offline canvas integration. |
 | [`@codegraphy-dev/graph-renderer`](./packages/graph-renderer/README.md) | WebGPU graph renderer and WebAssembly physics. |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,8 @@
 
 Shared CodeGraphy engine package for workspace indexing, Graph Cache access, plugin management, Graph Query behavior, and the terminal `codegraphy` command.
 
-This package is the headless core used by the VS Code extension and CLI.
+This package is the headless core used by the VS Code extension, CLI, and
+optional MCP server.
 
 The published CLI supports Node.js `^22.14.0 || >=23.6.0`. An active Long-Term Support release is recommended.
 
@@ -80,8 +81,14 @@ Run `codegraphy --help` for the command list and `codegraphy <command> --help` f
 - Task Map: rank task-relevant Files from live terms and cached Relationships, with selected declarations and typed connections.
 - Target Query: inspect one exact File or Symbol with prioritized declarations and bounded Relationships.
 - Graph Query: list scoped Nodes and Edges, then use complete cached types by default for exact targeted relationships and bounded paths unless an invocation explicitly projects Node or Edge Types.
+- Workspace Commands: execute status, explicit Indexing, and Graph Query through one transport-neutral response contract with Graph Cache freshness and result completeness metadata.
 
-The core package exposes `indexCodeGraphyWorkspace` for one-shot Indexing and composes `createCodeGraphyWorkspaceCacheUpdater` with `subscribeCodeGraphyWorkspaceChanges` for the explicit foreground CLI watcher. The VS Code Extension uses Core only after an explicit Index or Re-index Workspace action; it does not subscribe to source-file changes.
+The core package exposes `executeCodeGraphyWorkspaceCommand` for interface
+adapters, `indexCodeGraphyWorkspace` for one-shot Indexing, and
+`createCodeGraphyWorkspaceCacheUpdater` with
+`subscribeCodeGraphyWorkspaceChanges` for the explicit foreground CLI watcher.
+The VS Code Extension uses Core only after an explicit Index or Re-index
+Workspace action; it does not subscribe to source-file changes.
 
 ## Built-In Language Coverage
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -426,6 +426,7 @@ export type {
   GraphQueryReport as WorkspaceGraphQueryReport,
   IndexWorkspaceResult,
   WorkspaceGraphQueryInput,
+  WorkspaceGraphQueryProjection,
   WorkspaceGraphQueryResult,
   WorkspacePathInput,
   WorkspaceStatusResult,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -434,6 +434,15 @@ export { requestCodeGraphyIndexWorkspace } from './workspace/requestIndexing';
 export { requestWorkspaceGraphQuery } from './workspace/requestQuery';
 export { readCodeGraphyWorkspaceStatusForCli } from './workspace/requestStatus';
 export type {
+  CodeGraphyWorkspaceCommand,
+  CodeGraphyWorkspaceCommandDependencies,
+  CodeGraphyWorkspaceCommandMetadata,
+  CodeGraphyWorkspaceCommandName,
+  CodeGraphyWorkspaceCommandResponse,
+  CodeGraphyWorkspaceIncompleteReason,
+} from './workspace/command';
+export { executeCodeGraphyWorkspaceCommand } from './workspace/command';
+export type {
   CodeGraphyWorkspaceStaleReason,
   CodeGraphyWorkspaceStatus,
   CodeGraphyWorkspaceStatusState,

--- a/packages/core/src/workspace/command.ts
+++ b/packages/core/src/workspace/command.ts
@@ -39,6 +39,7 @@ export type CodeGraphyWorkspaceIncompleteReason =
   | 'file-budget-reached'
   | 'page-truncated'
   | 'path-limit-reached'
+  | 'query-target-not-found'
   | 'relationship-limit-reached'
   | 'source-files-skipped';
 
@@ -143,6 +144,16 @@ function readError(result: WorkspaceGraphQueryResult): { code: string; message: 
     : undefined;
 }
 
+function readErrorIncompleteReason(errorCode: string): CodeGraphyWorkspaceIncompleteReason {
+  if (errorCode === 'graph_cache_not_found') {
+    return 'cache-missing';
+  }
+  if (errorCode === 'query_target_not_found') {
+    return 'query-target-not-found';
+  }
+  return 'command-failed';
+}
+
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -195,7 +206,7 @@ export async function executeCodeGraphyWorkspaceCommand(
         ok: false,
         command: input.command,
         error,
-        metadata: createMetadata(workspaceRoot, status, ['cache-missing']),
+        metadata: createMetadata(workspaceRoot, status, [readErrorIncompleteReason(error.code)]),
       };
     }
     return {

--- a/packages/core/src/workspace/command.ts
+++ b/packages/core/src/workspace/command.ts
@@ -1,0 +1,219 @@
+import type { DiagnosticEventSink } from '../diagnostics/events';
+import type { GraphQueryRequest } from '../graphQuery';
+import { resolveCodeGraphyWorkspacePath } from './requestPaths';
+import { requestCodeGraphyIndexWorkspace } from './requestIndexing';
+import { requestWorkspaceGraphQuery } from './requestQuery';
+import { readCodeGraphyWorkspaceStatusForCli } from './requestStatus';
+import type {
+  IndexWorkspaceResult,
+  WorkspaceGraphQueryInput,
+  WorkspaceGraphQueryProjection,
+  WorkspaceGraphQueryResult,
+  WorkspacePathInput,
+  WorkspaceStatusResult,
+} from './requestTypes';
+
+export type CodeGraphyWorkspaceCommandName = 'index' | 'query' | 'status';
+
+interface CodeGraphyWorkspaceCommandBase {
+  diagnostics?: DiagnosticEventSink;
+  workspacePath?: string;
+}
+
+export type CodeGraphyWorkspaceCommand =
+  | CodeGraphyWorkspaceCommandBase & {
+    command: 'index';
+  }
+  | CodeGraphyWorkspaceCommandBase & {
+    command: 'query';
+    projection?: WorkspaceGraphQueryProjection;
+    query: GraphQueryRequest;
+  }
+  | CodeGraphyWorkspaceCommandBase & {
+    command: 'status';
+  };
+
+export type CodeGraphyWorkspaceIncompleteReason =
+  | 'cache-missing'
+  | 'command-failed'
+  | 'file-budget-reached'
+  | 'page-truncated'
+  | 'path-limit-reached'
+  | 'relationship-limit-reached'
+  | 'source-files-skipped';
+
+export interface CodeGraphyWorkspaceCommandMetadata {
+  workspaceRoot: string;
+  cache: {
+    state: WorkspaceStatusResult['state'];
+    staleReasons: string[];
+  };
+  result: {
+    complete: boolean;
+    reasons: CodeGraphyWorkspaceIncompleteReason[];
+  };
+}
+
+export type CodeGraphyWorkspaceCommandResponse =
+  | {
+    ok: true;
+    command: CodeGraphyWorkspaceCommandName;
+    data: IndexWorkspaceResult | WorkspaceGraphQueryResult | WorkspaceStatusResult;
+    metadata: CodeGraphyWorkspaceCommandMetadata;
+  }
+  | {
+    ok: false;
+    command: CodeGraphyWorkspaceCommandName;
+    error: {
+      code: string;
+      message: string;
+    };
+    metadata: CodeGraphyWorkspaceCommandMetadata;
+  };
+
+export interface CodeGraphyWorkspaceCommandDependencies {
+  cwd(): string;
+  indexWorkspace(input: WorkspacePathInput): Promise<IndexWorkspaceResult>;
+  queryWorkspace(input: WorkspaceGraphQueryInput): Promise<WorkspaceGraphQueryResult>;
+  readStatus(input: WorkspacePathInput): WorkspaceStatusResult;
+}
+
+const DEFAULT_DEPENDENCIES: CodeGraphyWorkspaceCommandDependencies = {
+  cwd: () => process.cwd(),
+  indexWorkspace: requestCodeGraphyIndexWorkspace,
+  queryWorkspace: requestWorkspaceGraphQuery,
+  readStatus: readCodeGraphyWorkspaceStatusForCli,
+};
+
+function readResultObject(result: unknown): Record<string, unknown> {
+  return typeof result === 'object' && result !== null
+    ? result as Record<string, unknown>
+    : {};
+}
+
+function collectQueryIncompleteReasons(
+  result: WorkspaceGraphQueryResult,
+): CodeGraphyWorkspaceIncompleteReason[] {
+  const reasons: CodeGraphyWorkspaceIncompleteReason[] = [];
+  const value = readResultObject(result);
+  const page = readResultObject(value.page);
+  if (page.nextOffset !== null && page.nextOffset !== undefined) {
+    reasons.push('page-truncated');
+  }
+  if (value.complete === false) {
+    reasons.push('path-limit-reached');
+  }
+  const limits = readResultObject(value.limits);
+  if (limits.complete === false) {
+    reasons.push('relationship-limit-reached');
+  }
+  const sources = readResultObject(value.sources);
+  const text = readResultObject(sources.text);
+  if (typeof text.filesSkipped === 'number' && text.filesSkipped > 0) {
+    reasons.push('source-files-skipped');
+  }
+  return reasons;
+}
+
+function createMetadata(
+  workspaceRoot: string,
+  status: WorkspaceStatusResult,
+  reasons: CodeGraphyWorkspaceIncompleteReason[],
+): CodeGraphyWorkspaceCommandMetadata {
+  return {
+    workspaceRoot,
+    cache: {
+      state: status.state,
+      staleReasons: status.staleReasons,
+    },
+    result: {
+      complete: reasons.length === 0,
+      reasons,
+    },
+  };
+}
+
+function readError(result: WorkspaceGraphQueryResult): { code: string; message: string } | undefined {
+  const value = readResultObject(result);
+  return typeof value.error === 'string'
+    ? {
+        code: value.error,
+        message: typeof value.message === 'string' ? value.message : value.error,
+      }
+    : undefined;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function executeCodeGraphyWorkspaceCommand(
+  input: CodeGraphyWorkspaceCommand,
+  dependencies: CodeGraphyWorkspaceCommandDependencies = DEFAULT_DEPENDENCIES,
+): Promise<CodeGraphyWorkspaceCommandResponse> {
+  const workspaceRoot = resolveCodeGraphyWorkspacePath(input.workspacePath, dependencies.cwd());
+  const pathInput: WorkspacePathInput = {
+    workspacePath: workspaceRoot,
+    ...(input.diagnostics ? { diagnostics: input.diagnostics } : {}),
+  };
+
+  try {
+    if (input.command === 'status') {
+      const data = dependencies.readStatus(pathInput);
+      return {
+        ok: true,
+        command: input.command,
+        data,
+        metadata: createMetadata(workspaceRoot, data, []),
+      };
+    }
+
+    if (input.command === 'index') {
+      const data = await dependencies.indexWorkspace(pathInput);
+      const status = dependencies.readStatus(pathInput);
+      const reasons: CodeGraphyWorkspaceIncompleteReason[] = data.discovery.limitReached
+        ? ['file-budget-reached']
+        : [];
+      return {
+        ok: true,
+        command: input.command,
+        data,
+        metadata: createMetadata(workspaceRoot, status, reasons),
+      };
+    }
+
+    const data = await dependencies.queryWorkspace({
+      ...input.query,
+      workspacePath: workspaceRoot,
+      ...(input.projection ? { projection: input.projection } : {}),
+      ...(input.diagnostics ? { diagnostics: input.diagnostics } : {}),
+    });
+    const status = dependencies.readStatus(pathInput);
+    const error = readError(data);
+    if (error) {
+      return {
+        ok: false,
+        command: input.command,
+        error,
+        metadata: createMetadata(workspaceRoot, status, ['cache-missing']),
+      };
+    }
+    return {
+      ok: true,
+      command: input.command,
+      data,
+      metadata: createMetadata(workspaceRoot, status, collectQueryIncompleteReasons(data)),
+    };
+  } catch (error) {
+    const status = dependencies.readStatus(pathInput);
+    return {
+      ok: false,
+      command: input.command,
+      error: {
+        code: 'workspace_command_failed',
+        message: formatError(error),
+      },
+      metadata: createMetadata(workspaceRoot, status, ['command-failed']),
+    };
+  }
+}

--- a/packages/core/tests/workspace/command.test.ts
+++ b/packages/core/tests/workspace/command.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  IndexWorkspaceResult,
+  WorkspaceGraphQueryInput,
+  WorkspaceGraphQueryResult,
+  WorkspacePathInput,
+  WorkspaceStatusResult,
+} from '../../src/workspace/requestTypes';
+import {
+  executeCodeGraphyWorkspaceCommand,
+  type CodeGraphyWorkspaceCommandDependencies,
+} from '../../src/workspace/command';
+
+function createStatus(
+  state: WorkspaceStatusResult['state'] = 'fresh',
+  staleReasons: string[] = [],
+): WorkspaceStatusResult {
+  return {
+    workspaceRoot: '/workspace/project',
+    graphCache: '.codegraphy/graph.sqlite',
+    state,
+    hasGraphCache: state !== 'missing',
+    staleReasons,
+    enabledPlugins: ['codegraphy.markdown'],
+    message: `Graph Cache is ${state}.`,
+  };
+}
+
+function createIndexResult(limitReached = false): IndexWorkspaceResult {
+  return {
+    workspaceRoot: '/workspace/project',
+    graphCache: '.codegraphy/graph.sqlite',
+    message: 'Indexing completed.',
+    discovery: {
+      indexedFiles: 10,
+      totalFound: limitReached ? 12 : 10,
+      limitReached,
+    },
+    indexing: {
+      mode: 'incremental',
+      analyzedFiles: 2,
+      deletedFiles: 0,
+      reusedFiles: 8,
+    },
+  };
+}
+
+function createDependencies(
+  options: {
+    status?: WorkspaceStatusResult;
+    query?: WorkspaceGraphQueryResult;
+    index?: IndexWorkspaceResult;
+  } = {},
+): CodeGraphyWorkspaceCommandDependencies {
+  return {
+    cwd: () => '/workspace/project',
+    indexWorkspace: vi.fn(async (_input: WorkspacePathInput) =>
+      options.index ?? createIndexResult()),
+    queryWorkspace: vi.fn(async (_input: WorkspaceGraphQueryInput) =>
+      options.query ?? {
+        nodes: [],
+        page: {
+          offset: 0,
+          limit: 100,
+          returned: 0,
+          total: 0,
+          nextOffset: null,
+        },
+        workspaceRoot: '/workspace/project',
+        cacheStatus: { state: 'fresh', staleReasons: [] },
+      }),
+    readStatus: vi.fn((_input: WorkspacePathInput) =>
+      options.status ?? createStatus()),
+  };
+}
+
+describe('workspace/command', () => {
+  it('returns status through one transport-neutral response envelope', async () => {
+    const dependencies = createDependencies();
+
+    await expect(executeCodeGraphyWorkspaceCommand({
+      command: 'status',
+      workspacePath: '/workspace/project',
+    }, dependencies)).resolves.toEqual({
+      ok: true,
+      command: 'status',
+      data: createStatus(),
+      metadata: {
+        workspaceRoot: '/workspace/project',
+        cache: {
+          state: 'fresh',
+          staleReasons: [],
+        },
+        result: {
+          complete: true,
+          reasons: [],
+        },
+      },
+    });
+  });
+
+  it('reports stale cache provenance and bounded query pagination separately', async () => {
+    const dependencies = createDependencies({
+      status: createStatus('stale', ['pending-changed-files']),
+      query: {
+        nodes: [{ path: 'src/app.ts', nodeType: 'file' }],
+        page: {
+          offset: 0,
+          limit: 1,
+          returned: 1,
+          total: 2,
+          nextOffset: 1,
+        },
+        workspaceRoot: '/workspace/project',
+        cacheStatus: {
+          state: 'stale',
+          staleReasons: ['pending-changed-files'],
+        },
+      },
+    });
+
+    const result = await executeCodeGraphyWorkspaceCommand({
+      command: 'query',
+      workspacePath: '/workspace/project',
+      query: {
+        report: 'nodes',
+        arguments: { limit: 1 },
+      },
+    }, dependencies);
+
+    expect(result).toMatchObject({
+      ok: true,
+      command: 'query',
+      metadata: {
+        cache: {
+          state: 'stale',
+          staleReasons: ['pending-changed-files'],
+        },
+        result: {
+          complete: false,
+          reasons: ['page-truncated'],
+        },
+      },
+    });
+    expect(dependencies.queryWorkspace).toHaveBeenCalledWith({
+      workspacePath: '/workspace/project',
+      report: 'nodes',
+      arguments: { limit: 1 },
+    });
+  });
+
+  it('reports Indexing file-budget limits as incomplete results', async () => {
+    const dependencies = createDependencies({
+      index: createIndexResult(true),
+    });
+
+    const result = await executeCodeGraphyWorkspaceCommand({
+      command: 'index',
+      workspacePath: '/workspace/project',
+    }, dependencies);
+
+    expect(result).toMatchObject({
+      ok: true,
+      command: 'index',
+      metadata: {
+        result: {
+          complete: false,
+          reasons: ['file-budget-reached'],
+        },
+      },
+    });
+  });
+
+  it('turns Core query failures into the same response contract', async () => {
+    const dependencies = createDependencies({
+      status: createStatus('missing', ['never-indexed']),
+      query: {
+        error: 'graph_cache_not_found',
+        message: 'Run Indexing first.',
+        workspaceRoot: '/workspace/project',
+      },
+    });
+
+    await expect(executeCodeGraphyWorkspaceCommand({
+      command: 'query',
+      query: {
+        report: 'search',
+        arguments: { pattern: 'settings' },
+      },
+    }, dependencies)).resolves.toEqual({
+      ok: false,
+      command: 'query',
+      error: {
+        code: 'graph_cache_not_found',
+        message: 'Run Indexing first.',
+      },
+      metadata: {
+        workspaceRoot: '/workspace/project',
+        cache: {
+          state: 'missing',
+          staleReasons: ['never-indexed'],
+        },
+        result: {
+          complete: false,
+          reasons: ['cache-missing'],
+        },
+      },
+    });
+  });
+
+  it('returns thrown failures without leaking transport-specific errors', async () => {
+    const dependencies = createDependencies();
+    vi.mocked(dependencies.indexWorkspace).mockRejectedValueOnce(new Error('Indexing failed'));
+
+    const result = await executeCodeGraphyWorkspaceCommand({
+      command: 'index',
+    }, dependencies);
+
+    expect(result).toEqual({
+      ok: false,
+      command: 'index',
+      error: {
+        code: 'workspace_command_failed',
+        message: 'Indexing failed',
+      },
+      metadata: {
+        workspaceRoot: '/workspace/project',
+        cache: {
+          state: 'fresh',
+          staleReasons: [],
+        },
+        result: {
+          complete: false,
+          reasons: ['command-failed'],
+        },
+      },
+    });
+  });
+});

--- a/packages/core/tests/workspace/command.test.ts
+++ b/packages/core/tests/workspace/command.test.ts
@@ -208,6 +208,40 @@ describe('workspace/command', () => {
     });
   });
 
+  it('does not report a missing query target as a missing Graph Cache', async () => {
+    const dependencies = createDependencies({
+      query: {
+        error: 'query_target_not_found',
+        message: 'No exact File or Symbol matched src/missing.ts.',
+        workspaceRoot: '/workspace/project',
+      },
+    });
+
+    const result = await executeCodeGraphyWorkspaceCommand({
+      command: 'query',
+      query: {
+        report: 'overview',
+        arguments: { target: 'src/missing.ts' },
+      },
+    }, dependencies);
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'query_target_not_found',
+      },
+      metadata: {
+        cache: {
+          state: 'fresh',
+        },
+        result: {
+          complete: false,
+          reasons: ['query-target-not-found'],
+        },
+      },
+    });
+  });
+
   it('returns thrown failures without leaking transport-specific errors', async () => {
     const dependencies = createDependencies();
     vi.mocked(dependencies.indexWorkspace).mockRejectedValueOnce(new Error('Indexing failed'));

--- a/packages/extension/docs/boundaries.md
+++ b/packages/extension/docs/boundaries.md
@@ -18,7 +18,7 @@ The extension host is still the VS Code composition root. It wires the graph pro
 
 The extension source tree is intentionally feature-first inside each runtime boundary:
 
-- `src/extension/agentBridge/` owns VS Code URI request handling for local agent tooling.
+- `src/extension/agentBridge/` owns the local VS Code URI transport, open-Workspace validation, request and response files, user notifications, and Graph View reload after explicit Indexing. Core owns the status, Indexing, Graph Query, freshness, completeness, and error response behavior behind that adapter.
 - `src/extension/graphView/` and `src/extension/graphViewProvider.ts` own VS Code host orchestration for the Graph View.
 - `src/extension/pipeline/` owns extension-facing adapters over `@codegraphy-dev/core` pipeline APIs and extension-only orchestration.
 - `src/extension/repoSettings/` owns repo-local settings, freshness decisions, and Graph Cache trust state.

--- a/packages/extension/docs/graph-cache-lifecycle.md
+++ b/packages/extension/docs/graph-cache-lifecycle.md
@@ -25,6 +25,8 @@ Saving, creating, changing, deleting, or renaming files does not process source 
 
 Users choose **Re-index Workspace** when they want the Extension to rediscover files, run built-in and Extension-host plugin analysis, project the complete Relationship Graph, and replace the Graph Cache.
 
+A local agent can also send an explicit Index request through the VS Code URI bridge. The bridge validates the open Workspace, delegates Indexing to Core, and reloads the Graph View from the updated cache. Status and Graph Query requests through the bridge do not perform Indexing.
+
 The separate foreground `codegraphy watch` command belongs to the Core CLI. It can maintain the same workspace cache during an explicit terminal session, but the Extension does not launch or own that process.
 
 ## Progress UI

--- a/packages/extension/src/extension/agentBridge/uri/actions.ts
+++ b/packages/extension/src/extension/agentBridge/uri/actions.ts
@@ -1,67 +1,64 @@
+import {
+  executeCodeGraphyWorkspaceCommand,
+  type CodeGraphyWorkspaceCommand,
+} from '@codegraphy-dev/core';
 import type {
   CodeGraphyAgentAction,
   CodeGraphyAgentBridgeProvider,
-  CodeGraphyAgentGraphQueryRequest,
   CodeGraphyAgentRequest,
   CodeGraphyAgentUriDependencies,
   CodeGraphyAgentUriResult,
 } from './types';
-import { writeFailureResponse } from './response';
 
-export function formatErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-async function handleIndexRequest(
+function createWorkspaceCommand(
+  action: CodeGraphyAgentAction,
   request: CodeGraphyAgentRequest,
-  provider: CodeGraphyAgentBridgeProvider,
-  dependencies: CodeGraphyAgentUriDependencies,
-): Promise<CodeGraphyAgentUriResult> {
-  try {
-    await provider.refreshIndex();
-    await dependencies.writeResponseFile(request.responsePath, {
-      requestId: request.requestId,
-      repo: request.repo,
-      status: 'indexed',
-    });
-    return { status: 'indexed' };
-  } catch (error) {
-    const message = formatErrorMessage(error);
-    await writeFailureResponse(request, message, dependencies);
-    dependencies.showErrorMessage(`CodeGraphy failed to index ${request.repo}: ${message}`);
-    return { status: 'failed' };
+): CodeGraphyWorkspaceCommand {
+  if (action === 'query') {
+    if (!request.query) {
+      throw new Error('CodeGraphy query request did not include a Graph Query.');
+    }
+    return {
+      command: action,
+      workspacePath: request.repo,
+      query: request.query,
+    };
   }
+  return {
+    command: action,
+    workspacePath: request.repo,
+  };
 }
 
-async function handleQueryRequest(
-  request: CodeGraphyAgentRequest,
-  provider: CodeGraphyAgentBridgeProvider,
-  dependencies: CodeGraphyAgentUriDependencies,
-): Promise<CodeGraphyAgentUriResult> {
-  try {
-    const result = provider.queryGraph((request as CodeGraphyAgentGraphQueryRequest).query);
-    await dependencies.writeResponseFile(request.responsePath, {
-      requestId: request.requestId,
-      repo: request.repo,
-      status: 'ok',
-      result,
-    });
-    return { status: 'queried' };
-  } catch (error) {
-    const message = formatErrorMessage(error);
-    await writeFailureResponse(request, message, dependencies);
-    dependencies.showErrorMessage(`CodeGraphy failed to query ${request.repo}: ${message}`);
-    return { status: 'failed' };
-  }
+function successStatus(action: CodeGraphyAgentAction): CodeGraphyAgentUriResult {
+  if (action === 'index') return { status: 'indexed' };
+  if (action === 'query') return { status: 'queried' };
+  return { status: 'status-read' };
 }
 
-export function dispatchAgentAction(
+export async function dispatchAgentAction(
   action: CodeGraphyAgentAction,
   request: CodeGraphyAgentRequest,
   provider: CodeGraphyAgentBridgeProvider,
   dependencies: CodeGraphyAgentUriDependencies,
 ): Promise<CodeGraphyAgentUriResult> {
-  return action === 'index'
-    ? handleIndexRequest(request, provider, dependencies)
-    : handleQueryRequest(request, provider, dependencies);
+  const execute = dependencies.executeWorkspaceCommand ?? executeCodeGraphyWorkspaceCommand;
+  const response = await execute(createWorkspaceCommand(action, request));
+  await dependencies.writeResponseFile(request.responsePath, {
+    requestId: request.requestId,
+    repo: request.repo,
+    response,
+  });
+
+  if (!response.ok) {
+    dependencies.showErrorMessage(
+      `CodeGraphy ${action} failed for ${request.repo}: ${response.error.message}`,
+    );
+    return { status: 'failed' };
+  }
+
+  if (action === 'index') {
+    await provider.refresh();
+  }
+  return successStatus(action);
 }

--- a/packages/extension/src/extension/agentBridge/uri/handler.ts
+++ b/packages/extension/src/extension/agentBridge/uri/handler.ts
@@ -3,7 +3,7 @@ import type { GraphViewProvider } from '../../graphViewProvider';
 import { handleCodeGraphyAgentUri } from './handle';
 
 export function createCodeGraphyAgentUriHandler(
-  provider: Pick<GraphViewProvider, 'queryGraph' | 'refreshIndex'>,
+  provider: Pick<GraphViewProvider, 'refresh'>,
 ): vscode.UriHandler {
   return {
     handleUri: async (uri: vscode.Uri): Promise<void> => {

--- a/packages/extension/src/extension/agentBridge/uri/request.ts
+++ b/packages/extension/src/extension/agentBridge/uri/request.ts
@@ -17,6 +17,9 @@ export function readAgentAction(uriPath: string): CodeGraphyAgentAction | undefi
   if (uriPath === '/query') {
     return 'query';
   }
+  if (uriPath === '/status') {
+    return 'status';
+  }
   return undefined;
 }
 

--- a/packages/extension/src/extension/agentBridge/uri/response.ts
+++ b/packages/extension/src/extension/agentBridge/uri/response.ts
@@ -11,7 +11,6 @@ export async function writeFailureResponse(
   await dependencies.writeResponseFile(request.responsePath, {
     requestId: request.requestId,
     repo: request.repo,
-    status: 'failed',
     error,
   });
 }

--- a/packages/extension/src/extension/agentBridge/uri/types.ts
+++ b/packages/extension/src/extension/agentBridge/uri/types.ts
@@ -1,4 +1,8 @@
-import type { GraphQueryRequest, GraphQueryResult } from '@codegraphy-dev/core';
+import type {
+  CodeGraphyWorkspaceCommand,
+  CodeGraphyWorkspaceCommandResponse,
+  GraphQueryRequest,
+} from '@codegraphy-dev/core';
 
 export type CodeGraphyAgentUriStatus =
   | 'failed'
@@ -6,6 +10,7 @@ export type CodeGraphyAgentUriStatus =
   | 'missing-request'
   | 'missing-workspace'
   | 'queried'
+  | 'status-read'
   | 'unsupported-action'
   | 'wrong-workspace';
 
@@ -22,39 +27,35 @@ export interface CodeGraphyAgentRequest {
   repo: string;
   requestId?: string;
   responsePath: string;
+  query?: GraphQueryRequest;
 }
 
-export interface CodeGraphyAgentGraphQueryRequest extends CodeGraphyAgentRequest {
+export type CodeGraphyAgentGraphQueryRequest = CodeGraphyAgentRequest & {
   query: GraphQueryRequest;
-}
+};
 
-export type CodeGraphyAgentAction = 'index' | 'query';
+export type CodeGraphyAgentAction = 'index' | 'query' | 'status';
 
 export type CodeGraphyAgentResponse =
   | {
     requestId?: string;
     repo: string;
-    status: 'failed';
     error: string;
   }
   | {
     requestId?: string;
     repo: string;
-    status: 'indexed';
-  }
-  | {
-    requestId?: string;
-    repo: string;
-    status: 'ok';
-    result: GraphQueryResult;
+    response: CodeGraphyWorkspaceCommandResponse;
   };
 
 export interface CodeGraphyAgentBridgeProvider {
-  refreshIndex(): Promise<void>;
-  queryGraph(request: GraphQueryRequest): GraphQueryResult;
+  refresh(): Promise<void>;
 }
 
 export interface CodeGraphyAgentUriDependencies {
+  executeWorkspaceCommand?(
+    command: CodeGraphyWorkspaceCommand,
+  ): Promise<CodeGraphyWorkspaceCommandResponse>;
   getWorkspaceRoot(): string | undefined;
   readRequestFile(filePath: string): Promise<CodeGraphyAgentRequest>;
   showErrorMessage(message: string): unknown;

--- a/packages/extension/tests/extension/agentBridge/uri.test.ts
+++ b/packages/extension/tests/extension/agentBridge/uri.test.ts
@@ -1,7 +1,25 @@
+import type {
+  CodeGraphyWorkspaceCommand,
+  CodeGraphyWorkspaceCommandResponse,
+  GraphQueryRequest,
+} from '@codegraphy-dev/core';
 import * as path from 'node:path';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { GraphQueryRequest } from '@codegraphy-dev/core';
+import { describe, expect, it, vi } from 'vitest';
 import { handleCodeGraphyAgentUri } from '../../../src/extension/agentBridge/uri';
+
+const workspaceRoot = path.resolve('/workspace/project');
+
+const freshMetadata: CodeGraphyWorkspaceCommandResponse['metadata'] = {
+  workspaceRoot,
+  cache: {
+    state: 'fresh',
+    staleReasons: [],
+  },
+  result: {
+    complete: true,
+    reasons: [],
+  },
+};
 
 function createDependencies(
   request: {
@@ -10,10 +28,12 @@ function createDependencies(
     responsePath: string;
     query?: GraphQueryRequest;
   },
-  workspaceRoot?: string,
+  response: CodeGraphyWorkspaceCommandResponse,
+  activeWorkspace?: string,
 ) {
   return {
-    getWorkspaceRoot: () => workspaceRoot,
+    executeWorkspaceCommand: vi.fn(async (_command: CodeGraphyWorkspaceCommand) => response),
+    getWorkspaceRoot: () => activeWorkspace,
     readRequestFile: vi.fn(async () => request),
     showErrorMessage: vi.fn(),
     showWarningMessage: vi.fn(),
@@ -21,247 +41,233 @@ function createDependencies(
   };
 }
 
-function createUri(action: string) {
+function createUri(action: string, withRequest = true) {
   return {
     path: action,
-    query: 'request=/tmp/codegraphy-request.json',
-  };
-}
-
-function createUriWithoutRequest(action: string) {
-  return {
-    path: action,
-    query: '',
+    query: withRequest ? 'request=/tmp/codegraphy-request.json' : '',
   };
 }
 
 describe('agentBridge/uri', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('runs Indexing and writes an indexed response for the active workspace', async () => {
-    const workspaceRoot = path.resolve('/workspace/project');
-    const refreshIndex = vi.fn(async () => {});
+  it('runs Core Indexing and reloads the Graph View for the active workspace', async () => {
+    const response: CodeGraphyWorkspaceCommandResponse = {
+      ok: true,
+      command: 'index',
+      data: {
+        workspaceRoot,
+        graphCache: '.codegraphy/graph.sqlite',
+        message: 'Indexing completed.',
+        discovery: {
+          indexedFiles: 1,
+          totalFound: 1,
+          limitReached: false,
+        },
+        indexing: {
+          mode: 'incremental',
+          analyzedFiles: 1,
+          deletedFiles: 0,
+          reusedFiles: 0,
+        },
+      },
+      metadata: freshMetadata,
+    };
     const dependencies = createDependencies({
       repo: workspaceRoot,
       requestId: 'request-1',
       responsePath: '/tmp/codegraphy-response.json',
-    }, workspaceRoot);
+    }, response, workspaceRoot);
+    const refresh = vi.fn(async () => undefined);
 
     const result = await handleCodeGraphyAgentUri(
       createUri('/index'),
-      { refreshIndex, queryGraph: vi.fn() },
+      { refresh },
       dependencies,
     );
 
     expect(result.status).toBe('indexed');
-    expect(refreshIndex).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledOnce();
     expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
       '/tmp/codegraphy-response.json',
       {
         repo: workspaceRoot,
         requestId: 'request-1',
-        status: 'indexed',
+        response,
       },
     );
   });
 
-  it('runs Graph Query through the provider and writes the query response', async () => {
-    const workspaceRoot = path.resolve('/workspace/project');
-    const query: GraphQueryRequest = { report: 'nodes', arguments: {} };
-    const queryGraph = vi.fn(() => ({
-      nodes: [{ path: 'src/app.ts', nodeType: 'file' as const }],
-      page: { offset: 0, limit: 500, returned: 1, total: 1, nextOffset: null },
-    }));
+  it('runs live search through Core instead of the rendered Graph View', async () => {
+    const query: GraphQueryRequest = {
+      report: 'search',
+      arguments: { pattern: 'settings' },
+    };
+    const response: CodeGraphyWorkspaceCommandResponse = {
+      ok: true,
+      command: 'query',
+      data: {
+        pattern: 'settings',
+        matches: [],
+        page: {
+          offset: 0,
+          limit: 20,
+          returned: 0,
+          total: 0,
+          nextOffset: null,
+        },
+        sources: {
+          text: {
+            freshness: 'live',
+            filesScanned: 1,
+            filesSkipped: 0,
+          },
+          symbols: {
+            freshness: 'cached',
+            cacheState: 'fresh',
+          },
+        },
+      },
+      metadata: freshMetadata,
+    };
     const dependencies = createDependencies({
       repo: workspaceRoot,
       requestId: 'request-2',
       responsePath: '/tmp/codegraphy-response.json',
       query,
-    }, workspaceRoot);
+    }, response, workspaceRoot);
 
     const result = await handleCodeGraphyAgentUri(
       createUri('/query'),
-      { refreshIndex: vi.fn(), queryGraph },
+      { refresh: vi.fn() },
       dependencies,
     );
 
     expect(result.status).toBe('queried');
-    expect(queryGraph).toHaveBeenCalledWith(query);
-    expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
-      '/tmp/codegraphy-response.json',
-      {
-        repo: workspaceRoot,
-        requestId: 'request-2',
-        status: 'ok',
-        result: {
-          nodes: [{ path: 'src/app.ts', nodeType: 'file' }],
-          page: { offset: 0, limit: 500, returned: 1, total: 1, nextOffset: null },
-        },
-      },
-    );
+    expect(dependencies.executeWorkspaceCommand).toHaveBeenCalledWith({
+      command: 'query',
+      query,
+      workspacePath: workspaceRoot,
+    });
   });
 
-  it('writes a failure when the receiving VS Code window is for another repo', async () => {
-    const requestedRepo = path.resolve('/workspace/project');
+  it('reads Core freshness status through the URI bridge', async () => {
+    const response: CodeGraphyWorkspaceCommandResponse = {
+      ok: true,
+      command: 'status',
+      data: {
+        workspaceRoot,
+        graphCache: '.codegraphy/graph.sqlite',
+        state: 'stale',
+        hasGraphCache: true,
+        staleReasons: ['pending-changed-files'],
+        enabledPlugins: [],
+        message: 'Graph Cache is stale.',
+      },
+      metadata: {
+        ...freshMetadata,
+        cache: {
+          state: 'stale',
+          staleReasons: ['pending-changed-files'],
+        },
+      },
+    };
     const dependencies = createDependencies({
-      repo: requestedRepo,
+      repo: workspaceRoot,
       requestId: 'request-3',
       responsePath: '/tmp/codegraphy-response.json',
-    }, path.resolve('/workspace/other'));
+    }, response, workspaceRoot);
+
+    await expect(handleCodeGraphyAgentUri(
+      createUri('/status'),
+      { refresh: vi.fn() },
+      dependencies,
+    )).resolves.toEqual({ status: 'status-read' });
+  });
+
+  it('blocks a request received by the wrong VS Code workspace', async () => {
+    const response = {
+      ok: false,
+      command: 'status',
+      error: {
+        code: 'unused',
+        message: 'unused',
+      },
+      metadata: freshMetadata,
+    } satisfies CodeGraphyWorkspaceCommandResponse;
+    const dependencies = createDependencies({
+      repo: workspaceRoot,
+      requestId: 'request-4',
+      responsePath: '/tmp/codegraphy-response.json',
+    }, response, path.resolve('/workspace/other'));
 
     const result = await handleCodeGraphyAgentUri(
-      createUri('/index'),
-      { refreshIndex: vi.fn(), queryGraph: vi.fn() },
+      createUri('/status'),
+      { refresh: vi.fn() },
       dependencies,
     );
 
     expect(result.status).toBe('wrong-workspace');
-    expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
-      '/tmp/codegraphy-response.json',
-      expect.objectContaining({
-        repo: requestedRepo,
-        requestId: 'request-3',
-        status: 'failed',
-      }),
-    );
-    expect(dependencies.showWarningMessage).toHaveBeenCalledWith(
-      expect.stringContaining('targeted'),
-    );
-  });
-
-  it('writes a failure when there is no workspace folder open', async () => {
-    const requestedRepo = path.resolve('/workspace/project');
-    const dependencies = createDependencies({
-      repo: requestedRepo,
-      requestId: 'request-4',
-      responsePath: '/tmp/codegraphy-response.json',
-    });
-
-    const result = await handleCodeGraphyAgentUri(
-      createUri('/index'),
-      { refreshIndex: vi.fn(), queryGraph: vi.fn() },
-      dependencies,
-    );
-
-    expect(result.status).toBe('missing-workspace');
+    expect(dependencies.executeWorkspaceCommand).not.toHaveBeenCalled();
     expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
       '/tmp/codegraphy-response.json',
       {
-        error: `CodeGraphy agent request for ${requestedRepo} needs a VS Code window opened on that repo.`,
-        repo: requestedRepo,
+        error: expect.stringContaining('targeted'),
+        repo: workspaceRoot,
         requestId: 'request-4',
-        status: 'failed',
       },
     );
   });
 
-  it('ignores supported actions when no request file is provided', async () => {
-    const dependencies = createDependencies({
-      repo: path.resolve('/workspace/project'),
-      responsePath: '/tmp/codegraphy-response.json',
-    }, path.resolve('/workspace/project'));
-
-    const result = await handleCodeGraphyAgentUri(
-      createUriWithoutRequest('/index'),
-      { refreshIndex: vi.fn(), queryGraph: vi.fn() },
-      dependencies,
-    );
-
-    expect(result.status).toBe('missing-request');
-    expect(dependencies.readRequestFile).not.toHaveBeenCalled();
-    expect(dependencies.writeResponseFile).not.toHaveBeenCalled();
-    expect(dependencies.showWarningMessage).toHaveBeenCalledWith(
-      expect.stringContaining('request file'),
-    );
-  });
-
-  it('writes a failure response when indexing throws', async () => {
-    const workspaceRoot = path.resolve('/workspace/project');
+  it('blocks a request when no VS Code workspace is open', async () => {
+    const response = {
+      ok: false,
+      command: 'status',
+      error: {
+        code: 'unused',
+        message: 'unused',
+      },
+      metadata: freshMetadata,
+    } satisfies CodeGraphyWorkspaceCommandResponse;
     const dependencies = createDependencies({
       repo: workspaceRoot,
       requestId: 'request-5',
       responsePath: '/tmp/codegraphy-response.json',
-    }, workspaceRoot);
+    }, response);
 
     const result = await handleCodeGraphyAgentUri(
-      createUri('/index'),
-      {
-        refreshIndex: vi.fn(async () => {
-          throw new Error('index failed');
-        }),
-        queryGraph: vi.fn(),
-      },
+      createUri('/status'),
+      { refresh: vi.fn() },
       dependencies,
     );
 
-    expect(result.status).toBe('failed');
-    expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
-      '/tmp/codegraphy-response.json',
-      expect.objectContaining({
-        error: 'index failed',
-        repo: workspaceRoot,
-        requestId: 'request-5',
-        status: 'failed',
-      }),
-    );
-    expect(dependencies.showErrorMessage).toHaveBeenCalledWith(
-      expect.stringContaining('index failed'),
-    );
+    expect(result.status).toBe('missing-workspace');
+    expect(dependencies.executeWorkspaceCommand).not.toHaveBeenCalled();
   });
 
-  it('writes a failure response when querying throws', async () => {
-    const workspaceRoot = path.resolve('/workspace/project');
+  it('does not read files for unsupported actions or missing request paths', async () => {
+    const response = {
+      ok: false,
+      command: 'status',
+      error: {
+        code: 'unused',
+        message: 'unused',
+      },
+      metadata: freshMetadata,
+    } satisfies CodeGraphyWorkspaceCommandResponse;
     const dependencies = createDependencies({
       repo: workspaceRoot,
-      requestId: 'request-6',
       responsePath: '/tmp/codegraphy-response.json',
-      query: { report: 'nodes', arguments: {} },
-    }, workspaceRoot);
+    }, response, workspaceRoot);
 
-    const result = await handleCodeGraphyAgentUri(
-      createUri('/query'),
-      {
-        refreshIndex: vi.fn(),
-        queryGraph: vi.fn(() => {
-          throw new Error('query failed');
-        }),
-      },
-      dependencies,
-    );
-
-    expect(result.status).toBe('failed');
-    expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
-      '/tmp/codegraphy-response.json',
-      expect.objectContaining({
-        error: 'query failed',
-        repo: workspaceRoot,
-        requestId: 'request-6',
-        status: 'failed',
-      }),
-    );
-    expect(dependencies.showErrorMessage).toHaveBeenCalledWith(
-      expect.stringContaining('query failed'),
-    );
-  });
-
-  it('ignores unsupported actions', async () => {
-    const dependencies = createDependencies({
-      repo: path.resolve('/workspace/project'),
-      responsePath: '/tmp/codegraphy-response.json',
-    }, path.resolve('/workspace/project'));
-
-    const result = await handleCodeGraphyAgentUri(
+    await expect(handleCodeGraphyAgentUri(
       createUri('/unknown'),
-      { refreshIndex: vi.fn(), queryGraph: vi.fn() },
+      { refresh: vi.fn() },
       dependencies,
-    );
-
-    expect(result.status).toBe('unsupported-action');
-    expect(dependencies.writeResponseFile).not.toHaveBeenCalled();
-    expect(dependencies.showWarningMessage).toHaveBeenCalledWith(
-      'CodeGraphy ignored unsupported agent request: /unknown.',
-    );
+    )).resolves.toEqual({ status: 'unsupported-action' });
+    await expect(handleCodeGraphyAgentUri(
+      createUri('/status', false),
+      { refresh: vi.fn() },
+      dependencies,
+    )).resolves.toEqual({ status: 'missing-request' });
+    expect(dependencies.readRequestFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/tests/extension/agentBridge/uri/actions.test.ts
+++ b/packages/extension/tests/extension/agentBridge/uri/actions.test.ts
@@ -1,15 +1,31 @@
+import type {
+  CodeGraphyWorkspaceCommand,
+  CodeGraphyWorkspaceCommandResponse,
+} from '@codegraphy-dev/core';
 import { describe, expect, it, vi } from 'vitest';
-import {
-  dispatchAgentAction,
-  formatErrorMessage,
-} from '../../../../src/extension/agentBridge/uri/actions';
+import { dispatchAgentAction } from '../../../../src/extension/agentBridge/uri/actions';
 import type {
   CodeGraphyAgentRequest,
   CodeGraphyAgentUriDependencies,
 } from '../../../../src/extension/agentBridge/uri/types';
 
-function createDependencies(): CodeGraphyAgentUriDependencies {
+const freshMetadata: CodeGraphyWorkspaceCommandResponse['metadata'] = {
+  workspaceRoot: '/workspace/project',
+  cache: {
+    state: 'fresh',
+    staleReasons: [],
+  },
+  result: {
+    complete: true,
+    reasons: [],
+  },
+};
+
+function createDependencies(
+  response: CodeGraphyWorkspaceCommandResponse,
+): CodeGraphyAgentUriDependencies {
   return {
+    executeWorkspaceCommand: vi.fn(async (_command: CodeGraphyWorkspaceCommand) => response),
     getWorkspaceRoot: () => '/workspace/project',
     readRequestFile: vi.fn(),
     showErrorMessage: vi.fn(),
@@ -18,7 +34,7 @@ function createDependencies(): CodeGraphyAgentUriDependencies {
   };
 }
 
-function createRequest(query?: unknown): CodeGraphyAgentRequest {
+function createRequest(query?: CodeGraphyAgentRequest['query']): CodeGraphyAgentRequest {
   return {
     repo: '/workspace/project',
     requestId: 'request-1',
@@ -28,106 +44,165 @@ function createRequest(query?: unknown): CodeGraphyAgentRequest {
 }
 
 describe('agentBridge/uri/actions', () => {
-  it('formats non-error failures without losing the value', () => {
-    expect(formatErrorMessage('plain failure')).toBe('plain failure');
-  });
-
-  it('dispatches indexing requests through the provider', async () => {
-    const dependencies = createDependencies();
-    const refreshIndex = vi.fn(async () => undefined);
+  it('runs Indexing through Core and reloads the VS Code Graph View from the Graph Cache', async () => {
+    const response: CodeGraphyWorkspaceCommandResponse = {
+      ok: true,
+      command: 'index',
+      data: {
+        workspaceRoot: '/workspace/project',
+        graphCache: '.codegraphy/graph.sqlite',
+        message: 'Indexing completed.',
+        discovery: {
+          indexedFiles: 1,
+          totalFound: 1,
+          limitReached: false,
+        },
+        indexing: {
+          mode: 'incremental',
+          analyzedFiles: 1,
+          deletedFiles: 0,
+          reusedFiles: 0,
+        },
+      },
+      metadata: freshMetadata,
+    };
+    const dependencies = createDependencies(response);
+    const refresh = vi.fn(async () => undefined);
 
     const result = await dispatchAgentAction(
       'index',
       createRequest(),
-      { refreshIndex, queryGraph: vi.fn() },
+      { refresh },
       dependencies,
     );
 
     expect(result.status).toBe('indexed');
-    expect(refreshIndex).toHaveBeenCalledTimes(1);
+    expect(dependencies.executeWorkspaceCommand).toHaveBeenCalledWith({
+      command: 'index',
+      workspacePath: '/workspace/project',
+    });
+    expect(refresh).toHaveBeenCalledOnce();
     expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
       '/tmp/codegraphy-response.json',
       {
         repo: '/workspace/project',
         requestId: 'request-1',
-        status: 'indexed',
+        response,
       },
     );
   });
 
-  it('writes failed index responses with error messages', async () => {
-    const dependencies = createDependencies();
-
-    const result = await dispatchAgentAction(
-      'index',
-      createRequest(),
-      {
-        refreshIndex: vi.fn(async () => {
-          throw new Error('index exploded');
-        }),
-        queryGraph: vi.fn(),
+  it('runs every Graph Query report through the Core workspace command seam', async () => {
+    const response: CodeGraphyWorkspaceCommandResponse = {
+      ok: true,
+      command: 'query',
+      data: {
+        pattern: 'settings',
+        matches: [],
+        page: {
+          offset: 0,
+          limit: 20,
+          returned: 0,
+          total: 0,
+          nextOffset: null,
+        },
+        sources: {
+          text: {
+            freshness: 'live',
+            filesScanned: 1,
+            filesSkipped: 0,
+          },
+          symbols: {
+            freshness: 'cached',
+            cacheState: 'fresh',
+          },
+        },
       },
-      dependencies,
-    );
-
-    expect(result.status).toBe('failed');
-    expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
-      '/tmp/codegraphy-response.json',
-      {
-        error: 'index exploded',
-        repo: '/workspace/project',
-        requestId: 'request-1',
-        status: 'failed',
-      },
-    );
-    expect(dependencies.showErrorMessage).toHaveBeenCalledWith(
-      'CodeGraphy failed to index /workspace/project: index exploded',
-    );
-  });
-
-  it('dispatches query requests through the provider', async () => {
-    const dependencies = createDependencies();
-    const query = { report: 'nodes' as const, arguments: {} };
-    const queryGraph = vi.fn(() => ({
-      nodes: [{ path: 'src/app.ts', nodeType: 'file' as const }],
-      page: { offset: 0, limit: 500, returned: 1, total: 1, nextOffset: null },
-    }));
+      metadata: freshMetadata,
+    };
+    const dependencies = createDependencies(response);
+    const query = {
+      report: 'search' as const,
+      arguments: { pattern: 'settings' },
+    };
 
     const result = await dispatchAgentAction(
       'query',
       createRequest(query),
-      { refreshIndex: vi.fn(), queryGraph },
+      { refresh: vi.fn() },
       dependencies,
     );
 
     expect(result.status).toBe('queried');
-    expect(queryGraph).toHaveBeenCalledWith(query);
-    expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
-      '/tmp/codegraphy-response.json',
-      {
-        repo: '/workspace/project',
-        requestId: 'request-1',
-        result: {
-          nodes: [{ path: 'src/app.ts', nodeType: 'file' }],
-          page: { offset: 0, limit: 500, returned: 1, total: 1, nextOffset: null },
-        },
-        status: 'ok',
-      },
-    );
+    expect(dependencies.executeWorkspaceCommand).toHaveBeenCalledWith({
+      command: 'query',
+      workspacePath: '/workspace/project',
+      query,
+    });
   });
 
-  it('writes failed query responses with string errors', async () => {
-    const dependencies = createDependencies();
+  it('exposes Core workspace status without opening the Graph View', async () => {
+    const response: CodeGraphyWorkspaceCommandResponse = {
+      ok: true,
+      command: 'status',
+      data: {
+        workspaceRoot: '/workspace/project',
+        graphCache: '.codegraphy/graph.sqlite',
+        state: 'fresh',
+        hasGraphCache: true,
+        staleReasons: [],
+        enabledPlugins: [],
+        message: 'Graph Cache is fresh.',
+      },
+      metadata: freshMetadata,
+    };
+    const dependencies = createDependencies(response);
+    const refresh = vi.fn();
+
+    const result = await dispatchAgentAction(
+      'status',
+      createRequest(),
+      { refresh },
+      dependencies,
+    );
+
+    expect(result.status).toBe('status-read');
+    expect(dependencies.executeWorkspaceCommand).toHaveBeenCalledWith({
+      command: 'status',
+      workspacePath: '/workspace/project',
+    });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('writes Core command failures and shows the Core error message', async () => {
+    const response: CodeGraphyWorkspaceCommandResponse = {
+      ok: false,
+      command: 'query',
+      error: {
+        code: 'graph_cache_not_found',
+        message: 'Run Indexing first.',
+      },
+      metadata: {
+        ...freshMetadata,
+        cache: {
+          state: 'missing',
+          staleReasons: ['never-indexed'],
+        },
+        result: {
+          complete: false,
+          reasons: ['cache-missing'],
+        },
+      },
+    };
+    const dependencies = createDependencies(response);
 
     const result = await dispatchAgentAction(
       'query',
-      createRequest({ report: 'nodes', arguments: {} }),
-      {
-        refreshIndex: vi.fn(),
-        queryGraph: vi.fn(() => {
-          throw 'query exploded';
-        }),
-      },
+      createRequest({
+        report: 'nodes',
+        arguments: {},
+      }),
+      { refresh: vi.fn() },
       dependencies,
     );
 
@@ -135,14 +210,13 @@ describe('agentBridge/uri/actions', () => {
     expect(dependencies.writeResponseFile).toHaveBeenCalledWith(
       '/tmp/codegraphy-response.json',
       {
-        error: 'query exploded',
         repo: '/workspace/project',
         requestId: 'request-1',
-        status: 'failed',
+        response,
       },
     );
     expect(dependencies.showErrorMessage).toHaveBeenCalledWith(
-      'CodeGraphy failed to query /workspace/project: query exploded',
+      'CodeGraphy query failed for /workspace/project: Run Indexing first.',
     );
   });
 });

--- a/packages/extension/tests/extension/agentBridge/uri/dependencies.test.ts
+++ b/packages/extension/tests/extension/agentBridge/uri/dependencies.test.ts
@@ -64,13 +64,13 @@ describe('agentBridge/uri/dependencies', () => {
     });
 
     await DEFAULT_DEPENDENCIES.writeResponseFile(responsePath, {
+      error: 'request failed',
       repo: '/workspace/project',
       requestId: 'request-1',
-      status: 'indexed',
     });
 
     await expect(fs.readFile(responsePath, 'utf8')).resolves.toBe(
-      '{\n  "repo": "/workspace/project",\n  "requestId": "request-1",\n  "status": "indexed"\n}\n',
+      '{\n  "error": "request failed",\n  "repo": "/workspace/project",\n  "requestId": "request-1"\n}\n',
     );
   });
 

--- a/packages/extension/tests/extension/agentBridge/uri/handle.test.ts
+++ b/packages/extension/tests/extension/agentBridge/uri/handle.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { CodeGraphyWorkspaceCommandResponse } from '@codegraphy-dev/core';
 import { handleCodeGraphyAgentUri } from '../../../../src/extension/agentBridge/uri/handle';
 import type {
   CodeGraphyAgentRequest,
@@ -10,7 +11,39 @@ function createDependencies(
   request: CodeGraphyAgentRequest,
   workspaceRoot?: string,
 ): CodeGraphyAgentUriDependencies {
+  const response: CodeGraphyWorkspaceCommandResponse = {
+    ok: true,
+    command: 'index',
+    data: {
+      workspaceRoot: '/workspace/project',
+      graphCache: '.codegraphy/graph.sqlite',
+      message: 'Indexing completed.',
+      discovery: {
+        indexedFiles: 1,
+        totalFound: 1,
+        limitReached: false,
+      },
+      indexing: {
+        mode: 'incremental',
+        analyzedFiles: 1,
+        deletedFiles: 0,
+        reusedFiles: 0,
+      },
+    },
+    metadata: {
+      workspaceRoot: '/workspace/project',
+      cache: {
+        state: 'fresh',
+        staleReasons: [],
+      },
+      result: {
+        complete: true,
+        reasons: [],
+      },
+    },
+  };
   return {
+    executeWorkspaceCommand: vi.fn(async () => response),
     getWorkspaceRoot: vi.fn(() => workspaceRoot),
     readRequestFile: vi.fn(async () => request),
     showErrorMessage: vi.fn(),
@@ -32,7 +65,7 @@ describe('agentBridge/uri/handle', () => {
 
     const result = await handleCodeGraphyAgentUri(
       createUri('/unsupported'),
-      { refreshIndex: vi.fn(), queryGraph: vi.fn() },
+      { refresh: vi.fn() },
       dependencies,
     );
 
@@ -48,7 +81,7 @@ describe('agentBridge/uri/handle', () => {
 
     const result = await handleCodeGraphyAgentUri(
       createUri('/index', ''),
-      { refreshIndex: vi.fn(), queryGraph: vi.fn() },
+      { refresh: vi.fn() },
       dependencies,
     );
 
@@ -57,7 +90,7 @@ describe('agentBridge/uri/handle', () => {
   });
 
   it('returns workspace guard failures before dispatching the action', async () => {
-    const refreshIndex = vi.fn();
+    const refresh = vi.fn();
     const dependencies = createDependencies({
       repo: '/workspace/project',
       responsePath: '/tmp/response.json',
@@ -65,16 +98,16 @@ describe('agentBridge/uri/handle', () => {
 
     const result = await handleCodeGraphyAgentUri(
       createUri('/index'),
-      { refreshIndex, queryGraph: vi.fn() },
+      { refresh },
       dependencies,
     );
 
     expect(result.status).toBe('missing-workspace');
-    expect(refreshIndex).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
   });
 
   it('dispatches valid requests after action, request, and workspace checks pass', async () => {
-    const refreshIndex = vi.fn(async () => undefined);
+    const refresh = vi.fn(async () => undefined);
     const dependencies = createDependencies({
       repo: '/workspace/project',
       responsePath: '/tmp/response.json',
@@ -82,11 +115,11 @@ describe('agentBridge/uri/handle', () => {
 
     const result = await handleCodeGraphyAgentUri(
       createUri('/index'),
-      { refreshIndex, queryGraph: vi.fn() },
+      { refresh },
       dependencies,
     );
 
     expect(result.status).toBe('indexed');
-    expect(refreshIndex).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/extension/tests/extension/agentBridge/uri/handler.test.ts
+++ b/packages/extension/tests/extension/agentBridge/uri/handler.test.ts
@@ -9,8 +9,7 @@ describe('agentBridge/uri/handler', () => {
 
   it('adapts VS Code URI handling to the agent URI flow', async () => {
     const handler = createCodeGraphyAgentUriHandler({
-      refreshIndex: vi.fn(),
-      queryGraph: vi.fn(),
+      refresh: vi.fn(),
     });
 
     await handler.handleUri({ path: '/unsupported', query: '' } as vscode.Uri);

--- a/packages/extension/tests/extension/agentBridge/uri/request.test.ts
+++ b/packages/extension/tests/extension/agentBridge/uri/request.test.ts
@@ -31,6 +31,7 @@ describe('agentBridge/uri/request', () => {
   it('maps supported URI paths to agent actions', () => {
     expect(readAgentAction('/index')).toBe('index');
     expect(readAgentAction('/query')).toBe('query');
+    expect(readAgentAction('/status')).toBe('status');
     expect(readAgentAction('/unknown')).toBeUndefined();
   });
 

--- a/packages/extension/tests/extension/agentBridge/uri/response.test.ts
+++ b/packages/extension/tests/extension/agentBridge/uri/response.test.ts
@@ -27,7 +27,6 @@ describe('agentBridge/uri/response', () => {
         error: 'failure text',
         repo: '/workspace/project',
         requestId: 'request-1',
-        status: 'failed',
       },
     );
   });

--- a/packages/extension/tests/extension/agentBridge/uri/workspace.test.ts
+++ b/packages/extension/tests/extension/agentBridge/uri/workspace.test.ts
@@ -50,7 +50,6 @@ describe('agentBridge/uri/workspace', () => {
         error: 'CodeGraphy agent request for /workspace/project needs a VS Code window opened on that repo.',
         repo: '/workspace/project',
         requestId: 'request-2',
-        status: 'failed',
       },
     );
   });
@@ -74,7 +73,6 @@ describe('agentBridge/uri/workspace', () => {
         error: message,
         repo: '/workspace/project',
         requestId: 'request-3',
-        status: 'failed',
       },
     );
     expect(dependencies.showWarningMessage).toHaveBeenCalledWith(message);

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,48 @@
+# `@codegraphy-dev/mcp`
+
+Optional local MCP server for CodeGraphy. It exposes the existing Core Indexing and exploration operations as discoverable structured tools. It does not own Indexing, Graph Query logic, or a second semantic interface.
+
+## When MCP adds value
+
+Use MCP when the agent client supports MCP and you want:
+
+- tool discovery without teaching the client shell commands;
+- input validation from tool schemas before Core runs;
+- structured responses without parsing shell output;
+- one persistent stdio connection for repeated calls;
+- explicit Graph Cache freshness and result completeness metadata on every response.
+
+Use the CodeGraphy Agent Skill plus the Core CLI when the agent already has a shell, needs the complete CLI surface, or should choose its workflow from generalized instructions. The skill plus CLI has fewer installed packages and is easier to debug from a terminal. MCP adds client integration, not new analysis.
+
+## Install
+
+```bash
+npm install --global @codegraphy-dev/mcp
+```
+
+Configure an MCP client to launch:
+
+```text
+codegraphy-mcp
+```
+
+The command uses its current working directory as the CodeGraphy Workspace. Each tool also accepts an absolute `workspacePath`.
+
+## Tools
+
+| Tool | Existing Core operation |
+|---|---|
+| `codegraphy_status` | `codegraphy status` |
+| `codegraphy_index` | `codegraphy index` |
+| `codegraphy_search` | `codegraphy search` |
+| `codegraphy_map` | `codegraphy map` |
+| `codegraphy_query` | `codegraphy query` |
+| `codegraphy_nodes` | `codegraphy nodes` |
+| `codegraphy_edges` | `codegraphy edges` |
+| `codegraphy_dependencies` | `codegraphy dependencies` |
+| `codegraphy_dependents` | `codegraphy dependents` |
+| `codegraphy_path` | `codegraphy path` |
+
+Read-only tools never perform Indexing. `codegraphy_index` is the only tool in this package that writes the Graph Cache. Every tool returns the Core workspace command envelope as text and structured content.
+
+The response `metadata.cache` field reports fresh, stale, or missing cache state and its stale reasons. `metadata.result` reports whether paging, traversal, file-budget, or source limits truncated the result.

--- a/packages/mcp/bin/codegraphy-mcp.js
+++ b/packages/mcp/bin/codegraphy-mcp.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runCodeGraphyMcpServer } from '../dist/mcp/server.js';
+
+await runCodeGraphyMcpServer();

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@codegraphy-dev/mcp",
+  "version": "0.1.0",
+  "description": "Optional CodeGraphy MCP stdio server",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "bin": {
+    "codegraphy-mcp": "./bin/codegraphy-mcp.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/mcp/server.d.ts",
+      "default": "./dist/mcp/server.js"
+    }
+  },
+  "engines": {
+    "node": "^22.14.0 || >=23.6.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && esbuild src/mcp/server.ts --bundle --platform=node --format=esm --target=node22 --packages=external --external:@codegraphy-dev/core --outfile=dist/mcp/server.js",
+    "lint": "eslint src tests bin vitest.config.ts",
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@codegraphy-dev/core": "workspace:*",
+    "@modelcontextprotocol/server": "2.0.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/client": "2.0.0",
+    "@types/node": "^20.11.0",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.3.3",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/mcp/src/mcp/server.ts
+++ b/packages/mcp/src/mcp/server.ts
@@ -1,0 +1,367 @@
+import {
+  executeCodeGraphyWorkspaceCommand,
+  type CodeGraphyWorkspaceCommand,
+  type CodeGraphyWorkspaceCommandResponse,
+  type GraphQueryRequest,
+  type WorkspaceGraphQueryProjection,
+} from '@codegraphy-dev/core';
+import {
+  McpServer,
+  type CallToolResult,
+} from '@modelcontextprotocol/server';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import * as z from 'zod/v4';
+
+export interface CodeGraphyMcpServerDependencies {
+  cwd(): string;
+  executeWorkspaceCommand(
+    command: CodeGraphyWorkspaceCommand,
+  ): Promise<CodeGraphyWorkspaceCommandResponse>;
+}
+
+const DEFAULT_DEPENDENCIES: CodeGraphyMcpServerDependencies = {
+  cwd: () => process.cwd(),
+  executeWorkspaceCommand: executeCodeGraphyWorkspaceCommand,
+};
+
+const workspacePath = z.string().min(1).optional()
+  .describe('Absolute CodeGraphy Workspace path. Defaults to the MCP server working directory.');
+const limit = (defaultValue: number, maximum?: number) => z.number()
+  .int()
+  .positive()
+  .max(maximum ?? Number.MAX_SAFE_INTEGER)
+  .default(defaultValue);
+const offset = z.number().int().nonnegative().optional();
+const projectionFields = {
+  filterPatterns: z.array(z.string().min(1)).optional()
+    .describe('Temporary path Filters for this call. Does not change workspace settings.'),
+  nodeTypes: z.array(z.string().min(1)).optional()
+    .describe('Temporary Node Type projection for this call.'),
+  edgeTypes: z.array(z.string().min(1)).optional()
+    .describe('Temporary Edge Type projection for this call.'),
+};
+const workspaceFields = {
+  workspacePath,
+};
+const pagedFields = {
+  limit: limit(100),
+  offset,
+};
+const workspaceProjectionFields = {
+  ...workspaceFields,
+  ...projectionFields,
+};
+const pagedWorkspaceProjectionFields = {
+  ...workspaceProjectionFields,
+  ...pagedFields,
+};
+
+type ToolInput = {
+  workspacePath?: string;
+  filterPatterns?: string[];
+  nodeTypes?: string[];
+  edgeTypes?: string[];
+};
+
+const readOnlyAnnotations = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} satisfies NonNullable<Parameters<McpServer['registerTool']>[1]>['annotations'];
+
+const indexAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} satisfies NonNullable<Parameters<McpServer['registerTool']>[1]>['annotations'];
+
+function readProjection(input: ToolInput): WorkspaceGraphQueryProjection | undefined {
+  const projection: WorkspaceGraphQueryProjection = {
+    ...(input.filterPatterns ? { filterPatterns: input.filterPatterns } : {}),
+    ...(input.nodeTypes ? { nodeTypes: input.nodeTypes } : {}),
+    ...(input.edgeTypes ? { edgeTypes: input.edgeTypes } : {}),
+  };
+  return Object.keys(projection).length > 0 ? projection : undefined;
+}
+
+function createToolResult(response: CodeGraphyWorkspaceCommandResponse): CallToolResult {
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify(response, null, 2),
+    }],
+    structuredContent: response as unknown as Record<string, unknown>,
+    ...(response.ok ? {} : { isError: true }),
+  };
+}
+
+async function execute(
+  dependencies: CodeGraphyMcpServerDependencies,
+  command: CodeGraphyWorkspaceCommand,
+): Promise<CallToolResult> {
+  return createToolResult(await dependencies.executeWorkspaceCommand(command));
+}
+
+function workspaceCommandPath(
+  input: ToolInput,
+  dependencies: CodeGraphyMcpServerDependencies,
+): string {
+  return input.workspacePath ?? dependencies.cwd();
+}
+
+function createQueryCommand(
+  input: ToolInput,
+  dependencies: CodeGraphyMcpServerDependencies,
+  query: GraphQueryRequest,
+): CodeGraphyWorkspaceCommand {
+  const projection = readProjection(input);
+  const selectedPath = workspaceCommandPath(input, dependencies);
+  return {
+    command: 'query',
+    workspacePath: selectedPath,
+    query,
+    ...(projection ? { projection } : {}),
+  };
+}
+
+function registerWorkspaceTools(
+  server: McpServer,
+  dependencies: CodeGraphyMcpServerDependencies,
+): void {
+  server.registerTool(
+    'codegraphy_status',
+    {
+      description: 'Report Graph Cache freshness and stale reasons for a CodeGraphy Workspace.',
+      inputSchema: z.object(workspaceFields),
+      annotations: readOnlyAnnotations,
+    },
+    async input => execute(dependencies, {
+      command: 'status',
+      workspacePath: workspaceCommandPath(input, dependencies),
+    }),
+  );
+
+  server.registerTool(
+    'codegraphy_index',
+    {
+      description: 'Create or incrementally update the CodeGraphy Workspace Graph Cache.',
+      inputSchema: z.object(workspaceFields),
+      annotations: indexAnnotations,
+    },
+    async input => execute(dependencies, {
+      command: 'index',
+      workspacePath: workspaceCommandPath(input, dependencies),
+    }),
+  );
+}
+
+function registerDiscoveryTools(
+  server: McpServer,
+  dependencies: CodeGraphyMcpServerDependencies,
+): void {
+  server.registerTool(
+    'codegraphy_search',
+    {
+      description: 'Search live source, cached AST Symbols, and indexed Nodes with freshness provenance.',
+      inputSchema: z.object({
+        ...workspaceProjectionFields,
+        pattern: z.string().min(1),
+        limit: limit(20),
+        offset,
+      }),
+      annotations: readOnlyAnnotations,
+    },
+    async input => execute(dependencies, createQueryCommand(input, dependencies, {
+      report: 'search',
+      arguments: {
+        pattern: input.pattern,
+        limit: input.limit,
+        ...(input.offset !== undefined ? { offset: input.offset } : {}),
+      },
+    })),
+  );
+
+  server.registerTool(
+    'codegraphy_map',
+    {
+      description: 'Build a bounded task-personalized File map from live terms and cached Relationships.',
+      inputSchema: z.object({
+        ...workspaceProjectionFields,
+        query: z.string().min(1),
+        limit: limit(8, 20),
+        offset,
+      }),
+      annotations: readOnlyAnnotations,
+    },
+    async input => execute(dependencies, createQueryCommand(input, dependencies, {
+      report: 'task-map',
+      arguments: {
+        query: input.query,
+        limit: input.limit,
+        ...(input.offset !== undefined ? { offset: input.offset } : {}),
+      },
+    })),
+  );
+
+  server.registerTool(
+    'codegraphy_query',
+    {
+      description: 'Inspect one exact File or Symbol Node with declarations and incoming and outgoing Relationships.',
+      inputSchema: z.object({
+        ...workspaceProjectionFields,
+        target: z.string().min(1),
+      }),
+      annotations: readOnlyAnnotations,
+    },
+    async input => execute(dependencies, createQueryCommand(input, dependencies, {
+      report: 'overview',
+      arguments: {
+        target: input.target,
+      },
+    })),
+  );
+}
+
+function registerInventoryTools(
+  server: McpServer,
+  dependencies: CodeGraphyMcpServerDependencies,
+): void {
+  server.registerTool(
+    'codegraphy_nodes',
+    {
+      description: 'List bounded Nodes from the shaped Relationship Graph.',
+      inputSchema: z.object(pagedWorkspaceProjectionFields),
+      annotations: readOnlyAnnotations,
+    },
+    async input => execute(dependencies, createQueryCommand(input, dependencies, {
+      report: 'nodes',
+      arguments: {
+        limit: input.limit,
+        ...(input.offset !== undefined ? { offset: input.offset } : {}),
+      },
+    })),
+  );
+
+  server.registerTool(
+    'codegraphy_edges',
+    {
+      description: 'List bounded Relationships from the shaped Relationship Graph.',
+      inputSchema: z.object(pagedWorkspaceProjectionFields),
+      annotations: readOnlyAnnotations,
+    },
+    async input => execute(dependencies, createQueryCommand(input, dependencies, {
+      report: 'edges',
+      arguments: {
+        limit: input.limit,
+        ...(input.offset !== undefined ? { offset: input.offset } : {}),
+      },
+    })),
+  );
+}
+
+function registerNavigationTools(
+  server: McpServer,
+  dependencies: CodeGraphyMcpServerDependencies,
+): void {
+  const connectionFields = {
+    ...pagedWorkspaceProjectionFields,
+    target: z.string().min(1),
+  };
+  server.registerTool(
+    'codegraphy_dependencies',
+    {
+      description: 'List bounded outgoing Relationships from one exact File or Node.',
+      inputSchema: z.object(connectionFields),
+      annotations: readOnlyAnnotations,
+    },
+    async input => execute(dependencies, createQueryCommand(input, dependencies, {
+      report: 'edges',
+      arguments: {
+        from: input.target,
+        expandFileSelectors: true,
+        projectFileEndpoints: true,
+        limit: input.limit,
+        ...(input.offset !== undefined ? { offset: input.offset } : {}),
+      },
+    })),
+  );
+
+  server.registerTool(
+    'codegraphy_dependents',
+    {
+      description: 'List bounded incoming Relationships to one exact File or Node.',
+      inputSchema: z.object(connectionFields),
+      annotations: readOnlyAnnotations,
+    },
+    async input => execute(dependencies, createQueryCommand(input, dependencies, {
+      report: 'edges',
+      arguments: {
+        to: input.target,
+        expandFileSelectors: true,
+        projectFileEndpoints: true,
+        limit: input.limit,
+        ...(input.offset !== undefined ? { offset: input.offset } : {}),
+      },
+    })),
+  );
+
+  server.registerTool(
+    'codegraphy_path',
+    {
+      description: 'Find bounded directed Relationship paths between two exact Files or Nodes.',
+      inputSchema: z.object({
+        ...workspaceProjectionFields,
+        from: z.string().min(1),
+        to: z.string().min(1),
+        maxDepth: z.number().int().positive().default(6),
+        maxPaths: z.number().int().positive().default(5),
+      }),
+      annotations: readOnlyAnnotations,
+    },
+    async input => execute(dependencies, createQueryCommand(input, dependencies, {
+      report: 'paths',
+      arguments: {
+        from: input.from,
+        to: input.to,
+        maxDepth: input.maxDepth,
+        maxPaths: input.maxPaths,
+        expandFileSelectors: true,
+        projectFileEndpoints: true,
+      },
+    })),
+  );
+}
+
+export function createCodeGraphyMcpServer(
+  dependencies: CodeGraphyMcpServerDependencies = DEFAULT_DEPENDENCIES,
+): McpServer {
+  const server = new McpServer(
+    {
+      name: 'codegraphy',
+      version: '0.1.0',
+    },
+    {
+      instructions: [
+        'Use status before relying on cached Relationships when freshness matters.',
+        'Use search or map to discover targets, then query for an exact overview.',
+        'Every result includes metadata.cache freshness and metadata.result completeness.',
+        'Index only when the user wants to change the workspace Graph Cache.',
+      ].join(' '),
+    },
+  );
+  registerWorkspaceTools(server, dependencies);
+  registerDiscoveryTools(server, dependencies);
+  registerInventoryTools(server, dependencies);
+  registerNavigationTools(server, dependencies);
+  return server;
+}
+
+type ServeCodeGraphyMcp = (createServer: () => McpServer) => unknown;
+
+export async function runCodeGraphyMcpServer(
+  serve: ServeCodeGraphyMcp = serveStdio,
+): Promise<void> {
+  await serve(() => createCodeGraphyMcpServer());
+}

--- a/packages/mcp/tests/mcp/server.test.ts
+++ b/packages/mcp/tests/mcp/server.test.ts
@@ -1,0 +1,266 @@
+import {
+  Client,
+  InMemoryTransport,
+  type CallToolResult,
+} from '@modelcontextprotocol/client';
+import type {
+  CodeGraphyWorkspaceCommand,
+  CodeGraphyWorkspaceCommandResponse,
+} from '@codegraphy-dev/core';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createCodeGraphyMcpServer,
+  runCodeGraphyMcpServer,
+} from '../../src/mcp/server';
+
+function createResponse(
+  command: CodeGraphyWorkspaceCommand['command'],
+): CodeGraphyWorkspaceCommandResponse {
+  if (command === 'status') {
+    return {
+      ok: true,
+      command,
+      data: {
+        workspaceRoot: '/workspace/project',
+        graphCache: '.codegraphy/graph.sqlite',
+        state: 'stale',
+        hasGraphCache: true,
+        staleReasons: ['pending-changed-files'],
+        enabledPlugins: [],
+        message: 'Graph Cache is stale.',
+      },
+      metadata: {
+        workspaceRoot: '/workspace/project',
+        cache: {
+          state: 'stale',
+          staleReasons: ['pending-changed-files'],
+        },
+        result: {
+          complete: true,
+          reasons: [],
+        },
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    command,
+    data: {
+      nodes: [],
+      page: {
+        offset: 0,
+        limit: 20,
+        returned: 0,
+        total: 0,
+        nextOffset: null,
+      },
+    },
+    metadata: {
+      workspaceRoot: '/workspace/project',
+      cache: {
+        state: 'fresh',
+        staleReasons: [],
+      },
+      result: {
+        complete: true,
+        reasons: [],
+      },
+    },
+  };
+}
+
+async function connectServer(executeWorkspaceCommand = vi.fn(
+  async (command: CodeGraphyWorkspaceCommand) => createResponse(command.command),
+)): Promise<{
+  client: Client;
+  executeWorkspaceCommand: typeof executeWorkspaceCommand;
+}> {
+  const server = createCodeGraphyMcpServer({
+    cwd: () => '/workspace/project',
+    executeWorkspaceCommand,
+  });
+  const client = new Client({
+    name: 'codegraphy-mcp-test',
+    version: '1.0.0',
+  });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client, executeWorkspaceCommand };
+}
+
+function structuredResponse(result: CallToolResult): CodeGraphyWorkspaceCommandResponse {
+  return result.structuredContent as unknown as CodeGraphyWorkspaceCommandResponse;
+}
+
+describe('mcp/server', () => {
+  it('serves a fresh CodeGraphy server for each stdio connection', async () => {
+    const serve = vi.fn(async (createServer: () => unknown) => {
+      expect(createServer()).toBeDefined();
+    });
+
+    await runCodeGraphyMcpServer(serve);
+
+    expect(serve).toHaveBeenCalledOnce();
+  });
+
+  it('discovers the existing CodeGraphy workflow as typed MCP tools', async () => {
+    const { client } = await connectServer();
+
+    const result = await client.listTools();
+
+    expect(result.tools.map(tool => tool.name)).toEqual([
+      'codegraphy_status',
+      'codegraphy_index',
+      'codegraphy_search',
+      'codegraphy_map',
+      'codegraphy_query',
+      'codegraphy_nodes',
+      'codegraphy_edges',
+      'codegraphy_dependencies',
+      'codegraphy_dependents',
+      'codegraphy_path',
+    ]);
+    expect(result.tools.find(tool => tool.name === 'codegraphy_search')).toMatchObject({
+      annotations: {
+        readOnlyHint: true,
+      },
+      inputSchema: {
+        required: ['pattern'],
+      },
+    });
+    expect(result.tools.find(tool => tool.name === 'codegraphy_index')).toMatchObject({
+      annotations: {
+        idempotentHint: true,
+        readOnlyHint: false,
+      },
+    });
+  });
+
+  it('invokes Core directly and returns structured freshness and completeness', async () => {
+    const { client, executeWorkspaceCommand } = await connectServer();
+
+    const result = await client.callTool({
+      name: 'codegraphy_status',
+      arguments: {
+        workspacePath: '/workspace/project',
+      },
+    });
+
+    expect(executeWorkspaceCommand).toHaveBeenCalledWith({
+      command: 'status',
+      workspacePath: '/workspace/project',
+    });
+    expect(structuredResponse(result)).toMatchObject({
+      ok: true,
+      metadata: {
+        cache: {
+          state: 'stale',
+          staleReasons: ['pending-changed-files'],
+        },
+        result: {
+          complete: true,
+          reasons: [],
+        },
+      },
+    });
+  });
+
+  it('maps exploration tools one-to-one onto existing Core Graph Query reports', async () => {
+    const { client, executeWorkspaceCommand } = await connectServer();
+
+    await client.callTool({
+      name: 'codegraphy_search',
+      arguments: {
+        pattern: 'workspace command',
+        limit: 12,
+      },
+    });
+    await client.callTool({
+      name: 'codegraphy_dependencies',
+      arguments: {
+        target: 'src/app.ts',
+      },
+    });
+    await client.callTool({
+      name: 'codegraphy_path',
+      arguments: {
+        from: 'src/app.ts',
+        to: 'src/model.ts',
+      },
+    });
+
+    expect(executeWorkspaceCommand).toHaveBeenNthCalledWith(1, {
+      command: 'query',
+      workspacePath: '/workspace/project',
+      query: {
+        report: 'search',
+        arguments: {
+          pattern: 'workspace command',
+          limit: 12,
+        },
+      },
+    });
+    expect(executeWorkspaceCommand).toHaveBeenNthCalledWith(2, {
+      command: 'query',
+      workspacePath: '/workspace/project',
+      query: {
+        report: 'edges',
+        arguments: {
+          from: 'src/app.ts',
+          expandFileSelectors: true,
+          projectFileEndpoints: true,
+          limit: 100,
+        },
+      },
+    });
+    expect(executeWorkspaceCommand).toHaveBeenNthCalledWith(3, {
+      command: 'query',
+      workspacePath: '/workspace/project',
+      query: {
+        report: 'paths',
+        arguments: {
+          from: 'src/app.ts',
+          to: 'src/model.ts',
+          maxDepth: 6,
+          maxPaths: 5,
+          expandFileSelectors: true,
+          projectFileEndpoints: true,
+        },
+      },
+    });
+  });
+
+  it('returns Core command failures as MCP tool errors that clients can inspect', async () => {
+    const failedResponse: CodeGraphyWorkspaceCommandResponse = {
+      ok: false,
+      command: 'query',
+      error: {
+        code: 'graph_cache_not_found',
+        message: 'Run Indexing first.',
+      },
+      metadata: {
+        workspaceRoot: '/workspace/project',
+        cache: {
+          state: 'missing',
+          staleReasons: ['never-indexed'],
+        },
+        result: {
+          complete: false,
+          reasons: ['cache-missing'],
+        },
+      },
+    };
+    const { client } = await connectServer(vi.fn(async () => failedResponse));
+
+    const result = await client.callTool({
+      name: 'codegraphy_nodes',
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    expect(structuredResponse(result)).toEqual(failedResponse);
+  });
+});

--- a/packages/mcp/tsconfig.build.json
+++ b/packages/mcp/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {}
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "tests",
+    "dist"
+  ]
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@codegraphy-dev/core": ["../core/src/index.ts"]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts",
+    "scripts/**/*.mjs",
+    "vitest.config.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@codegraphy-dev/core': resolve(__dirname, '../core/src/index.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,34 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  packages/mcp:
+    dependencies:
+      '@codegraphy-dev/core':
+        specifier: workspace:*
+        version: link:../core
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0
+        version: 2.0.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0
+        version: 2.0.0
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.37
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@20.19.37)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/plugin-api: {}
 
   packages/plugin-godot:
@@ -1887,6 +1915,18 @@ packages:
 
   '@mdi/js@7.4.47':
     resolution: {integrity: sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==}
+
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -5096,6 +5136,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -5714,6 +5762,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.5:
+    resolution: {integrity: sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==}
 
   js-md4@0.3.2:
     resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
@@ -6467,6 +6518,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
@@ -9031,6 +9086,25 @@ snapshots:
       react: 19.2.7
 
   '@mdi/js@7.4.47': {}
+
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      jose: 6.2.5
+      pkce-challenge: 5.0.1
+      zod: 4.3.6
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.3.6
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.3.6
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -12481,6 +12555,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -13113,6 +13193,8 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.7.0: {}
+
+  jose@6.2.5: {}
 
   js-md4@0.3.2: {}
 
@@ -13864,6 +13946,8 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.58.2: {}
 


### PR DESCRIPTION
## Summary

- add one transport-neutral Core command contract for workspace status, explicit Indexing, and Graph Query
- route the VS Code agent URI bridge through Core and add status requests
- add an optional MCP stdio server that maps typed tools one-to-one onto the existing Core operations
- report Graph Cache freshness and result completeness in both transports

## MCP versus the Agent Skill and CLI

MCP adds typed tool discovery, schema validation, structured results without shell parsing, and a persistent stdio connection. It does not add analysis or a second query model. The Agent Skill plus CLI remains the preferred smaller surface for shell-capable agents and exposes the complete CLI.

## Verification

- Core workspace command tests: 6 passed
- VS Code URI bridge tests: 31 passed
- MCP protocol tests: 5 passed with a real MCP client and in-memory transport
- Core, extension, and MCP typechecks passed
- Core and MCP builds passed
- Core and MCP lint passed
- real stdio MCP client smoke passed and discovered all 10 tools
- `git diff --check` passed

The bounded full-suite attempt reached 15 successful Turbo tasks before it was stopped at about 66 seconds. Core had reported one failure during the parallel run; the likely concurrent package snapshot file passed immediately in isolation (7/7). Playwright reached the VS Code build before the bounded attempt was stopped. CI is the source of truth for the complete matrix.