### PR TITLE
fix: replace broken README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 </p>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=codegraphy.codegraphy"><img src="https://img.shields.io/badge/VS%20Code-Install-007ACC?logo=visualstudiocode&logoColor=white" alt="Install CodeGraphy from the VS Code Marketplace" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=codegraphy.codegraphy"><img src="https://badgen.net/vs-marketplace/v/codegraphy.codegraphy?label=extension" alt="VS Code Marketplace version" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=codegraphy.codegraphy"><img src="https://badgen.net/vs-marketplace/i/codegraphy.codegraphy?label=installs" alt="VS Code Marketplace installs" /></a>
   <a href="https://www.npmjs.com/package/@codegraphy-dev/core"><img src="https://img.shields.io/npm/v/%40codegraphy-dev%2Fcore?label=core%20CLI" alt="Core CLI version" /></a>
   <a href="https://www.npmjs.com/package/@codegraphy-dev/tldraw"><img src="https://img.shields.io/npm/v/%40codegraphy-dev%2Ftldraw?label=tldraw" alt="tldraw interface version" /></a>
   <a href="https://www.npmjs.com/package/@codegraphy-dev/plugin-api"><img src="https://img.shields.io/npm/v/%40codegraphy-dev%2Fplugin-api?label=plugin%20API" alt="Plugin API version" /></a>
-  <a href="https://discord.gg/Z75vbkt4Ry"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Join the CodeGraphy Discord" /></a>
+  <a href="https://discord.gg/Z75vbkt4Ry"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FZ75vbkt4Ry%3Fwith_counts%3Dtrue&amp;query=%24.approximate_member_count&amp;label=Discord&amp;logo=discord&amp;logoColor=white&amp;color=5865F2" alt="CodeGraphy Discord members" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@
 </p>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=codegraphy.codegraphy"><img src="https://img.shields.io/visual-studio-marketplace/v/codegraphy.codegraphy?label=extension" alt="VS Code Marketplace version" /></a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=codegraphy.codegraphy"><img src="https://img.shields.io/visual-studio-marketplace/i/codegraphy.codegraphy?label=installs" alt="VS Code Marketplace installs" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=codegraphy.codegraphy"><img src="https://img.shields.io/badge/VS%20Code-Install-007ACC?logo=visualstudiocode&logoColor=white" alt="Install CodeGraphy from the VS Code Marketplace" /></a>
   <a href="https://www.npmjs.com/package/@codegraphy-dev/core"><img src="https://img.shields.io/npm/v/%40codegraphy-dev%2Fcore?label=core%20CLI" alt="Core CLI version" /></a>
   <a href="https://www.npmjs.com/package/@codegraphy-dev/tldraw"><img src="https://img.shields.io/npm/v/%40codegraphy-dev%2Ftldraw?label=tldraw" alt="tldraw interface version" /></a>
   <a href="https://www.npmjs.com/package/@codegraphy-dev/plugin-api"><img src="https://img.shields.io/npm/v/%40codegraphy-dev%2Fplugin-api?label=plugin%20API" alt="Plugin API version" /></a>
-  <a href="https://discord.gg/Z75vbkt4Ry"><img src="https://img.shields.io/discord/1534289518977486849?label=Discord&logo=discord&logoColor=white" alt="Join the CodeGraphy Discord community" /></a>
+  <a href="https://discord.gg/Z75vbkt4Ry"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Join the CodeGraphy Discord" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- preserve the separate live Marketplace version and install-count badges using a working provider
- preserve the live Discord member-count badge using Discord's permanent-invite API instead of the disabled server-widget endpoint
- keep the npm package version badges unchanged

## Checks

- Marketplace version badge reports `v5.16.2`
- Marketplace install badge reports `10.6K`
- Discord badge reports the live member count from the CodeGraphy invite
- fetched every badge URL successfully with no retired, widget-disabled, or invalid output
- inspected GitHub's rendered branch README with Playwright
- `git diff --check` passed

## Visual proof

![GitHub-rendered CodeGraphy README badges](https://github.com/user-attachments/assets/b8c4e47d-4440-4b2a-97c0-0b41665739f8)
