### PR TITLE
docs: codify autonomous delivery workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,12 @@ The graph renderer draws Nodes with WebGPU and runs force and collision physics 
 
 Use the focused workspaces in `examples/` to inspect and validate language and plugin behavior end to end. Keep each example small enough that a person can understand the expected files, Nodes, and Relationships.
 
+## Deliver through pull requests
+
+Authorization to implement a task includes authorization to use the complete repository workflow. Do not ask separately for permission to commit, push, create or update a pull request, interact with Trello or GitHub, or inspect CI. The user has already granted full development permissions for these actions.
+
+Work on a branch or isolated worktree. Commit coherent checkpoints and push them frequently. Open or update a draft pull request early, link the Trello card or issue, and keep checking CI while useful work continues. Before ending a coding task, ensure the latest task changes are committed and pushed and that a draft pull request exists. Do not leave completed work only local, uncommitted, or unpushed unless the user explicitly asks you to.
+
 ## Keep feedback loops short
 
 Use the smallest check that can disprove a change. Prefer focused unit tests while iterating. Run a focused Playwright scenario when the behavior needs a real browser or extension host; let CI run the complete Playwright suite in parallel. Push checkpoints and check the pull request periodically while useful work continues so failures appear before the branch drifts far from a green state.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,12 @@ CodeGraphy accepts focused changes through pull requests against `main`.
    pnpm test
    ```
 
+6. Commit coherent checkpoints using Conventional Commits and push them frequently.
+
+7. Open or update a draft pull request against `main`, link the task, and inspect CI while work continues.
+
+Implementation authorization includes this standard delivery workflow. Do not ask separately for permission to commit, push, create or update the pull request, interact with the task tracker, or inspect CI unless the user explicitly limits the task.
+
 ## Code style
 
 - Follow the package and feature boundaries described in [`AGENTS.md`](./AGENTS.md).
@@ -82,9 +88,11 @@ docs: update README with installation instructions
 
 ## Pull requests
 
-1. Create PRs against `main`.
-2. Explain the behavior change and the checks you ran.
-3. Request review after CI passes.
+1. Create draft PRs against `main` early enough for CI to provide feedback during implementation.
+2. Keep the branch pushed and the PR description current.
+3. Explain the behavior change and the checks you ran.
+4. Link the relevant Trello card or issue.
+5. Request review after CI passes.
 
 ### PR checklist
 


### PR DESCRIPTION
## Summary

- make full development permissions explicit in the repository's agent instructions
- define implementation authorization as including commits, frequent pushes, draft PR creation, task tracking, and CI inspection
- add a hard completion gate against leaving completed work local, uncommitted, or unpushed
- align the contributor workflow and PR guidance with that operating model

This prevents the permission-gating mistake identified while delivering #335.

## Checks

- [x] Documentation-only change
- [x] `git diff --check`
- [x] Verified the permission and delivery rules appear in both `AGENTS.md` and `CONTRIBUTING.md`
