### PR TITLE
Limit Vercel deployments to main

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "cd ../.. && pnpm exec turbo run build --filter=@codegraphy/web",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  }
 }


### PR DESCRIPTION
## What changed

- Disable automatic Vercel Git deployments for every branch except `main`.
- Keep the existing production deployment after changes merge to `main`.

## Why

Vercel creates an authorization-failed deployment check for pull requests from external forks before it determines whether the website is affected. This means package-only contributions still require a maintainer to authorize an unnecessary website preview.

CodeGraphy does not require automatic website previews for pull requests. Limiting deployments to `main` removes that contributor-facing failure while preserving the production deployment workflow.

## Impact

- Pull requests no longer create Vercel preview deployments.
- Merges and direct pushes to `main` continue to deploy the website.
- Local website development remains unchanged.

## Verification

- `jq empty apps/web/vercel.json`
- `pnpm --filter @codegraphy/web build`
- `git diff --check`
