### PR TITLE
Show target directory in creation inputs

### DIFF
--- a/.changeset/bright-creation-breadcrumbs.md
+++ b/.changeset/bright-creation-breadcrumbs.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Show the target directory when creating a file or folder from the Graph View.

--- a/packages/extension/src/extension/graphView/files/actions.ts
+++ b/packages/extension/src/extension/graphView/files/actions.ts
@@ -58,7 +58,8 @@ export async function createGraphViewFile(
   if (!handlers.workspaceFolder) return undefined;
 
   const fileName = await handlers.showInputBox({
-    prompt: 'Enter file name',
+    title: 'New File',
+    prompt: directory === '.' ? '/' : `${directory}/`,
     placeHolder: 'newfile.ts',
     ignoreFocusOut: true,
   });
@@ -87,7 +88,8 @@ export async function createGraphViewFolder(
   if (!handlers.workspaceFolder) return undefined;
 
   const folderName = await handlers.showInputBox({
-    prompt: 'Enter folder name',
+    title: 'New Folder',
+    prompt: directory === '.' ? '/' : `${directory}/`,
     placeHolder: 'new-folder',
     ignoreFocusOut: true,
   });

--- a/packages/extension/tests/extension/graphView/files/actions.test.ts
+++ b/packages/extension/tests/extension/graphView/files/actions.test.ts
@@ -76,7 +76,8 @@ describe('graphView/files/actions', () => {
     });
 
     expect(showInputBox).toHaveBeenCalledWith({
-      prompt: 'Enter file name',
+      title: 'New File',
+      prompt: 'src/',
       placeHolder: 'newfile.ts',
       ignoreFocusOut: true,
     });
@@ -99,6 +100,19 @@ describe('graphView/files/actions', () => {
     });
 
     expect(showErrorMessage).toHaveBeenCalledWith('Failed to create file: disk full');
+  });
+
+  it('shows the workspace-root breadcrumb when creating a file', async () => {
+    const showInputBox = vi.fn(async () => undefined);
+
+    await createGraphViewFile('.', {
+      workspaceFolder: { uri: vscode.Uri.file('/workspace') },
+      showInputBox,
+      executeCreateAction: vi.fn(),
+      showErrorMessage: vi.fn(),
+    });
+
+    expect(showInputBox).toHaveBeenCalledWith(expect.objectContaining({ prompt: '/' }));
   });
 
   it('creates files in the workspace root without prefixing the current directory', async () => {
@@ -214,7 +228,8 @@ describe('graphView/files/actions', () => {
     });
 
     expect(showInputBox).toHaveBeenCalledWith({
-      prompt: 'Enter folder name',
+      title: 'New Folder',
+      prompt: 'src/',
       placeHolder: 'new-folder',
       ignoreFocusOut: true,
     });
@@ -222,6 +237,19 @@ describe('graphView/files/actions', () => {
       'src/components',
       vscode.Uri.file('/workspace'),
     );
+  });
+
+  it('shows the workspace-root breadcrumb when creating a folder', async () => {
+    const showInputBox = vi.fn(async () => undefined);
+
+    await createGraphViewFolder('.', {
+      workspaceFolder: { uri: vscode.Uri.file('/workspace') },
+      showInputBox,
+      executeCreateFolderAction: vi.fn(),
+      showErrorMessage: vi.fn(),
+    });
+
+    expect(showInputBox).toHaveBeenCalledWith(expect.objectContaining({ prompt: '/' }));
   });
 
   it('creates nested folders below the selected directory', async () => {


### PR DESCRIPTION
## Summary

- show `New File` / `New Folder` titles in the native VS Code creation input
- show `/` for the workspace root or a trailing-slash workspace-relative target directory
- preserve the existing placeholder, validation, cancellation, and creation behavior
- add a patch changeset for `@codegraphy-dev/extension`

Trello: https://trello.com/c/LEgcUpQJ/249-show-the-target-directory-breadcrumb-in-creation-inputs

## Visual proof

Recorded from this PR build in an isolated VS Code 1.131.0 Extension Development Host.

Verified flows:

- **New File** at workspace root shows `/`
- **New Folder** at workspace root shows `/`
- **New File** from the `src` folder node shows `src/`

### Complete interaction

https://github.com/user-attachments/assets/428a2b3c-a7cc-4733-a710-198d0e4fb936

![Creation target breadcrumb flow](https://github.com/user-attachments/assets/6212d69d-cd53-4e30-9eb0-55a5de589b7b)

### Captured inputs

| New File at `/` | New Folder at `/` |
| --- | --- |
| <img width="560" alt="New File input showing the workspace-root breadcrumb" src="https://github.com/user-attachments/assets/92e608fd-d7dc-4525-8e90-c9a4b8b13995" /> | <img width="560" alt="New Folder input showing the workspace-root breadcrumb" src="https://github.com/user-attachments/assets/50b81592-6438-490d-a5eb-9ce99bc5c1fc" /> |

**New File in `src/`:**

<img width="760" alt="New File input showing the src target-directory breadcrumb" src="https://github.com/user-attachments/assets/30aeb7bf-6294-4486-a801-250dfb963db6" />

## Verification

- `pnpm --filter @codegraphy-dev/extension exec vitest run --config vitest.config.ts tests/extension/graphView/files/actions.test.ts` — 58 passed
- `pnpm --filter @codegraphy-dev/extension test` — 1,045 files / 5,548 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm build` — passed

The first concurrent root `pnpm test` run reported three unrelated `@codegraphy-dev/tldraw` timing failures. Its isolated rerun passed all 32 files / 94 tests.

