### PR TITLE
feat: identify graph context menu targets

### DIFF
--- a/.changeset/clear-context-menu-targets.md
+++ b/.changeset/clear-context-menu-targets.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Show the active Node, Edge, multi-selection, or workspace root above Graph Context Menu actions.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,6 +83,7 @@ Interaction rules:
 - A single click selects and focuses a Node. File Nodes also preview their file.
 - A double-click opens a File Node as a persistent editor tab.
 - Right-click captures Context Selection without previewing or opening a file.
+- Every Graph Context Menu identifies that captured Node, Edge, multi-node selection, or workspace root above its actions.
 - Multi-node context actions apply only when the action supports the complete Context Selection.
 - Delete actions require confirmation and move files or empty created folders to trash.
 - Collapse follows Edge Direction and preserves Boundary Paths to shared visible targets.

--- a/packages/extension/src/extension/graphView/provider/webview/defaultDependencies.ts
+++ b/packages/extension/src/extension/graphView/provider/webview/defaultDependencies.ts
@@ -69,6 +69,7 @@ export function createDefaultGraphViewProviderWebviewMethodDependencies(): Graph
         createGraphViewNonce(),
         getActiveGraphViewThemeKind(),
         process.env.CODEGRAPHY_ACCEPTANCE === '1',
+        vscode.workspace.workspaceFolders?.[0]?.name,
       ),
     resolveWebviewView: resolveGraphViewWebviewView,
     openInEditor: openGraphViewInEditor,

--- a/packages/extension/src/extension/graphView/webview/html.ts
+++ b/packages/extension/src/extension/graphView/webview/html.ts
@@ -11,12 +11,21 @@ export function createGraphViewNonce(random: () => number = Math.random): string
   return text;
 }
 
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 export function createGraphViewHtml(
   extensionUri: vscode.Uri,
   webview: Pick<vscode.Webview, 'asWebviewUri' | 'cspSource'>,
   nonce: string,
   initialTheme: CodeGraphyWebviewThemeKind = 'dark',
   enableGraphDebug = false,
+  workspaceName?: string,
 ): string {
   const scriptUri = webview.asWebviewUri(
     vscode.Uri.joinPath(extensionUri, 'dist', 'webview', 'index.js')
@@ -34,7 +43,7 @@ export function createGraphViewHtml(
   <link href="${styleUri.toString()}" rel="stylesheet">
   <title>CodeGraphy</title>
 </head>
-<body data-codegraphy-theme="${initialTheme}"${enableGraphDebug ? ' data-codegraphy-debug="true"' : ''}>
+<body data-codegraphy-theme="${initialTheme}"${enableGraphDebug ? ' data-codegraphy-debug="true"' : ''}${workspaceName?.trim() ? ` data-codegraphy-workspace-name="${escapeHtmlAttribute(workspaceName.trim())}"` : ''}>
   <div id="root"></div>
   <script type="module" nonce="${nonce}" src="${scriptUri.toString()}"></script>
 </body>

--- a/packages/extension/src/webview/components/graph/contextMenu/build/entries.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/build/entries.ts
@@ -4,6 +4,8 @@ import {
 } from '../contracts';
 import { decideGraphContextMenu } from '../decision/model';
 import { buildGraphViewContextMenuEntries } from '../graphView/entries';
+import { buildGraphContextMenuHeader } from '../header/model';
+import { separator } from '../common/entryFactories';
 import { buildBaseGraphContextMenuEntries } from './baseEntries';
 import { captureContextSelection, insertCreateMenuEntries } from './selectionEntries';
 
@@ -14,6 +16,7 @@ export function buildGraphContextMenuEntries(
     selection,
     favorites,
     graphViewContributions,
+    workspaceName,
     nodes,
     edges,
   } = options;
@@ -31,7 +34,7 @@ export function buildGraphContextMenuEntries(
     })
     : [];
   const positionedBaseEntries = insertCreateMenuEntries(baseEntries, graphViewCreateEntries);
-  return captureContextSelection([
+  const actionEntries = captureContextSelection([
     ...positionedBaseEntries,
     ...buildGraphViewContextMenuEntries({
       decision,
@@ -41,4 +44,11 @@ export function buildGraphContextMenuEntries(
       selection,
     }),
   ], selection);
+  const header = buildGraphContextMenuHeader(selection, { edges, nodes, workspaceName });
+  if (!header) return actionEntries;
+  return [
+    { kind: 'header', id: 'context-target-header', header },
+    separator('context-target-header-separator'),
+    ...actionEntries,
+  ];
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/contracts.ts
@@ -41,7 +41,23 @@ export interface GraphContextMenuActionInvocation {
   contextSelection: GraphContextSelection;
 }
 
+export interface GraphContextMenuIdentity {
+  label: string;
+  exactId?: string;
+}
+
+export type GraphContextMenuHeader =
+  | { kind: 'background'; workspaceName: string }
+  | { kind: 'edge'; source: GraphContextMenuIdentity; target: GraphContextMenuIdentity; relationship?: string }
+  | { kind: 'multiNode'; count: number }
+  | { kind: 'node'; target: GraphContextMenuIdentity };
+
 export type GraphContextMenuEntry =
+  | {
+      kind: 'header';
+      id: string;
+      header: GraphContextMenuHeader;
+    }
   | {
       kind: 'item';
       id: string;
@@ -61,6 +77,7 @@ export interface GraphContextSelection {
   kind: GraphContextTargetKind;
   targets: string[];
   edgeId?: string;
+  visibleEdgeId?: string;
   graphPosition?: { x: number; y: number };
 }
 
@@ -92,6 +109,7 @@ export interface BuildGraphContextMenuOptions {
   selection: GraphContextSelection;
   favorites: ReadonlySet<string>;
   graphViewContributions?: ExtensionGraphViewContributionSet;
+  workspaceName?: string;
   nodes?: readonly GraphContextMenuNode[];
   edges?: readonly GraphContextMenuEdge[];
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/header/identity.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/header/identity.ts
@@ -7,6 +7,19 @@ export function buildGraphContextMenuIdentity(
   nodeId: string,
   nodes: readonly GraphContextMenuNode[] | undefined,
 ): GraphContextMenuIdentity {
-  const label = nodes?.find(node => node.id === nodeId)?.label?.trim() || nodeId;
+  const node = nodes?.find(candidate => candidate.id === nodeId);
+  const label = node?.label?.trim() || nodeId;
+  if (node?.nodeType === 'folder') {
+    const folderLabel = withTrailingSlash(label);
+    const folderId = withTrailingSlash(nodeId);
+    return folderLabel === folderId
+      ? { label: folderLabel }
+      : { label: folderLabel, exactId: folderId };
+  }
+
   return label === nodeId ? { label } : { label, exactId: nodeId };
+}
+
+function withTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value : `${value}/`;
 }

--- a/packages/extension/src/webview/components/graph/contextMenu/header/identity.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/header/identity.ts
@@ -1,0 +1,12 @@
+import type {
+  GraphContextMenuIdentity,
+  GraphContextMenuNode,
+} from '../contracts';
+
+export function buildGraphContextMenuIdentity(
+  nodeId: string,
+  nodes: readonly GraphContextMenuNode[] | undefined,
+): GraphContextMenuIdentity {
+  const label = nodes?.find(node => node.id === nodeId)?.label?.trim() || nodeId;
+  return label === nodeId ? { label } : { label, exactId: nodeId };
+}

--- a/packages/extension/src/webview/components/graph/contextMenu/header/model.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/header/model.ts
@@ -1,0 +1,47 @@
+import type {
+  GraphContextMenuEdge,
+  GraphContextMenuHeader,
+  GraphContextMenuNode,
+  GraphContextSelection,
+} from '../contracts';
+import { buildGraphContextMenuIdentity } from './identity';
+import { readGraphContextMenuRelationship } from './relationship';
+
+const FALLBACK_WORKSPACE_NAME = 'Workspace';
+
+export function buildGraphContextMenuHeader(
+  selection: GraphContextSelection,
+  options: {
+    edges?: readonly GraphContextMenuEdge[];
+    nodes?: readonly GraphContextMenuNode[];
+    workspaceName?: string;
+  },
+): GraphContextMenuHeader | undefined {
+  if (selection.kind === 'background') {
+    return {
+      kind: 'background',
+      workspaceName: options.workspaceName?.trim() || FALLBACK_WORKSPACE_NAME,
+    };
+  }
+
+  if (selection.kind === 'edge') {
+    const [sourceId, targetId] = selection.targets;
+    if (!sourceId || !targetId) return undefined;
+    return {
+      kind: 'edge',
+      source: buildGraphContextMenuIdentity(sourceId, options.nodes),
+      target: buildGraphContextMenuIdentity(targetId, options.nodes),
+      relationship: readGraphContextMenuRelationship(selection, options.edges),
+    };
+  }
+
+  if (selection.targets.length === 0) return undefined;
+  if (selection.targets.length > 1) {
+    return { kind: 'multiNode', count: selection.targets.length };
+  }
+
+  return {
+    kind: 'node',
+    target: buildGraphContextMenuIdentity(selection.targets[0], options.nodes),
+  };
+}

--- a/packages/extension/src/webview/components/graph/contextMenu/header/model.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/header/model.ts
@@ -9,6 +9,10 @@ import { readGraphContextMenuRelationship } from './relationship';
 
 const FALLBACK_WORKSPACE_NAME = 'Workspace';
 
+function withTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
 export function buildGraphContextMenuHeader(
   selection: GraphContextSelection,
   options: {
@@ -20,7 +24,9 @@ export function buildGraphContextMenuHeader(
   if (selection.kind === 'background') {
     return {
       kind: 'background',
-      workspaceName: options.workspaceName?.trim() || FALLBACK_WORKSPACE_NAME,
+      workspaceName: withTrailingSlash(
+        options.workspaceName?.trim() || FALLBACK_WORKSPACE_NAME,
+      ),
     };
   }
 

--- a/packages/extension/src/webview/components/graph/contextMenu/header/relationship.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/header/relationship.ts
@@ -1,0 +1,21 @@
+import type {
+  GraphContextMenuEdge,
+  GraphContextSelection,
+} from '../contracts';
+
+function findVisibleEdge(
+  selection: GraphContextSelection,
+  edges: readonly GraphContextMenuEdge[] | undefined,
+): GraphContextMenuEdge | undefined {
+  const visibleEdgeId = selection.visibleEdgeId ?? selection.edgeId;
+  return edges?.find(candidate => candidate.id === visibleEdgeId);
+}
+
+export function readGraphContextMenuRelationship(
+  selection: GraphContextSelection,
+  edges: readonly GraphContextMenuEdge[] | undefined,
+): string | undefined {
+  const edge = findVisibleEdge(selection, edges);
+  const relationship = edge?.kind?.trim() || edge?.runtimeEdgeType?.trim();
+  return relationship || undefined;
+}

--- a/packages/extension/src/webview/components/graph/contextMenu/selection.ts
+++ b/packages/extension/src/webview/components/graph/contextMenu/selection.ts
@@ -28,7 +28,8 @@ export function makeBackgroundContextSelection(
 export function makeEdgeContextSelection(
   edgeId: string,
   sourceId: string,
-  targetId: string
+  targetId: string,
+  visibleEdgeId: string = edgeId,
 ): GraphContextSelection {
-  return { kind: 'edge', edgeId, targets: [sourceId, targetId] };
+  return { kind: 'edge', edgeId, visibleEdgeId, targets: [sourceId, targetId] };
 }

--- a/packages/extension/src/webview/components/graph/environment/workspace.ts
+++ b/packages/extension/src/webview/components/graph/environment/workspace.ts
@@ -1,0 +1,11 @@
+interface WorkspaceDocumentLike {
+  body?: {
+    dataset?: {
+      codegraphyWorkspaceName?: string;
+    };
+  };
+}
+
+export function readGraphWorkspaceName(documentLike: WorkspaceDocumentLike | undefined): string {
+  return documentLike?.body?.dataset?.codegraphyWorkspaceName?.trim() || 'Workspace';
+}

--- a/packages/extension/src/webview/components/graph/interactionRuntime/handlers/contextMenu.ts
+++ b/packages/extension/src/webview/components/graph/interactionRuntime/handlers/contextMenu.ts
@@ -119,7 +119,7 @@ export function createContextMenuHandlers(
 
     flushSync(() => {
       dependencies.setContextSelection(
-        makeEdgeContextSelection(edgeId, sourceId, targetId),
+        makeEdgeContextSelection(edgeId, sourceId, targetId, link.id),
       );
     });
     dependencies.lastGraphContextEventRef.current = Date.now();

--- a/packages/extension/src/webview/components/graph/view/component.tsx
+++ b/packages/extension/src/webview/components/graph/view/component.tsx
@@ -16,6 +16,7 @@ import { useGraphDebugApi } from '../debug/api';
 import { buildGraphDebugOptions } from '../debug/options';
 import { buildGraphDataLayoutKey } from './layoutKey';
 import { detectMacPlatform } from '../environment/platform';
+import { readGraphWorkspaceName } from '../environment/workspace';
 import { useGraphLegends, useGraphViewStoreState } from './store';
 import { useGraphCallbacks } from '../rendering/useGraphCallbacks';
 import { useGraphInteractionRuntime } from '../runtime/use/interaction';
@@ -34,6 +35,7 @@ interface GraphProps {
   onAddFilterRequested?: (patterns: string[]) => void;
   onAddLegendRequested?: (rule: { pattern: string; color: string; target: 'node' | 'edge' }) => void;
   pluginHost?: WebviewPluginHost;
+  workspaceName?: string;
 }
 
 function hasGraphViewContributions(
@@ -59,6 +61,7 @@ export default function Graph({
   onAddFilterRequested = () => {},
   onAddLegendRequested = () => {},
   pluginHost,
+  workspaceName = readGraphWorkspaceName(globalThis.document),
 }: GraphProps): React.ReactElement {
   const viewState = useGraphViewStoreState();
   const legends = useGraphLegends();
@@ -140,6 +143,7 @@ export default function Graph({
       pluginHost={pluginHost}
       theme={theme}
       viewState={viewState}
+      workspaceName={workspaceName}
     />
   );
 }

--- a/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
@@ -38,13 +38,13 @@ function EdgeHeader({ header }: { header: Extract<GraphContextMenuHeader, { kind
     <>
       <div className="flex min-w-0 items-center gap-1 font-semibold text-[var(--cg-menu-foreground)]">
         <MiddleTruncatedText
-          className="min-w-0 max-w-[calc(50%_-_0.75rem)] shrink-0"
+          className="min-w-0 w-max max-w-[calc(50%_-_0.75rem)] shrink-0"
           text={header.source.label}
           tooltipText={header.source.exactId ? `${header.source.label} — ${header.source.exactId}` : header.source.label}
         />
         <span aria-hidden="true" className="shrink-0">→</span>
         <MiddleTruncatedText
-          className="min-w-0 max-w-[calc(50%_-_0.75rem)] shrink-0"
+          className="min-w-0 w-max max-w-[calc(50%_-_0.75rem)] shrink-0"
           text={header.target.label}
           tooltipText={header.target.exactId ? `${header.target.label} — ${header.target.exactId}` : header.target.label}
         />

--- a/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
@@ -38,13 +38,13 @@ function EdgeHeader({ header }: { header: Extract<GraphContextMenuHeader, { kind
     <>
       <div className="flex min-w-0 items-center gap-1 font-semibold text-[var(--cg-menu-foreground)]">
         <MiddleTruncatedText
-          className="min-w-0 max-w-[calc(50%-0.75rem)]"
+          className="min-w-0 max-w-[calc(50%_-_0.75rem)] shrink-0"
           text={header.source.label}
           tooltipText={header.source.exactId ? `${header.source.label} — ${header.source.exactId}` : header.source.label}
         />
         <span aria-hidden="true" className="shrink-0">→</span>
         <MiddleTruncatedText
-          className="min-w-0 max-w-[calc(50%-0.75rem)]"
+          className="min-w-0 max-w-[calc(50%_-_0.75rem)] shrink-0"
           text={header.target.label}
           tooltipText={header.target.exactId ? `${header.target.label} — ${header.target.exactId}` : header.target.label}
         />

--- a/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
@@ -33,21 +33,40 @@ function IdentityHeader({ header }: { header: Extract<GraphContextMenuHeader, { 
   );
 }
 
+function EdgeEndpoint({
+  endpoint,
+  identity,
+}: {
+  endpoint: 'source' | 'target';
+  identity: Extract<GraphContextMenuHeader, { kind: 'edge' }>['source'];
+}): ReactElement {
+  return (
+    <span
+      className="inline-grid min-w-0 max-w-[calc(50%_-_0.75rem)] overflow-hidden"
+      data-edge-header-endpoint={endpoint}
+    >
+      <span
+        aria-hidden="true"
+        className="invisible col-start-1 row-start-1 whitespace-nowrap"
+      >
+        {identity.label}
+      </span>
+      <MiddleTruncatedText
+        className="col-start-1 row-start-1 w-full"
+        text={identity.label}
+        tooltipText={identity.exactId ? `${identity.label} — ${identity.exactId}` : identity.label}
+      />
+    </span>
+  );
+}
+
 function EdgeHeader({ header }: { header: Extract<GraphContextMenuHeader, { kind: 'edge' }> }): ReactElement {
   return (
     <>
       <div className="flex min-w-0 items-center gap-1 font-semibold text-[var(--cg-menu-foreground)]">
-        <MiddleTruncatedText
-          className="min-w-0 w-max max-w-[calc(50%_-_0.75rem)] shrink-0"
-          text={header.source.label}
-          tooltipText={header.source.exactId ? `${header.source.label} — ${header.source.exactId}` : header.source.label}
-        />
+        <EdgeEndpoint endpoint="source" identity={header.source} />
         <span aria-hidden="true" className="shrink-0">→</span>
-        <MiddleTruncatedText
-          className="min-w-0 w-max max-w-[calc(50%_-_0.75rem)] shrink-0"
-          text={header.target.label}
-          tooltipText={header.target.exactId ? `${header.target.label} — ${header.target.exactId}` : header.target.label}
-        />
+        <EdgeEndpoint endpoint="target" identity={header.target} />
       </div>
       {header.relationship ? (
         <MiddleTruncatedText className="pt-0.5 text-[11px] font-mono font-normal text-muted-foreground" text={header.relationship} />

--- a/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
@@ -1,0 +1,82 @@
+import type { ReactElement } from 'react';
+import { ContextMenuLabel } from '../../../ui/context/menu';
+import type { GraphContextMenuHeader } from '../../contextMenu/contracts';
+import { MiddleTruncatedText } from './middleTruncation';
+
+export function graphContextMenuAccessibleName(header: GraphContextMenuHeader): string {
+  if (header.kind === 'background') return `${header.workspaceName} root`;
+  if (header.kind === 'multiNode') return `${header.count} Nodes selected`;
+  if (header.kind === 'node') {
+    return header.target.exactId
+      ? `${header.target.label}, ${header.target.exactId}`
+      : header.target.label;
+  }
+
+  const source = header.source.exactId
+    ? `${header.source.label}, ${header.source.exactId}`
+    : header.source.label;
+  const target = header.target.exactId
+    ? `${header.target.label}, ${header.target.exactId}`
+    : header.target.label;
+  const endpoints = `${source} to ${target}`;
+  return header.relationship ? `${endpoints}, ${header.relationship}` : endpoints;
+}
+
+function IdentityHeader({ header }: { header: Extract<GraphContextMenuHeader, { kind: 'node' }> }): ReactElement {
+  return (
+    <>
+      <MiddleTruncatedText className="font-semibold text-[var(--cg-menu-foreground)]" text={header.target.label} />
+      {header.target.exactId ? (
+        <MiddleTruncatedText className="pt-0.5 text-[11px] font-normal text-muted-foreground" text={header.target.exactId} />
+      ) : null}
+    </>
+  );
+}
+
+function EdgeHeader({ header }: { header: Extract<GraphContextMenuHeader, { kind: 'edge' }> }): ReactElement {
+  return (
+    <>
+      <div className="flex min-w-0 items-center gap-1 font-semibold text-[var(--cg-menu-foreground)]">
+        <MiddleTruncatedText
+          className="min-w-0 flex-1 text-right"
+          text={header.source.label}
+          tooltipText={header.source.exactId ? `${header.source.label} — ${header.source.exactId}` : header.source.label}
+        />
+        <span aria-hidden="true" className="shrink-0">→</span>
+        <MiddleTruncatedText
+          className="min-w-0 flex-1"
+          text={header.target.label}
+          tooltipText={header.target.exactId ? `${header.target.label} — ${header.target.exactId}` : header.target.label}
+        />
+      </div>
+      {header.relationship ? (
+        <MiddleTruncatedText className="pt-0.5 text-[11px] font-mono font-normal text-muted-foreground" text={header.relationship} />
+      ) : null}
+    </>
+  );
+}
+
+function BackgroundHeader({ header }: { header: Extract<GraphContextMenuHeader, { kind: 'background' }> }): ReactElement {
+  return (
+    <div className="flex min-w-0 items-baseline gap-1">
+      <MiddleTruncatedText className="min-w-0 flex-1 font-semibold text-[var(--cg-menu-foreground)]" text={header.workspaceName} />
+      <span className="shrink-0 text-[11px] font-normal text-muted-foreground">(root)</span>
+    </div>
+  );
+}
+
+export function ViewportContextMenuHeader({ header }: { header: GraphContextMenuHeader }): ReactElement {
+  return (
+    <ContextMenuLabel
+      className="min-w-0 py-1.5 leading-snug"
+      data-context-menu-header={header.kind}
+    >
+      {header.kind === 'background' ? <BackgroundHeader header={header} /> : null}
+      {header.kind === 'edge' ? <EdgeHeader header={header} /> : null}
+      {header.kind === 'multiNode' ? (
+        <p className="font-semibold text-[var(--cg-menu-foreground)]">{header.count} Nodes selected</p>
+      ) : null}
+      {header.kind === 'node' ? <IdentityHeader header={header} /> : null}
+    </ContextMenuLabel>
+  );
+}

--- a/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
@@ -38,13 +38,13 @@ function EdgeHeader({ header }: { header: Extract<GraphContextMenuHeader, { kind
     <>
       <div className="flex min-w-0 items-center gap-1 font-semibold text-[var(--cg-menu-foreground)]">
         <MiddleTruncatedText
-          className="min-w-0 flex-1"
+          className="min-w-0 max-w-[calc(50%-0.75rem)]"
           text={header.source.label}
           tooltipText={header.source.exactId ? `${header.source.label} — ${header.source.exactId}` : header.source.label}
         />
         <span aria-hidden="true" className="shrink-0">→</span>
         <MiddleTruncatedText
-          className="min-w-0 flex-1"
+          className="min-w-0 max-w-[calc(50%-0.75rem)]"
           text={header.target.label}
           tooltipText={header.target.exactId ? `${header.target.label} — ${header.target.exactId}` : header.target.label}
         />

--- a/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/contextMenu/header.tsx
@@ -38,7 +38,7 @@ function EdgeHeader({ header }: { header: Extract<GraphContextMenuHeader, { kind
     <>
       <div className="flex min-w-0 items-center gap-1 font-semibold text-[var(--cg-menu-foreground)]">
         <MiddleTruncatedText
-          className="min-w-0 flex-1 text-right"
+          className="min-w-0 flex-1"
           text={header.source.label}
           tooltipText={header.source.exactId ? `${header.source.label} — ${header.source.exactId}` : header.source.label}
         />

--- a/packages/extension/src/webview/components/graph/viewport/contextMenu/middleTruncation.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/contextMenu/middleTruncation.tsx
@@ -1,0 +1,114 @@
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react';
+import { cn } from '../../../ui/cn';
+
+const ELLIPSIS = '…';
+
+type MeasureText = (value: string) => number;
+
+interface GraphemeSegmenter {
+  segment(value: string): Iterable<{ segment: string }>;
+}
+
+interface GraphemeSegmenterConstructor {
+  new (locales?: string | string[], options?: { granularity: 'grapheme' }): GraphemeSegmenter;
+}
+
+function splitGraphemes(text: string): string[] {
+  const Segmenter = (Intl as typeof Intl & { Segmenter?: GraphemeSegmenterConstructor }).Segmenter;
+  if (!Segmenter) return Array.from(text);
+  return Array.from(
+    new Segmenter(undefined, { granularity: 'grapheme' }).segment(text),
+    entry => entry.segment,
+  );
+}
+
+export function middleTruncateText(
+  text: string,
+  maxWidth: number,
+  measureText: MeasureText,
+): string {
+  if (maxWidth <= 0 || measureText(text) <= maxWidth) return text;
+  if (measureText(ELLIPSIS) > maxWidth) return ELLIPSIS;
+
+  const characters = splitGraphemes(text);
+  let lower = 0;
+  let upper = characters.length;
+  let best = ELLIPSIS;
+
+  while (lower <= upper) {
+    const visibleCharacters = Math.floor((lower + upper) / 2);
+    const startLength = Math.ceil(visibleCharacters / 2);
+    const endLength = Math.floor(visibleCharacters / 2);
+    const start = characters.slice(0, startLength).join('');
+    const end = endLength > 0 ? characters.slice(-endLength).join('') : '';
+    const candidate = `${start}${ELLIPSIS}${end}`;
+
+    if (measureText(candidate) <= maxWidth) {
+      best = candidate;
+      lower = visibleCharacters + 1;
+    } else {
+      upper = visibleCharacters - 1;
+    }
+  }
+
+  return best;
+}
+
+function measureForElement(element: HTMLElement): MeasureText | undefined {
+  const canvas = element.ownerDocument.createElement('canvas');
+  const context = canvas.getContext('2d');
+  if (!context) return undefined;
+  context.font = getComputedStyle(element).font;
+  return value => context.measureText(value).width;
+}
+
+export function MiddleTruncatedText({
+  text,
+  className,
+  tooltipText = text,
+}: {
+  className?: string;
+  text: string;
+  tooltipText?: string;
+}): ReactElement {
+  const elementRef = useRef<HTMLSpanElement>(null);
+  const [displayText, setDisplayText] = useState(text);
+
+  useLayoutEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    const update = (): void => {
+      const width = element.clientWidth;
+      if (width <= 0) {
+        setDisplayText(text);
+        return;
+      }
+      const measureText = measureForElement(element);
+      setDisplayText(measureText ? middleTruncateText(text, width, measureText) : text);
+    };
+
+    update();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [text]);
+
+  const truncated = displayText !== text;
+  return (
+    <span
+      ref={elementRef}
+      className={cn('block min-w-0 overflow-hidden whitespace-nowrap', className)}
+      data-truncated={truncated ? 'true' : undefined}
+      title={truncated ? tooltipText : undefined}
+    >
+      {displayText}
+    </span>
+  );
+}

--- a/packages/extension/src/webview/components/graph/viewport/contextMenu/view.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/contextMenu/view.tsx
@@ -9,6 +9,10 @@ import {
 } from '../../../ui/context/menu';
 import type { GraphContextMenuEntry } from '../../contextMenu/contracts';
 import type { ViewportProps } from '../contracts';
+import {
+  graphContextMenuAccessibleName,
+  ViewportContextMenuHeader,
+} from './header';
 
 export function ViewportContextMenuItems({
   handleMenuAction,
@@ -17,6 +21,9 @@ export function ViewportContextMenuItems({
   return (
     <>
       {menuEntries.map(entry => {
+        if (entry.kind === 'header') {
+          return <ViewportContextMenuHeader key={entry.id} header={entry.header} />;
+        }
         if (entry.kind === 'separator') {
           return <ContextMenuSeparator key={entry.id} />;
         }
@@ -33,9 +40,19 @@ export function ViewportContextMenuItems({
   );
 }
 
+export function graphContextMenuName(menuEntries: readonly GraphContextMenuEntry[]): string | undefined {
+  const headerEntry = menuEntries.find(
+    (entry): entry is Extract<GraphContextMenuEntry, { kind: 'header' }> => entry.kind === 'header',
+  );
+  return headerEntry ? graphContextMenuAccessibleName(headerEntry.header) : undefined;
+}
+
 export function createMenuEntriesSignature(menuEntries: readonly GraphContextMenuEntry[]): string {
   return menuEntries
-    .map(entry => entry.kind === 'separator' ? `${entry.id}:separator` : `${entry.id}:${entry.label}`)
+    .map(entry => {
+      if (entry.kind === 'header') return `${entry.id}:header:${JSON.stringify(entry.header)}`;
+      return entry.kind === 'separator' ? `${entry.id}:separator` : `${entry.id}:${entry.label}`;
+    })
     .join('|');
 }
 

--- a/packages/extension/src/webview/components/graph/viewport/model.ts
+++ b/packages/extension/src/webview/components/graph/viewport/model.ts
@@ -31,6 +31,7 @@ export interface GraphViewportModelOptions {
   appearance?: GraphAppearance;
   viewportRuntime: Pick<UseGraphRenderingRuntimeResult, 'containerSize'>;
   viewState: Pick<GraphViewStoreState, 'favorites'>;
+  workspaceName?: string;
 }
 
 export function useGraphViewportModel({
@@ -41,6 +42,7 @@ export function useGraphViewportModel({
   appearance,
   viewportRuntime,
   viewState,
+  workspaceName,
 }: GraphViewportModelOptions): GraphViewportModel {
   const sharedProps = useMemo(
     () => buildSharedGraphProps({
@@ -69,6 +71,7 @@ export function useGraphViewportModel({
     selection: graphState.contextSelection,
     favorites: viewState.favorites,
     graphViewContributions,
+    workspaceName,
     nodes: graphState.graphData.nodes,
     edges: graphState.graphData.links,
   });

--- a/packages/extension/src/webview/components/graph/viewport/shell.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/shell.tsx
@@ -38,6 +38,7 @@ export interface GraphViewportShellProps {
   pluginHost?: WebviewPluginHost;
   theme: ThemeKind;
   viewState: GraphViewStoreState;
+  workspaceName?: string;
 }
 
 export function GraphViewportShell({
@@ -51,6 +52,7 @@ export function GraphViewportShell({
   pluginHost,
   theme,
   viewState,
+  workspaceName,
 }: GraphViewportShellProps): ReactElement {
   const lastPublishedViewportScaleRef = useRef<number | null>(null);
   const lastAccessibilitySignatureRef = useRef('');
@@ -96,6 +98,7 @@ export function GraphViewportShell({
     interactions,
     viewportRuntime,
     viewState,
+    workspaceName,
   });
 
   const publishGraphViewportScale = (globalScale: number): void => {

--- a/packages/extension/src/webview/components/graph/viewport/view.tsx
+++ b/packages/extension/src/webview/components/graph/viewport/view.tsx
@@ -8,6 +8,7 @@ import { NodeTooltip } from '../../nodeTooltip/view';
 import { GraphAccessibilityOverlay } from './accessibilityLayer/overlay';
 import {
   createMenuEntriesSignature,
+  graphContextMenuName,
   ViewportContextMenuItems,
 } from './contextMenu/view';
 import type { GraphAccessibilityItems } from './accessibility';
@@ -50,6 +51,7 @@ export function Viewport({
   pluginHost,
 }: ViewportProps): ReactElement {
   const menuEntriesSignature = createMenuEntriesSignature(menuEntries);
+  const menuName = graphContextMenuName(menuEntries);
 
   return (
     <ContextMenu>
@@ -92,7 +94,12 @@ export function Viewport({
         </div>
       </ContextMenuTrigger>
 
-      <ContextMenuContent key={menuEntriesSignature} data-menu-entries-signature={menuEntriesSignature} className="w-64">
+      <ContextMenuContent
+        aria-label={menuName}
+        key={menuEntriesSignature}
+        data-menu-entries-signature={menuEntriesSignature}
+        className="w-64"
+      >
         <ViewportContextMenuItems
           handleMenuAction={handleMenuAction}
           menuEntries={menuEntries}

--- a/packages/extension/tests/acceptance/cucumber/steps.ts
+++ b/packages/extension/tests/acceptance/cucumber/steps.ts
@@ -81,6 +81,8 @@ Step(/^I right click the (.+) node to open its Graph Context Menu$/);
 Step(/^I right click the graph background to open its Graph Context Menu$/);
 Step(/^I right click one of the folder nodes to open its Graph Context Menu$/);
 Step(/^I right click one of the selected nodes to open its Graph Context Menu$/);
+Step(/^I see "(.+)" in the Graph Context Menu header$/);
+Step(/^the Graph Context Menu accessible name includes "(.+)"$/);
 Step(/^I see the "(.+)" entry$/);
 Step(/^I see the "Open x Files" entry, where x is the number of selected nodes$/);
 Step(/^I see the "Delete x Files" entry, where x is the number of selected nodes$/);

--- a/packages/extension/tests/acceptance/graphView/steps.ts
+++ b/packages/extension/tests/acceptance/graphView/steps.ts
@@ -646,6 +646,14 @@ const patternGraphViewAcceptanceSteps: PatternAcceptanceStep[] = [
     await rightClickNode(context, TARGET_NODE);
   }),
 
+  step(/^I see "(.+)" in the Graph Context Menu header$/, async (context, _step, match) => {
+    await expectContextMenuHeaderText(context, match[1]);
+  }),
+
+  step(/^the Graph Context Menu accessible name includes "(.+)"$/, async (context, _step, match) => {
+    await expectContextMenuAccessibleName(context, match[1]);
+  }),
+
   step(/^I see the "(.+)" entry$/, async (context, _step, match) => {
     await expectContextMenuEntry(context, match[1]);
   }),
@@ -1233,6 +1241,25 @@ async function waitForIndexingToFinish(context: GraphAcceptanceContext): Promise
 async function readZoomScaleMetric(context: GraphAcceptanceContext): Promise<number> {
   return await readGraphDebugZoom(requireGraphFrame(context))
     ?? readScreenDistanceBetweenNodes(context, TARGET_NODE, 'src/palette.ts');
+}
+
+async function expectContextMenuHeaderText(
+  context: GraphAcceptanceContext,
+  text: string,
+): Promise<void> {
+  const header = requireGraphFrame(context).locator('[data-context-menu-header]');
+  await expect(header).toBeVisible();
+  await expect(header).toContainText(text);
+}
+
+async function expectContextMenuAccessibleName(
+  context: GraphAcceptanceContext,
+  text: string,
+): Promise<void> {
+  const menu = requireGraphFrame(context).getByRole('menu', {
+    name: new RegExp(escapeRegExp(text), 'i'),
+  });
+  await expect(menu).toBeVisible();
 }
 
 async function expectContextMenuEntry(context: GraphAcceptanceContext, label: string): Promise<void> {

--- a/packages/extension/tests/acceptance/specs/background-context-menu.feature
+++ b/packages/extension/tests/acceptance/specs/background-context-menu.feature
@@ -10,7 +10,7 @@ And I see edges
 And the graph nodes match the expected files in the examples/example-typescript workspace
 
 When I right click the graph background to open its Graph Context Menu
-And I see "example-typescript" in the Graph Context Menu header
+And I see "example-typescript/" in the Graph Context Menu header
 And I see "(root)" in the Graph Context Menu header
 And I see the "New File" entry
 And I see the "New Folder" entry

--- a/packages/extension/tests/acceptance/specs/background-context-menu.feature
+++ b/packages/extension/tests/acceptance/specs/background-context-menu.feature
@@ -10,6 +10,8 @@ And I see edges
 And the graph nodes match the expected files in the examples/example-typescript workspace
 
 When I right click the graph background to open its Graph Context Menu
+And I see "example-typescript" in the Graph Context Menu header
+And I see "(root)" in the Graph Context Menu header
 And I see the "New File" entry
 And I see the "New Folder" entry
 And I see the "Re-index Workspace" entry

--- a/packages/extension/tests/acceptance/specs/edge-context-menu.feature
+++ b/packages/extension/tests/acceptance/specs/edge-context-menu.feature
@@ -10,6 +10,11 @@ And I see edges
 And the graph nodes match the expected files in the examples/example-typescript workspace
 
 When I right click the edge going from src/index.ts node to src/types.ts node to open its Graph Context Menu
+And I see "index.ts" in the Graph Context Menu header
+And I see "types.ts" in the Graph Context Menu header
+And I see "import" in the Graph Context Menu header
+And the Graph Context Menu accessible name includes "src/index.ts"
+And the Graph Context Menu accessible name includes "src/types.ts"
 And I see the "Open Source" entry
 And I see the "Open Target" entry
 And I see the "Copy Source Path" entry

--- a/packages/extension/tests/acceptance/specs/file-context-menu.feature
+++ b/packages/extension/tests/acceptance/specs/file-context-menu.feature
@@ -10,6 +10,8 @@ And I see edges
 And the graph nodes match the expected files in the examples/example-typescript workspace
 
 When I right click the src/index.ts node to open its Graph Context Menu
+And I see "index.ts" in the Graph Context Menu header
+And I see "src/index.ts" in the Graph Context Menu header
 And I see the "Open File" entry
 And I see the "Reveal in Explorer" entry
 And I see the "Copy Relative Path" entry

--- a/packages/extension/tests/acceptance/specs/folder-context-menu.feature
+++ b/packages/extension/tests/acceptance/specs/folder-context-menu.feature
@@ -24,7 +24,7 @@ And the Nests edge is toggled on
 And I can see there are 21 nodes and 31 connections displayed
 
 And I right click one of the folder nodes to open its Graph Context Menu
-And I see "src" in the Graph Context Menu header
+And I see "src/" in the Graph Context Menu header
 And I see the "New File" entry
 And I see the "New Folder" entry
 And I see the "Reveal in explorer" entry

--- a/packages/extension/tests/acceptance/specs/folder-context-menu.feature
+++ b/packages/extension/tests/acceptance/specs/folder-context-menu.feature
@@ -24,6 +24,7 @@ And the Nests edge is toggled on
 And I can see there are 21 nodes and 31 connections displayed
 
 And I right click one of the folder nodes to open its Graph Context Menu
+And I see "src" in the Graph Context Menu header
 And I see the "New File" entry
 And I see the "New Folder" entry
 And I see the "Reveal in explorer" entry

--- a/packages/extension/tests/acceptance/specs/multi-node-context-menu.feature
+++ b/packages/extension/tests/acceptance/specs/multi-node-context-menu.feature
@@ -13,6 +13,7 @@ When I click and drag on the background I can select multiple nodes at once
 Then I see all the selected nodes outlined in white
 
 When I right click one of the selected nodes to open its Graph Context Menu
+And I see "2 Nodes selected" in the Graph Context Menu header
 And I see the "Open x Files" entry, where x is the number of selected nodes
 And I see the "Copy Relative Paths" entry
 And I see the "Add All to Favorites" entry

--- a/packages/extension/tests/extension/graphView/provider/webview/defaultDependencies.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/webview/defaultDependencies.test.ts
@@ -108,6 +108,7 @@ describe('graphView/provider/webview/defaultDependencies', () => {
       'nonce-123',
       'light',
       false,
+      undefined,
     );
   });
 

--- a/packages/extension/tests/extension/graphView/provider/webview/hostDefaultDependencies.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/webview/hostDefaultDependencies.test.ts
@@ -122,6 +122,7 @@ describe('graphView/provider/webview/host default dependencies', () => {
       'nonce-123',
       'light',
       false,
+      undefined,
     );
     expect(mocks.setGraphViewProviderMessageListener).toHaveBeenCalledWith(
       nextWebview,
@@ -178,6 +179,7 @@ describe('graphView/provider/webview/host default dependencies', () => {
       'nonce-123',
       'light',
       false,
+      undefined,
     );
   });
 });

--- a/packages/extension/tests/extension/graphView/webview/html.test.ts
+++ b/packages/extension/tests/extension/graphView/webview/html.test.ts
@@ -37,6 +37,22 @@ describe('graphView/webview/html', () => {
     expect(html).toContain('<div id="root"></div>');
   });
 
+  it('exposes an escaped workspace name to the webview', () => {
+    const html = createGraphViewHtml(
+      vscode.Uri.file('/test/extension'),
+      {
+        cspSource: 'vscode-webview://test',
+        asWebviewUri: vi.fn((uri: vscode.Uri) => `webview:${uri.fsPath}`),
+      } as unknown as vscode.Webview,
+      'nonce-value',
+      'dark',
+      false,
+      'Code & "Graph"',
+    );
+
+    expect(html).toContain('data-codegraphy-workspace-name="Code &amp; &quot;Graph&quot;"');
+  });
+
   it('marks the graph debug bridge as enabled when requested', () => {
     const html = createGraphViewHtml(
       vscode.Uri.file('/test/extension'),

--- a/packages/extension/tests/webview/graph/contextMenu/background/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/background/view.test.tsx
@@ -76,10 +76,10 @@ describe('Graph context menu (background)', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('example-typescript')).toBeInTheDocument();
+      expect(screen.getByText('example-typescript/')).toBeInTheDocument();
     });
     expect(screen.getByText('(root)')).toBeInTheDocument();
-    expect(screen.getByRole('menu')).toHaveAccessibleName('example-typescript root');
+    expect(screen.getByRole('menu')).toHaveAccessibleName('example-typescript/ root');
   });
 
   it('falls back to background menu when only container contextmenu event fires', async () => {

--- a/packages/extension/tests/webview/graph/contextMenu/background/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/background/view.test.tsx
@@ -68,6 +68,20 @@ describe('Graph context menu (background)', () => {
     });
   });
 
+  it('shows the workspace name and root context above background actions', async () => {
+    render(<Graph data={menuData} workspaceName="example-typescript" />);
+
+    await act(async () => {
+      OwnedGraphSurface.simulateBackgroundRightClick();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('example-typescript')).toBeInTheDocument();
+    });
+    expect(screen.getByText('(root)')).toBeInTheDocument();
+    expect(screen.getByRole('menu')).toHaveAccessibleName('example-typescript root');
+  });
+
   it('falls back to background menu when only container contextmenu event fires', async () => {
     const { container } = render(<Graph data={menuData} />);
     const graphContainer = getGraphContainer(container);

--- a/packages/extension/tests/webview/graph/contextMenu/build/background.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/build/background.test.ts
@@ -9,10 +9,16 @@ describe('graph/contextMenu/build/background', () => {
     const entries = buildGraphContextMenuEntries({
       selection: makeBackgroundContextSelection(),
       favorites: new Set(),
+      workspaceName: 'example-typescript',
     });
 
-    expect(entries).toHaveLength(5);
+    expect(entries).toHaveLength(7);
     expect(entries).toMatchObject([
+      {
+        kind: 'header',
+        header: { kind: 'background', workspaceName: 'example-typescript' },
+      },
+      { kind: 'separator' },
       { kind: 'item', label: 'New File', disabled: false },
       { kind: 'item', label: 'New Folder', disabled: false },
       { kind: 'separator' },

--- a/packages/extension/tests/webview/graph/contextMenu/build/background.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/build/background.test.ts
@@ -16,7 +16,7 @@ describe('graph/contextMenu/build/background', () => {
     expect(entries).toMatchObject([
       {
         kind: 'header',
-        header: { kind: 'background', workspaceName: 'example-typescript' },
+        header: { kind: 'background', workspaceName: 'example-typescript/' },
       },
       { kind: 'separator' },
       { kind: 'item', label: 'New File', disabled: false },

--- a/packages/extension/tests/webview/graph/contextMenu/build/edge.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/build/edge.test.ts
@@ -11,8 +11,16 @@ describe('graph/contextMenu/build/edge', () => {
       favorites: new Set(),
     });
 
-    expect(entries).toHaveLength(5);
     expect(entries).toMatchObject([
+      {
+        kind: 'header',
+        header: {
+          kind: 'edge',
+          source: { label: 'src/a.ts' },
+          target: { label: 'src/b.ts' },
+        },
+      },
+      { kind: 'separator' },
       { kind: 'item', label: 'Open Source' },
       { kind: 'item', label: 'Open Target' },
       { kind: 'item', label: 'Copy Source Path' },

--- a/packages/extension/tests/webview/graph/contextMenu/build/node.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/build/node.test.ts
@@ -53,8 +53,18 @@ describe('graph/contextMenu/build/node', () => {
     const entries = buildGraphContextMenuEntries({
       selection: makeNodeContextSelection('src/app.ts', new Set()),
       favorites: new Set(),
+      nodes: [{ id: 'src/app.ts', label: 'App' }],
     });
 
+    expect(entries[0]).toEqual({
+      kind: 'header',
+      id: 'context-target-header',
+      header: {
+        kind: 'node',
+        target: { label: 'App', exactId: 'src/app.ts' },
+      },
+    });
+    expect(entries[1]).toMatchObject({ kind: 'separator' });
     expect(itemLabels(entries)).toContain('Open File');
     expect(itemLabels(entries)).toContain('Delete File');
   });
@@ -76,6 +86,10 @@ describe('graph/contextMenu/build/node', () => {
       favorites: new Set(),
     });
 
+    expect(entries[0]).toMatchObject({
+      kind: 'header',
+      header: { kind: 'multiNode', count: 2 },
+    });
     expect(itemLabels(entries)).toHaveLength(5);
     expect(itemLabels(entries)).toEqual([
       'Open 2 Files',

--- a/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
@@ -77,18 +77,18 @@ describe('Graph context menu (edge)', () => {
         'app.ts, src/app.ts to utils.ts, src/utils.ts, import',
       );
     });
-    expect(screen.getByText('app.ts')).toBeInTheDocument();
-    expect(screen.getByText('app.ts')).not.toHaveClass('text-right', 'flex-1');
-    expect(screen.getByText('app.ts')).toHaveClass(
-      'w-max',
+    const sourceEndpoint = document.querySelector('[data-edge-header-endpoint="source"]');
+    const targetEndpoint = document.querySelector('[data-edge-header-endpoint="target"]');
+    expect(sourceEndpoint).toHaveClass(
+      'inline-grid',
       'max-w-[calc(50%_-_0.75rem)]',
-      'shrink-0',
     );
-    expect(screen.getByText('utils.ts')).toHaveClass(
-      'w-max',
+    expect(targetEndpoint).toHaveClass(
+      'inline-grid',
       'max-w-[calc(50%_-_0.75rem)]',
-      'shrink-0',
     );
+    expect(sourceEndpoint?.querySelector('.w-full')).toHaveTextContent('app.ts');
+    expect(targetEndpoint?.querySelector('.w-full')).toHaveTextContent('utils.ts');
     expect(screen.getByText('import')).toBeInTheDocument();
   });
 

--- a/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
@@ -65,6 +65,23 @@ describe('Graph context menu (edge)', () => {
     expect(screen.getByText('Copy Both Paths')).toBeInTheDocument();
   });
 
+  it('shows both endpoint names and the relationship above edge actions', async () => {
+    render(<Graph data={menuData} />);
+
+    await act(async () => {
+      OwnedGraphSurface.simulateLinkRightClick(edge);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('menu')).toHaveAccessibleName(
+        'app.ts, src/app.ts to utils.ts, src/utils.ts, import',
+      );
+    });
+    expect(screen.getByText('app.ts')).toBeInTheDocument();
+    expect(screen.getByText('utils.ts')).toBeInTheDocument();
+    expect(screen.getByText('import')).toBeInTheDocument();
+  });
+
   it('shows edge menu items from mac ctrl+click in 2d (same as right-click)', async () => {
     const platformSpy = mockMacPlatform();
     try {

--- a/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
@@ -78,6 +78,7 @@ describe('Graph context menu (edge)', () => {
       );
     });
     expect(screen.getByText('app.ts')).toBeInTheDocument();
+    expect(screen.getByText('app.ts')).not.toHaveClass('text-right');
     expect(screen.getByText('utils.ts')).toBeInTheDocument();
     expect(screen.getByText('import')).toBeInTheDocument();
   });

--- a/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
@@ -78,8 +78,9 @@ describe('Graph context menu (edge)', () => {
       );
     });
     expect(screen.getByText('app.ts')).toBeInTheDocument();
-    expect(screen.getByText('app.ts')).not.toHaveClass('text-right');
-    expect(screen.getByText('utils.ts')).toBeInTheDocument();
+    expect(screen.getByText('app.ts')).not.toHaveClass('text-right', 'flex-1');
+    expect(screen.getByText('app.ts')).toHaveClass('max-w-[calc(50%-0.75rem)]');
+    expect(screen.getByText('utils.ts')).toHaveClass('max-w-[calc(50%-0.75rem)]');
     expect(screen.getByText('import')).toBeInTheDocument();
   });
 

--- a/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
@@ -80,10 +80,12 @@ describe('Graph context menu (edge)', () => {
     expect(screen.getByText('app.ts')).toBeInTheDocument();
     expect(screen.getByText('app.ts')).not.toHaveClass('text-right', 'flex-1');
     expect(screen.getByText('app.ts')).toHaveClass(
+      'w-max',
       'max-w-[calc(50%_-_0.75rem)]',
       'shrink-0',
     );
     expect(screen.getByText('utils.ts')).toHaveClass(
+      'w-max',
       'max-w-[calc(50%_-_0.75rem)]',
       'shrink-0',
     );

--- a/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/edge/view.test.tsx
@@ -79,8 +79,14 @@ describe('Graph context menu (edge)', () => {
     });
     expect(screen.getByText('app.ts')).toBeInTheDocument();
     expect(screen.getByText('app.ts')).not.toHaveClass('text-right', 'flex-1');
-    expect(screen.getByText('app.ts')).toHaveClass('max-w-[calc(50%-0.75rem)]');
-    expect(screen.getByText('utils.ts')).toHaveClass('max-w-[calc(50%-0.75rem)]');
+    expect(screen.getByText('app.ts')).toHaveClass(
+      'max-w-[calc(50%_-_0.75rem)]',
+      'shrink-0',
+    );
+    expect(screen.getByText('utils.ts')).toHaveClass(
+      'max-w-[calc(50%_-_0.75rem)]',
+      'shrink-0',
+    );
     expect(screen.getByText('import')).toBeInTheDocument();
   });
 

--- a/packages/extension/tests/webview/graph/contextMenu/header/middleTruncation.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/header/middleTruncation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { middleTruncateText } from '../../../../../src/webview/components/graph/viewport/contextMenu/middleTruncation';
+
+const measureCharacters = (value: string): number => value.length;
+
+describe('graph/contextMenu/header/middleTruncation', () => {
+  it('keeps text unchanged when it fits', () => {
+    expect(middleTruncateText('src/app.ts', 10, measureCharacters)).toBe('src/app.ts');
+  });
+
+  it('preserves both ends when text is too wide', () => {
+    const result = middleTruncateText(
+      'src/features/settings/AccountSecurityPanel.tsx',
+      20,
+      measureCharacters,
+    );
+
+    expect(result).toHaveLength(20);
+    expect(result.startsWith('src/featur')).toBe(true);
+    expect(result.endsWith('Panel.tsx')).toBe(true);
+    expect(result).toContain('…');
+  });
+
+  it('keeps Unicode endpoint characters intact', () => {
+    expect(middleTruncateText('🌳-workspace-🚀', 8, measureCharacters)).toMatch(/^🌳.*🚀$/u);
+    expect(middleTruncateText('👨‍👩‍👧‍👦-workspace', 15, measureCharacters)).toMatch(/^👨‍👩‍👧‍👦.*e$/u);
+  });
+
+  it('uses only an ellipsis when no other text fits', () => {
+    expect(middleTruncateText('target', 1, measureCharacters)).toBe('…');
+  });
+});

--- a/packages/extension/tests/webview/graph/contextMenu/header/middleTruncation.view.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/header/middleTruncation.view.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MiddleTruncatedText } from '../../../../../src/webview/components/graph/viewport/contextMenu/middleTruncation';
+
+describe('graph/contextMenu/header/MiddleTruncatedText', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the full identity as a title only when the visible name is truncated', () => {
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(10);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      font: '',
+      measureText: (value: string) => ({ width: value.length }),
+    } as never);
+
+    const { container, rerender } = render(
+      <MiddleTruncatedText
+        text="AccountSecurityPanel.tsx"
+        tooltipText="AccountSecurityPanel.tsx — src/components/AccountSecurityPanel.tsx"
+      />,
+    );
+
+    const truncated = container.querySelector('span');
+    expect(truncated).not.toBeNull();
+    expect(truncated).toHaveTextContent(/^Accou…\.tsx$/);
+    expect(truncated).toHaveAttribute(
+      'title',
+      'AccountSecurityPanel.tsx — src/components/AccountSecurityPanel.tsx',
+    );
+
+    rerender(<MiddleTruncatedText text="App.ts" />);
+    expect(container.querySelector('span')).not.toHaveAttribute('title');
+  });
+});

--- a/packages/extension/tests/webview/graph/contextMenu/header/model.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/header/model.test.ts
@@ -25,6 +25,20 @@ describe('graph/contextMenu/header/model', () => {
     )).toEqual({ kind: 'node', target: { label: 'src/app.ts' } });
   });
 
+  it('ends folder identities with one slash', () => {
+    expect(buildGraphContextMenuHeader(
+      { kind: 'node', targets: ['src'] },
+      { nodes: [{ id: 'src', label: 'src', nodeType: 'folder' }] },
+    )).toEqual({ kind: 'node', target: { label: 'src/' } });
+    expect(buildGraphContextMenuHeader(
+      { kind: 'node', targets: ['src/components/'] },
+      { nodes: [{ id: 'src/components/', label: 'Components/', nodeType: 'folder' }] },
+    )).toEqual({
+      kind: 'node',
+      target: { label: 'Components/', exactId: 'src/components/' },
+    });
+  });
+
   it('falls back to the exact id when node metadata or a usable label is unavailable', () => {
     expect(buildGraphContextMenuHeader(
       { kind: 'node', targets: ['src/missing.ts'] },
@@ -136,11 +150,11 @@ describe('graph/contextMenu/header/model', () => {
   it('uses the workspace name for background context and falls back safely', () => {
     expect(buildGraphContextMenuHeader(
       { kind: 'background', targets: [] },
-      { workspaceName: 'CodeGraphyV4' },
-    )).toEqual({ kind: 'background', workspaceName: 'CodeGraphyV4' });
+      { workspaceName: 'CodeGraphyV4/' },
+    )).toEqual({ kind: 'background', workspaceName: 'CodeGraphyV4/' });
     expect(buildGraphContextMenuHeader(
       { kind: 'background', targets: [] },
       { workspaceName: '  ' },
-    )).toEqual({ kind: 'background', workspaceName: 'Workspace' });
+    )).toEqual({ kind: 'background', workspaceName: 'Workspace/' });
   });
 });

--- a/packages/extension/tests/webview/graph/contextMenu/header/model.test.ts
+++ b/packages/extension/tests/webview/graph/contextMenu/header/model.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { buildGraphContextMenuHeader } from '../../../../../src/webview/components/graph/contextMenu/header/model';
+import type { GraphContextSelection } from '../../../../../src/webview/components/graph/contextMenu/contracts';
+
+const nodes = [
+  { id: 'src/app.ts', label: ' App ' },
+  { id: 'src/utils.ts', label: 'Utils' },
+];
+
+describe('graph/contextMenu/header/model', () => {
+  it('identifies one node by display label and exact id', () => {
+    expect(buildGraphContextMenuHeader(
+      { kind: 'node', targets: ['src/app.ts'] },
+      { nodes },
+    )).toEqual({
+      kind: 'node',
+      target: { label: 'App', exactId: 'src/app.ts' },
+    });
+  });
+
+  it('omits the secondary identity when the displayed label already equals the id', () => {
+    expect(buildGraphContextMenuHeader(
+      { kind: 'node', targets: ['src/app.ts'] },
+      { nodes: [{ id: 'src/app.ts', label: 'src/app.ts' }] },
+    )).toEqual({ kind: 'node', target: { label: 'src/app.ts' } });
+  });
+
+  it('falls back to the exact id when node metadata or a usable label is unavailable', () => {
+    expect(buildGraphContextMenuHeader(
+      { kind: 'node', targets: ['src/missing.ts'] },
+      { nodes },
+    )).toEqual({ kind: 'node', target: { label: 'src/missing.ts' } });
+    expect(buildGraphContextMenuHeader(
+      { kind: 'node', targets: ['src/unlabelled.ts'] },
+      { nodes: [{ id: 'src/unlabelled.ts' }] },
+    )).toEqual({ kind: 'node', target: { label: 'src/unlabelled.ts' } });
+    expect(buildGraphContextMenuHeader(
+      { kind: 'node', targets: ['src/blank.ts'] },
+      { nodes: [{ id: 'src/blank.ts', label: '   ' }] },
+    )).toEqual({ kind: 'node', target: { label: 'src/blank.ts' } });
+  });
+
+  it('summarizes a multi-node context without listing node kinds or names', () => {
+    expect(buildGraphContextMenuHeader(
+      { kind: 'node', targets: ['src/app.ts', 'src/utils.ts'] },
+      { nodes },
+    )).toEqual({ kind: 'multiNode', count: 2 });
+  });
+
+  it('identifies an edge by both endpoint labels and its relationship', () => {
+    expect(buildGraphContextMenuHeader(
+      {
+        kind: 'edge',
+        edgeId: 'src/app.ts->src/utils.ts',
+        targets: ['src/app.ts', 'src/utils.ts'],
+      },
+      {
+        nodes,
+        edges: [
+          { id: 'unrelated', kind: 'reference' },
+          { id: 'src/app.ts->src/utils.ts', kind: ' import ' },
+        ],
+      },
+    )).toEqual({
+      kind: 'edge',
+      source: { label: 'App', exactId: 'src/app.ts' },
+      target: { label: 'Utils', exactId: 'src/utils.ts' },
+      relationship: 'import',
+    });
+  });
+
+  it('reads the relationship from the visible combined Edge', () => {
+    expect(buildGraphContextMenuHeader(
+      {
+        kind: 'edge',
+        edgeId: 'a->b#import',
+        visibleEdgeId: 'a<->b#import',
+        targets: ['a', 'b'],
+      },
+      { edges: [{ id: 'a<->b#import', kind: 'import' }] },
+    )).toMatchObject({ relationship: 'import' });
+  });
+
+  it('uses a trimmed runtime Edge Type when the built-in kind is blank', () => {
+    expect(buildGraphContextMenuHeader(
+      { kind: 'edge', edgeId: 'edge', targets: ['source', 'target'] },
+      { edges: [{ id: 'edge', kind: ' ', runtimeEdgeType: ' plugin-link ' }] },
+    )).toMatchObject({ relationship: 'plugin-link' });
+  });
+
+  it('rejects edge and node selections that do not identify complete targets', () => {
+    expect(buildGraphContextMenuHeader(
+      { kind: 'edge', edgeId: 'edge', targets: ['source'] },
+      {},
+    )).toBeUndefined();
+    expect(buildGraphContextMenuHeader(
+      { kind: 'edge', edgeId: 'edge', targets: ['', 'target'] },
+      {},
+    )).toBeUndefined();
+    expect(buildGraphContextMenuHeader(
+      { kind: 'node', targets: [] },
+      {},
+    )).toBeUndefined();
+  });
+
+  it('omits the relationship line when edge type metadata is unavailable', () => {
+    const selection: GraphContextSelection = {
+      kind: 'edge',
+      edgeId: 'edge',
+      targets: ['source', 'target'],
+    };
+    expect(buildGraphContextMenuHeader(selection, {})).toEqual({
+      kind: 'edge',
+      source: { label: 'source' },
+      target: { label: 'target' },
+      relationship: undefined,
+    });
+    expect(buildGraphContextMenuHeader(selection, {
+      edges: [{ id: 'edge' }],
+    })).toEqual({
+      kind: 'edge',
+      source: { label: 'source' },
+      target: { label: 'target' },
+      relationship: undefined,
+    });
+    expect(buildGraphContextMenuHeader(selection, {
+      edges: [{ id: 'edge', kind: ' ' }],
+    })).toEqual({
+      kind: 'edge',
+      source: { label: 'source' },
+      target: { label: 'target' },
+      relationship: undefined,
+    });
+  });
+
+  it('uses the workspace name for background context and falls back safely', () => {
+    expect(buildGraphContextMenuHeader(
+      { kind: 'background', targets: [] },
+      { workspaceName: 'CodeGraphyV4' },
+    )).toEqual({ kind: 'background', workspaceName: 'CodeGraphyV4' });
+    expect(buildGraphContextMenuHeader(
+      { kind: 'background', targets: [] },
+      { workspaceName: '  ' },
+    )).toEqual({ kind: 'background', workspaceName: 'Workspace' });
+  });
+});

--- a/packages/extension/tests/webview/graph/contextMenu/node/view/opening.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/node/view/opening.test.tsx
@@ -30,6 +30,20 @@ describe('Graph node context menu opening', () => {
     });
   });
 
+  it('shows the node name and exact id above node actions', async () => {
+    render(<Graph data={menuData} />);
+
+    await act(async () => {
+      OwnedGraphSurface.simulateNodeRightClick({ id: 'src/app.ts' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('menu')).toHaveAccessibleName('app.ts, src/app.ts');
+    });
+    expect(screen.getByText('app.ts')).toBeInTheDocument();
+    expect(screen.getByText('src/app.ts')).toBeInTheDocument();
+  });
+
   it('treats mac ctrl+click as right-click in 2d', async () => {
     const platformSpy = mockMacPlatform();
     try {

--- a/packages/extension/tests/webview/graph/contextMenu/node/view/selectionActions.test.tsx
+++ b/packages/extension/tests/webview/graph/contextMenu/node/view/selectionActions.test.tsx
@@ -26,6 +26,8 @@ describe('Graph node context menu selection actions', () => {
       expect(screen.getByText('Open 2 Files')).toBeInTheDocument();
     });
 
+    expect(screen.getByText('2 Nodes selected')).toBeInTheDocument();
+    expect(screen.getByRole('menu')).toHaveAccessibleName('2 Nodes selected');
     expect(screen.getByText('Copy Relative Paths')).toBeInTheDocument();
     expect(screen.getByText('Add All to Favorites')).toBeInTheDocument();
     expect(screen.getByText('Add Filter Patterns')).toBeInTheDocument();

--- a/packages/extension/tests/webview/graph/interactionRuntime/handlers/contextMenu.test.ts
+++ b/packages/extension/tests/webview/graph/interactionRuntime/handlers/contextMenu.test.ts
@@ -245,10 +245,41 @@ describe('graph/contextMenuHandlers', () => {
 
     expect(dependencies.setContextSelection).toHaveBeenCalledWith({
       edgeId: 'src/app.ts->src/utils.ts',
+      visibleEdgeId: 'src/app.ts->src/utils.ts',
       kind: 'edge',
       targets: ['src/app.ts', 'src/utils.ts'],
     });
     expect(dispatchEvent).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the visible Edge id when combined Edge actions target a raw Relationship', () => {
+    const dependencies = createInteractionDependencies();
+    dependencies.dataRef.current.edges = [
+      { id: 'a->b#import', from: 'a', to: 'b', kind: 'import', sources: [] },
+      { id: 'b->a#import', from: 'b', to: 'a', kind: 'import', sources: [] },
+    ];
+    const handlers = createContextMenuHandlers(
+      dependencies,
+      createContextMenuSelectionHandlers(dependencies),
+    );
+
+    handlers.openEdgeContextMenu(
+      {
+        id: 'a<->b#import',
+        from: 'a',
+        to: 'b',
+        source: 'a',
+        target: 'b',
+      } as unknown as FGLink,
+      new MouseEvent('contextmenu', { button: 2, buttons: 2 }),
+    );
+
+    expect(dependencies.setContextSelection).toHaveBeenCalledWith({
+      edgeId: 'a->b#import',
+      visibleEdgeId: 'a<->b#import',
+      kind: 'edge',
+      targets: ['a', 'b'],
+    });
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- identify the captured Node, Edge, multi-node selection, or workspace root above every Graph Context Menu's actions
- show exact Node/endpoint identities when they differ from display labels, with grapheme-safe middle truncation and full text on truncation
- expose the complete context through the menu's accessible name
- preserve relationship metadata for combined bidirectional Edges while keeping action targeting on the raw Edge
- propagate the workspace folder name to the webview, with `Workspace (root)` as the fallback

Trello: https://trello.com/c/Amzin9Cq

## Checks

- [x] Tests added/updated for new functionality
- [x] Documentation updated
- [x] Targeted ESLint passes
- [x] Extension type checking passes
- [x] Focused webview tests: 359 passed
- [x] Focused extension-host tests: 9 passed
- [x] Sidebar Graph View Playwright acceptance tests: 5 passed on VS Code 1.129.1
- [x] Scoped mutation testing for the header model: 100% mutation score, 0 survivors
- [x] Independent follow-up review found no remaining blockers

## Test-environment note

The default downloaded VS Code 1.131.0 bundle currently fails before extension launch because the local `@vscode/test-electron` path expects `Contents/MacOS/Electron`, while the downloaded application contains `Contents/MacOS/Code`. The focused acceptance scenarios were therefore run with `CODEGRAPHY_VSCODE_TEST_VERSION=1.129.1` and all passed.

## Visual proof

Captured from the Sidebar Graph View against this branch with the focused VS Code Playwright scenarios (5/5 passed):

![Context-menu target headers for file, folder, edge, multi-node selection, and workspace background](https://github.com/user-attachments/assets/6a1ae630-f920-46c1-aa64-a3310332edb1)

