### PR TITLE
docs: keep quality feedback loops scoped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,9 @@ The graph renderer draws Nodes with WebGPU and runs force and collision physics 
 ## Examples prove support
 
 Use the focused workspaces in `examples/` to inspect and validate language and plugin behavior end to end. Keep each example small enough that a person can understand the expected files, Nodes, and Relationships.
+
+## Keep feedback loops short
+
+Use the smallest check that can disprove a change. Prefer focused unit tests while iterating. Run a focused Playwright scenario when the behavior needs a real browser or extension host; let CI run the complete Playwright suite in parallel. Push checkpoints and check the pull request periodically while useful work continues so failures appear before the branch drifts far from a green state.
+
+Treat the quality tools as focused diagnostics, not a checklist to run after every change. Select the tool that fits the risk and scope it to the changed file or feature. Mutation testing is the most expensive: run it against one source file, use its survivors to improve the code or tests, then repeat that same scoped run until its output is clean.

--- a/docs/quality/README.md
+++ b/docs/quality/README.md
@@ -44,7 +44,9 @@ Current command expectations:
 - `mutate` requires one source module at a time; a bare repository or package run is invalid
 - `scrap` works best on package roots and test files/directories
 
-Use scoped mutation for changed source modules during normal work. Full mutation is intentionally expensive; prefer a file or feature-folder target that maps to the behavior being changed. CI's Vitest split does not automatically shard Stryker mutation runs; mutation speed still depends on target scope, Stryker incremental state, and the Vitest tests selected for the mutation target.
+Quality tools are diagnostics, not a required checklist for every change. Select a tool when its signal matches the current risk, then use the narrowest target that can answer the question. Repository-wide reports and mutation runs are expensive and should not block a faster relevant feedback loop.
+
+Mutation is the most expensive quality tool. Run it only when test effectiveness needs deeper inspection, and target one changed source module. Use the survivors to improve that module or its tests, then repeat the same scoped run until the result is clean. CI's Vitest split does not automatically shard Stryker mutation runs; mutation speed still depends on target scope, Stryker incremental state, and the Vitest tests selected for the mutation target.
 
 CRAP coverage and tool reports live under `reports/quality-tools/`.
 
@@ -56,12 +58,12 @@ Run these commands with an active Node.js LTS release. `@poleski/quality-tools` 
 
 ## Workflow
 
-For a behavior change:
+Choose the steps that fit the change:
 
-1. Run `organize`, `boundaries`, and `reachability` on the owning package or feature seam.
-2. Add or update behavior tests.
-3. Run mutation testing on the changed source module.
-4. Run CRAP on the changed package or subtree and SCRAP on the affected tests.
-5. Run `pnpm run organize -- .` as an advisory repository scan.
+1. Add or update the smallest behavior test that proves the change.
+2. Run the relevant quality tool against the changed file, tests, or feature seam.
+3. Inspect its report and make one focused correction.
+4. Repeat the same scoped command until it reports a clean result or identifies a deliberate exception.
+5. Use a broader advisory scan only when the change or investigation needs repository-wide context.
 
 CodeGraphy keeps thin monorepo wrappers and configuration. The reusable analyzers stay in `@poleski/quality-tools`.

--- a/docs/quality/mutation.md
+++ b/docs/quality/mutation.md
@@ -23,6 +23,7 @@ The root [quality.config.json](../../quality.config.json) defines mutation scope
 
 Operational notes:
 
+- Mutation testing is not a routine completion gate. Use it when a changed module needs stronger evidence that its tests detect faults.
 - Mutation testing is a local development tool and does not run in CI. Local mutation commands require one explicit source file.
 - Root `pnpm run mutate` is a CodeGraphy wrapper that resolves package and test scope, then delegates to the generic `@poleski/quality-tools` mutation runner.
 - Stryker stores incremental reports under `reports/quality-tools/mutation/` in the current checkout. Repeated runs of the same target can reuse unaffected mutant results from that local report.
@@ -31,4 +32,4 @@ Operational notes:
 - The mutation runner prints a progress heartbeat every 60 seconds while Stryker is still running.
 - Extension mutation defaults to two Stryker workers and reuses Vitest runners instead of restarting one after every mutant. Override with `CODEGRAPHY_STRYKER_CONCURRENCY` or `CODEGRAPHY_STRYKER_MAX_TEST_RUNNER_REUSE` when debugging runner isolation.
 - Mutation targets run directly through Stryker incremental mode without a separate typecheck preflight. Pass `--force` to rerun the mutants in scope.
-- Run mutation only for the changed source module.
+- Run mutation only for one changed source module. Inspect its survivors, improve the code or tests, then rerun that same target until the result is clean.

--- a/packages/extension/docs/testing.md
+++ b/packages/extension/docs/testing.md
@@ -23,6 +23,8 @@ pnpm --filter @codegraphy-dev/extension run build:vscode
 pnpm --filter @codegraphy-dev/extension exec playwright test --config playwright.vscode.config.ts --grep "Vue example"
 ```
 
+The complete Playwright suite takes long enough to interrupt normal iteration. Prefer focused Vitest coverage when it proves the changed behavior. Run one focused Playwright scenario when the change depends on the built browser or VS Code host. Push checkpoints so CI can run the complete suite while other useful work continues; do not wait for CI when the branch still has independent work available. Check the pull request periodically and correct failures before later changes drift far from the last green checkpoint.
+
 Do not debug Graph View acceptance behavior from a raw Playwright command against stale output. `test:vscode` regenerates acceptance specs and rebuilds the extension first; a direct `playwright test --config playwright.vscode.config.ts` does not. If you need to use the direct command while iterating, run `build:vscode` immediately before it.
 
 On macOS, the acceptance launcher must use the mock keychain path. The launcher in `tests/acceptance/graphView/vscode.ts` owns the VS Code arguments, including `--use-inmemory-secretstorage`, `--use-mock-keychain`, and a short `/tmp` temp base for VS Code IPC sockets. If a "Keychain Not Found" / "Code Key" modal appears, fix the launcher path instead of continuing through the modal.


### PR DESCRIPTION
## Summary

- prefer focused local checks during iteration
- let CI run the complete Playwright suite in parallel
- define a single-file mutation feedback loop

## Verification

- `git diff --check`
- full Playwright and mutation suites intentionally not run for documentation-only changes