### PR TITLE
fix: stream re-index progress in real time

### DIFF
--- a/.changeset/live-index-progress.md
+++ b/.changeset/live-index-progress.md
@@ -1,0 +1,6 @@
+---
+"@codegraphy-dev/core": patch
+"@codegraphy-dev/extension": patch
+---
+
+Show live File Discovery, analysis, and queued Graph Cache update progress during Re-indexing.

--- a/packages/core/src/analysis/fileAnalysis/run.ts
+++ b/packages/core/src/analysis/fileAnalysis/run.ts
@@ -28,6 +28,7 @@ import {
   createWorkspaceFileContentHash,
   hasAmbiguousWorkspaceFileTimestamp,
 } from '../cache';
+
 const ANALYSIS_PROGRESS_YIELD_INTERVAL = 25;
 
 function createWorkspaceFileAnalysisState(): IWorkspaceFileAnalysisState {
@@ -279,10 +280,11 @@ export async function analyzeWorkspaceFiles(
 
   for (const file of options.files) {
     await analyzeWorkspaceFile(options, state, file);
+    const currentFileCount = getCurrentFileCount(state);
     if (
       options.onProgress
-      && getCurrentFileCount(state) % ANALYSIS_PROGRESS_YIELD_INTERVAL === 0
-      && getCurrentFileCount(state) < options.files.length
+      && currentFileCount % ANALYSIS_PROGRESS_YIELD_INTERVAL === 0
+      && currentFileCount < options.files.length
     ) {
       await waitForImmediate();
     }

--- a/packages/core/src/analysis/fileAnalysis/run.ts
+++ b/packages/core/src/analysis/fileAnalysis/run.ts
@@ -1,3 +1,4 @@
+import { setImmediate as waitForImmediate } from 'node:timers/promises';
 import type { IFileAnalysisResult } from '@codegraphy-dev/plugin-api';
 import type { IDiscoveredFile } from '../../discovery/contracts';
 import type { IProjectedConnection } from '../projectedConnection';
@@ -27,6 +28,7 @@ import {
   createWorkspaceFileContentHash,
   hasAmbiguousWorkspaceFileTimestamp,
 } from '../cache';
+const ANALYSIS_PROGRESS_YIELD_INTERVAL = 25;
 
 function createWorkspaceFileAnalysisState(): IWorkspaceFileAnalysisState {
   return {
@@ -277,6 +279,13 @@ export async function analyzeWorkspaceFiles(
 
   for (const file of options.files) {
     await analyzeWorkspaceFile(options, state, file);
+    if (
+      options.onProgress
+      && getCurrentFileCount(state) % ANALYSIS_PROGRESS_YIELD_INTERVAL === 0
+      && getCurrentFileCount(state) < options.files.length
+    ) {
+      await waitForImmediate();
+    }
   }
 
   const enrichedFileAnalysis = enrichWorkspaceFileAnalysis(state.fileAnalysis);

--- a/packages/core/src/analysis/workspaceAnalyze.ts
+++ b/packages/core/src/analysis/workspaceAnalyze.ts
@@ -93,7 +93,7 @@ export async function analyzeWorkspaceWithAnalyzer(
   dependencies.sendProgress?.({
     phase: 'Discovering Files',
     current: 0,
-    total: 1,
+    total: 0,
   });
   const disabledCustomFilterPatterns = new Set(config.disabledCustomFilterPatterns ?? []);
   const disabledPluginFilterPatterns = new Set(config.disabledPluginFilterPatterns ?? []);
@@ -108,6 +108,11 @@ export async function analyzeWorkspaceWithAnalyzer(
     config,
     signal,
     activeFilterPatterns,
+    progress => dependencies.sendProgress?.({
+      phase: 'Discovering Files',
+      current: progress.current,
+      total: 0,
+    }),
   );
   dependencies.sendProgress?.({
     phase: 'Discovering Files',

--- a/packages/core/src/analysis/workspaceDiscovery.ts
+++ b/packages/core/src/analysis/workspaceDiscovery.ts
@@ -24,6 +24,7 @@ export interface WorkspacePipelineDiscoveryDependencies<TFile> {
     respectGitignore: boolean;
     rootPath: string;
     signal?: AbortSignal;
+    onProgress?: (progress: { current: number }) => void;
   }): Promise<WorkspacePipelineDiscoveryResult<TFile>>;
 }
 
@@ -33,6 +34,7 @@ export async function discoverWorkspacePipelineFiles<TFile>(
   config: WorkspacePipelineDiscoveryConfig,
   signal?: AbortSignal,
   filterPatterns: readonly string[] = [],
+  onProgress?: (progress: { current: number }) => void,
 ): Promise<WorkspacePipelineDiscoveryResult<TFile>> {
   return dependencies.discover({
     rootPath: workspaceRoot,
@@ -42,6 +44,7 @@ export async function discoverWorkspacePipelineFiles<TFile>(
     filter: [...filterPatterns],
     respectGitignore: config.respectGitignore,
     signal,
+    onProgress,
   });
 }
 

--- a/packages/core/src/discovery/contracts.ts
+++ b/packages/core/src/discovery/contracts.ts
@@ -23,6 +23,8 @@ export interface IDiscoveryOptions {
   extensions?: string[];
   /** Abort signal for cancelling long-running discovery */
   signal?: AbortSignal;
+  /** Reports candidate files while the workspace scan is still running. */
+  onProgress?: (progress: { current: number }) => void;
 }
 
 /**

--- a/packages/core/src/discovery/file/service.ts
+++ b/packages/core/src/discovery/file/service.ts
@@ -176,6 +176,10 @@ export class FileDiscovery {
           gitignore: null,
         })) {
           candidateFiles.push({ absolutePath, relativePath });
+          const current = candidateFiles.length;
+          if (current === 1 || current % 25 === 0) {
+            options.onProgress?.({ current });
+          }
         }
         return true;
       },

--- a/packages/core/src/discovery/file/service.ts
+++ b/packages/core/src/discovery/file/service.ts
@@ -13,6 +13,8 @@ import { shouldIncludeFile } from './filter';
 import { walkDirectory } from './walk';
 import { DEFAULT_INCLUDE, EMPTY_PATTERNS, DEFAULT_MAX_FILES } from './defaults';
 
+const DISCOVERY_PROGRESS_INTERVAL = 25;
+
 function getDiscoveryConfig(options: IDiscoveryOptions) {
   return {
     maxFiles: options.maxFiles ?? DEFAULT_MAX_FILES,
@@ -177,7 +179,7 @@ export class FileDiscovery {
         })) {
           candidateFiles.push({ absolutePath, relativePath });
           const current = candidateFiles.length;
-          if (current === 1 || current % 25 === 0) {
+          if (current === 1 || current % DISCOVERY_PROGRESS_INTERVAL === 0) {
             options.onProgress?.({ current });
           }
         }

--- a/packages/core/tests/analysis/fileAnalysis/run.test.ts
+++ b/packages/core/tests/analysis/fileAnalysis/run.test.ts
@@ -101,6 +101,36 @@ function readCacheTiers(analysis: IFileAnalysisResult): string[] {
 }
 
 describe('pipeline/fileAnalysis', () => {
+  it('yields to the host while publishing progress for a large cached analysis', async () => {
+    const cache = createEmptyWorkspaceAnalysisCache();
+    const files = Array.from({ length: 50 }, (_, index) => {
+      const file = createFile(`src/file-${index}.ts`);
+      cache.files[file.relativePath] = {
+        mtime: 25,
+        analysis: createEmptyAnalysis(file.absolutePath),
+        size: 12,
+      };
+      return file;
+    });
+    const onProgress = vi.fn();
+
+    const analysis = analyzeWorkspaceFiles({
+      analyzeFile: vi.fn(async () => createEmptyAnalysis()),
+      cache,
+      files,
+      getFileStat: vi.fn(async () => ({ mtime: 25, size: 12 })),
+      onProgress,
+      readContent: vi.fn(async () => 'ignored'),
+      workspaceRoot: '/workspace',
+    });
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(onProgress.mock.calls.length).toBeGreaterThan(0);
+    expect(onProgress.mock.calls.length).toBeLessThan(files.length);
+    await analysis;
+    expect(onProgress).toHaveBeenCalledTimes(files.length);
+  });
+
   it('reuses cached connections and backfills missing size on cache hits', async () => {
     const cache = createEmptyWorkspaceAnalysisCache();
     const cachedConnections: IProjectedConnection[] = [

--- a/packages/core/tests/analysis/workspaceAnalyze.test.ts
+++ b/packages/core/tests/analysis/workspaceAnalyze.test.ts
@@ -104,6 +104,7 @@ describe('pipeline/analysis/analyze', () => {
       filter: ['**/*.user.ts', '**/*.generated.ts'],
       respectGitignore: true,
       signal: undefined,
+      onProgress: expect.any(Function),
     });
   });
 
@@ -195,7 +196,7 @@ describe('pipeline/analysis/analyze', () => {
     expect(dependencies.sendProgress).toHaveBeenNthCalledWith(1, {
       phase: 'Discovering Files',
       current: 0,
-      total: 1,
+      total: 0,
     });
     expect(dependencies.sendProgress).toHaveBeenNthCalledWith(2, {
       phase: 'Discovering Files',

--- a/packages/core/tests/analysis/workspaceAnalyze.test.ts
+++ b/packages/core/tests/analysis/workspaceAnalyze.test.ts
@@ -311,6 +311,42 @@ describe('pipeline/analysis/analyze', () => {
     });
   });
 
+  it('forwards live file discovery counts before discovery completes', async () => {
+    const source = createSource();
+    const dependencies = createDependencies();
+    let finishDiscovery!: () => void;
+    const discoveryGate = new Promise<void>(resolve => {
+      finishDiscovery = resolve;
+    });
+
+    dependencies.discover.mockImplementation(async options => {
+      const onProgress = (
+        options as typeof options & { onProgress?: (progress: { current: number }) => void }
+      ).onProgress;
+      onProgress?.({ current: 25 });
+      await discoveryGate;
+      return {
+        directories: [],
+        durationMs: 4,
+        files: [] as IDiscoveredFile[],
+        limitReached: false,
+        totalFound: 0,
+      };
+    });
+
+    const analysis = analyzeWorkspaceWithAnalyzer(source as never, dependencies as never);
+    await vi.waitFor(() => {
+      expect(dependencies.sendProgress).toHaveBeenCalledWith({
+        phase: 'Discovering Files',
+        current: 25,
+        total: 0,
+      });
+    });
+
+    finishDiscovery();
+    await analysis;
+  });
+
   it('keeps analyzing when progress reporting and the event bus are unavailable', async () => {
     const source = createSource();
     const dependencies = createDependencies();

--- a/packages/core/tests/discovery/file/discovery.discover.test.ts
+++ b/packages/core/tests/discovery/file/discovery.discover.test.ts
@@ -54,6 +54,17 @@ describe('FileDiscovery discover', () => {
     );
   });
 
+  it('reports candidate file counts while discovery is still running', async () => {
+    for (let index = 0; index < 26; index += 1) {
+      createFile(`src/file-${index}.ts`);
+    }
+    const onProgress = vi.fn();
+
+    await discovery.discover({ rootPath: tempDir, onProgress });
+
+    expect(onProgress.mock.calls.map(([progress]) => progress.current)).toEqual([1, 25]);
+  });
+
   it('includes file metadata', async () => {
     createFile('src/app.ts');
 

--- a/packages/extension/src/extension/graphView/provider/analysis/execution.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/execution.ts
@@ -4,7 +4,10 @@ import type {
   GraphViewProviderAnalysisMethodDependencies,
   GraphViewProviderAnalysisMethodsSource,
 } from './methods';
-import type { GraphViewAnalysisMode } from '../../analysis/execution';
+import type {
+  GraphViewAnalysisMode,
+  GraphViewIndexingProgress,
+} from '../../analysis/execution';
 import {
   createGraphViewProviderAnalysisState,
   syncGraphViewProviderAnalysisExecutionState,
@@ -19,13 +22,13 @@ export function createGraphViewProviderDoAnalyzeAndSendData(
   signal: AbortSignal,
   requestId: number,
   changedFilePaths?: readonly string[],
-  onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+  onProgress?: (progress: GraphViewIndexingProgress) => void,
 ) => Promise<void> {
   return async (
     signal: AbortSignal,
     requestId: number,
     changedFilePaths?: readonly string[],
-    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+    onProgress?: (progress: GraphViewIndexingProgress) => void,
   ): Promise<void> => {
     const state = createGraphViewProviderAnalysisState(source, mode, changedFilePaths);
 

--- a/packages/extension/src/extension/graphView/provider/analysis/execution.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/execution.ts
@@ -19,11 +19,13 @@ export function createGraphViewProviderDoAnalyzeAndSendData(
   signal: AbortSignal,
   requestId: number,
   changedFilePaths?: readonly string[],
+  onProgress?: (progress: { phase: string; current: number; total: number }) => void,
 ) => Promise<void> {
   return async (
     signal: AbortSignal,
     requestId: number,
     changedFilePaths?: readonly string[],
+    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
   ): Promise<void> => {
     const state = createGraphViewProviderAnalysisState(source, mode, changedFilePaths);
 
@@ -37,6 +39,7 @@ export function createGraphViewProviderDoAnalyzeAndSendData(
         isAbortError: error => delegates.callIsAbortError(error),
         markWorkspaceReady: (graphData, disabledPlugins) =>
           delegates.callMarkWorkspaceReady(graphData, disabledPlugins),
+        onProgress,
       }),
     );
 

--- a/packages/extension/src/extension/graphView/provider/analysis/handlers.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/handlers.ts
@@ -1,4 +1,5 @@
 import type { IGraphData } from '../../../../shared/graph/contracts';
+import type { GraphViewIndexingProgress } from '../../analysis/execution';
 import type {
   GraphViewProviderAnalysisHandlers,
   GraphViewProviderAnalysisRequestHandlers,
@@ -21,7 +22,7 @@ interface GraphViewProviderAnalysisHandlerCallbacks {
   isAnalysisStale(signal: AbortSignal, requestId: number): boolean;
   isAbortError(error: unknown): boolean;
   markWorkspaceReady(graph: IGraphData, disabledPlugins?: ReadonlySet<string>): void;
-  onProgress?(progress: { phase: string; current: number; total: number }): void;
+  onProgress?(progress: GraphViewIndexingProgress): void;
 }
 
 export function createGraphViewProviderAnalysisHandlers(

--- a/packages/extension/src/extension/graphView/provider/analysis/handlers.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/handlers.ts
@@ -21,6 +21,7 @@ interface GraphViewProviderAnalysisHandlerCallbacks {
   isAnalysisStale(signal: AbortSignal, requestId: number): boolean;
   isAbortError(error: unknown): boolean;
   markWorkspaceReady(graph: IGraphData, disabledPlugins?: ReadonlySet<string>): void;
+  onProgress?(progress: { phase: string; current: number; total: number }): void;
 }
 
 export function createGraphViewProviderAnalysisHandlers(
@@ -51,6 +52,7 @@ export function createGraphViewProviderAnalysisHandlers(
       sendGraphIndexStatusUpdated(source, hasIndex, freshness, detail),
     sendIndexProgress: progress => {
       source._sendMessage({ type: 'GRAPH_INDEX_PROGRESS', payload: progress });
+      callbacks.onProgress?.(progress);
     },
     sendPluginWebviewInjections: () => source._sendPluginWebviewInjections?.(),
     markWorkspaceReady: (graphData, disabledPlugins) =>

--- a/packages/extension/src/extension/graphView/provider/analysis/methods.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/methods.ts
@@ -72,6 +72,7 @@ export interface GraphViewProviderAnalysisMethods {
   _updateChangedFilesAndSendData(
     filePaths: readonly string[],
     signal?: AbortSignal,
+    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
   ): Promise<void>;
   _refreshAndSendData(): Promise<void>;
   _refreshIndexStatus(): void;
@@ -170,6 +171,7 @@ export function createGraphViewProviderAnalysisMethods(
   const enqueueChangedFilesUpdate = (
     filePaths: readonly string[],
     signal?: AbortSignal,
+    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
   ): Promise<void> => {
     if (source._analyzer?.hasIndex?.() === false) {
       return Promise.resolve();
@@ -184,7 +186,7 @@ export function createGraphViewProviderAnalysisMethods(
       };
       signal?.addEventListener('abort', abortUpdate, { once: true });
       try {
-        const activeUpdate = _updateChangedFilesAndSendData(filePaths);
+        const activeUpdate = _updateChangedFilesAndSendData(filePaths, onProgress);
         if (signal?.aborted) abortUpdate();
         await activeUpdate;
       } finally {

--- a/packages/extension/src/extension/graphView/provider/analysis/methods.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/methods.ts
@@ -1,5 +1,6 @@
 import type { IGraphData } from '../../../../shared/graph/contracts';
 import type { ExtensionToWebviewMessage } from '../../../../shared/protocol/extensionToWebview';
+import type { GraphViewIndexingProgress } from '../../analysis/execution';
 import type { GraphViewProviderAnalysisState } from '../../analysis/lifecycle';
 import { createGraphViewProviderAnalysisDelegates } from './delegates';
 import {
@@ -72,7 +73,7 @@ export interface GraphViewProviderAnalysisMethods {
   _updateChangedFilesAndSendData(
     filePaths: readonly string[],
     signal?: AbortSignal,
-    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+    onProgress?: (progress: GraphViewIndexingProgress) => void,
   ): Promise<void>;
   _refreshAndSendData(): Promise<void>;
   _refreshIndexStatus(): void;
@@ -171,7 +172,7 @@ export function createGraphViewProviderAnalysisMethods(
   const enqueueChangedFilesUpdate = (
     filePaths: readonly string[],
     signal?: AbortSignal,
-    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+    onProgress?: (progress: GraphViewIndexingProgress) => void,
   ): Promise<void> => {
     if (source._analyzer?.hasIndex?.() === false) {
       return Promise.resolve();

--- a/packages/extension/src/extension/graphView/provider/analysis/request.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/request.ts
@@ -18,18 +18,29 @@ export function createGraphViewProviderAnalyzeAndSendData(
     signal: AbortSignal,
     requestId: number,
     changedFilePaths?: readonly string[],
+    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
   ) => Promise<void>,
   mode: GraphViewAnalysisMode,
-): (changedFilePaths?: readonly string[]) => Promise<void> {
-  return async (changedFilePaths?: readonly string[]): Promise<void> => {
+): (
+  changedFilePaths?: readonly string[],
+  onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+) => Promise<void> {
+  return async (changedFilePaths, onProgress): Promise<void> => {
     const state = createGraphViewProviderAnalysisState(source, mode, changedFilePaths);
 
     await dependencies.runAnalysisRequest(
       state,
       createGraphViewProviderAnalysisRequestHandlers(source, dependencies, {
-        executeAnalysis: (signal, requestId) => changedFilePaths
-          ? doAnalyzeAndSendData(signal, requestId, changedFilePaths)
-          : doAnalyzeAndSendData(signal, requestId),
+        executeAnalysis: (signal, requestId) => {
+          if (changedFilePaths) {
+            return onProgress
+              ? doAnalyzeAndSendData(signal, requestId, changedFilePaths, onProgress)
+              : doAnalyzeAndSendData(signal, requestId, changedFilePaths);
+          }
+          return onProgress
+            ? doAnalyzeAndSendData(signal, requestId, undefined, onProgress)
+            : doAnalyzeAndSendData(signal, requestId);
+        },
         isAbortError: error => delegates.callIsAbortError(error),
       }),
     );

--- a/packages/extension/src/extension/graphView/provider/analysis/request.ts
+++ b/packages/extension/src/extension/graphView/provider/analysis/request.ts
@@ -4,7 +4,10 @@ import type {
   GraphViewProviderAnalysisMethodDependencies,
   GraphViewProviderAnalysisMethodsSource,
 } from './methods';
-import type { GraphViewAnalysisMode } from '../../analysis/execution';
+import type {
+  GraphViewAnalysisMode,
+  GraphViewIndexingProgress,
+} from '../../analysis/execution';
 import {
   createGraphViewProviderAnalysisState,
   syncGraphViewProviderAnalysisState,
@@ -18,12 +21,12 @@ export function createGraphViewProviderAnalyzeAndSendData(
     signal: AbortSignal,
     requestId: number,
     changedFilePaths?: readonly string[],
-    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+    onProgress?: (progress: GraphViewIndexingProgress) => void,
   ) => Promise<void>,
   mode: GraphViewAnalysisMode,
 ): (
   changedFilePaths?: readonly string[],
-  onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+  onProgress?: (progress: GraphViewIndexingProgress) => void,
 ) => Promise<void> {
   return async (changedFilePaths, onProgress): Promise<void> => {
     const state = createGraphViewProviderAnalysisState(source, mode, changedFilePaths);
@@ -31,16 +34,8 @@ export function createGraphViewProviderAnalyzeAndSendData(
     await dependencies.runAnalysisRequest(
       state,
       createGraphViewProviderAnalysisRequestHandlers(source, dependencies, {
-        executeAnalysis: (signal, requestId) => {
-          if (changedFilePaths) {
-            return onProgress
-              ? doAnalyzeAndSendData(signal, requestId, changedFilePaths, onProgress)
-              : doAnalyzeAndSendData(signal, requestId, changedFilePaths);
-          }
-          return onProgress
-            ? doAnalyzeAndSendData(signal, requestId, undefined, onProgress)
-            : doAnalyzeAndSendData(signal, requestId);
-        },
+        executeAnalysis: (signal, requestId) =>
+          doAnalyzeAndSendData(signal, requestId, changedFilePaths, onProgress),
         isAbortError: error => delegates.callIsAbortError(error),
       }),
     );

--- a/packages/extension/src/extension/graphView/provider/wiring/publicApi.ts
+++ b/packages/extension/src/extension/graphView/provider/wiring/publicApi.ts
@@ -3,6 +3,7 @@ import type { GraphQueryRequest, GraphQueryResult } from '@codegraphy-dev/core';
 import type { EventName, EventPayloads } from '../../../events/bus';
 import type { IGraphData } from '../../../../shared/graph/contracts';
 import type { WebviewToExtensionMessage } from '../../../../shared/protocol/webviewToExtension';
+import type { GraphViewIndexingProgress } from '../../analysis/execution';
 import { dispatchGraphViewProviderMessage } from '../../webview/providerMessages/dispatch';
 import type { GraphViewProviderMethodContainers } from './methodContainers';
 import type { GraphViewProviderMessageListenerSource } from '../../webview/providerMessages/listener';
@@ -33,7 +34,7 @@ export interface GraphViewProviderPublicMethods {
   updateWorkspaceFiles: (
     filePaths: readonly string[],
     signal?: AbortSignal,
-    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+    onProgress?: (progress: GraphViewIndexingProgress) => void,
   ) => Promise<void>;
   refreshIndex: () => Promise<void>;
   hydrateGraphScope: () => Promise<boolean>;

--- a/packages/extension/src/extension/graphView/provider/wiring/publicApi.ts
+++ b/packages/extension/src/extension/graphView/provider/wiring/publicApi.ts
@@ -33,6 +33,7 @@ export interface GraphViewProviderPublicMethods {
   updateWorkspaceFiles: (
     filePaths: readonly string[],
     signal?: AbortSignal,
+    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
   ) => Promise<void>;
   refreshIndex: () => Promise<void>;
   hydrateGraphScope: () => Promise<boolean>;
@@ -90,9 +91,12 @@ export function assignGraphViewProviderPublicMethods(
   target.refresh = () => target._methodContainers.refresh.refresh();
   target.refreshIndexStatus = () =>
     target._methodContainers.analysis._refreshIndexStatus();
-  target.updateWorkspaceFiles = (filePaths, signal) => signal
-    ? target._methodContainers.analysis._updateChangedFilesAndSendData(filePaths, signal)
-    : target._methodContainers.analysis._updateChangedFilesAndSendData(filePaths);
+  target.updateWorkspaceFiles = (filePaths, signal, onProgress) =>
+    target._methodContainers.analysis._updateChangedFilesAndSendData(
+      filePaths,
+      signal,
+      onProgress,
+    );
   target.refreshIndex = () => target._methodContainers.refresh.refreshIndex();
   target.hydrateGraphScope = () => target._methodContainers.refresh.hydrateGraphScope();
   target.hydratePluginGraphScope = pluginIds =>

--- a/packages/extension/src/extension/workspaceFiles/cacheUpdates/fingerprint.ts
+++ b/packages/extension/src/extension/workspaceFiles/cacheUpdates/fingerprint.ts
@@ -6,15 +6,23 @@ const PATH_SIGNATURE_CONCURRENCY = 8;
 
 interface FingerprintingWorkspaceCacheUpdateOptions {
   pathSignature(filePath: string): Promise<string>;
-  update(filePaths: readonly string[], signal: AbortSignal): Promise<void>;
+  update(
+    filePaths: readonly string[],
+    signal: AbortSignal,
+    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+  ): Promise<void>;
 }
 
 export function createFingerprintingWorkspaceCacheUpdate(
   options: FingerprintingWorkspaceCacheUpdateOptions,
-): (filePaths: readonly string[], signal: AbortSignal) => Promise<void> {
+): (
+  filePaths: readonly string[],
+  signal: AbortSignal,
+  onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+) => Promise<void> {
   const appliedPathSignatures = new Map<string, string>();
 
-  return async (filePaths, signal) => {
+  return async (filePaths, signal, onProgress) => {
     if (signal.aborted) return;
     const startingSignatures = await collectPathSignatures(
       filePaths,
@@ -24,7 +32,7 @@ export function createFingerprintingWorkspaceCacheUpdate(
       appliedPathSignatures.get(filePath) !== startingSignatures.get(filePath)
     ));
     if (changedPaths.length === 0) return;
-    await options.update(changedPaths, signal);
+    await options.update(changedPaths, signal, onProgress);
     for (const filePath of changedPaths) {
       const signature = startingSignatures.get(filePath);
       if (signature !== undefined) appliedPathSignatures.set(filePath, signature);

--- a/packages/extension/src/extension/workspaceFiles/cacheUpdates/fingerprint.ts
+++ b/packages/extension/src/extension/workspaceFiles/cacheUpdates/fingerprint.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import { stat } from 'node:fs/promises';
+import type { WorkspaceCacheUpdateProgress } from './model';
 
 const PATH_SIGNATURE_CONCURRENCY = 8;
 
@@ -9,7 +10,7 @@ interface FingerprintingWorkspaceCacheUpdateOptions {
   update(
     filePaths: readonly string[],
     signal: AbortSignal,
-    onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+    onProgress?: (progress: WorkspaceCacheUpdateProgress) => void,
   ): Promise<void>;
 }
 
@@ -18,7 +19,7 @@ export function createFingerprintingWorkspaceCacheUpdate(
 ): (
   filePaths: readonly string[],
   signal: AbortSignal,
-  onProgress?: (progress: { phase: string; current: number; total: number }) => void,
+  onProgress?: (progress: WorkspaceCacheUpdateProgress) => void,
 ) => Promise<void> {
   const appliedPathSignatures = new Map<string, string>();
 

--- a/packages/extension/src/extension/workspaceFiles/cacheUpdates/register.ts
+++ b/packages/extension/src/extension/workspaceFiles/cacheUpdates/register.ts
@@ -54,6 +54,7 @@ interface WorkspaceCacheUpdateProvider {
   updateWorkspaceFiles(
     filePaths: readonly string[],
     signal?: AbortSignal,
+    onProgress?: (progress: WorkspaceCacheUpdateProgress) => void,
   ): Promise<void>;
 }
 
@@ -118,7 +119,8 @@ export function registerWorkspaceCacheUpdates(
     onStatus: status => renderWorkspaceCacheUpdateStatus(statusBarItem, status),
     update: createFingerprintingWorkspaceCacheUpdate({
       pathSignature: filePath => dependencies.pathSignature(filePath),
-      update: (filePaths, signal) => provider.updateWorkspaceFiles(filePaths, signal),
+      update: (filePaths, signal, onProgress) =>
+        provider.updateWorkspaceFiles(filePaths, signal, onProgress),
     }),
   });
 

--- a/packages/extension/src/extension/workspaceFiles/cacheUpdates/register.ts
+++ b/packages/extension/src/extension/workspaceFiles/cacheUpdates/register.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import {
   createWorkspaceCacheUpdateScheduler,
+  type WorkspaceCacheUpdateProgress,
   type WorkspaceCacheUpdateScheduler,
   type WorkspaceCacheUpdateSchedulerOptions,
 } from './model';

--- a/packages/extension/src/extension/workspaceFiles/cacheUpdates/statusBar.ts
+++ b/packages/extension/src/extension/workspaceFiles/cacheUpdates/statusBar.ts
@@ -49,6 +49,9 @@ function statusBarText(
         ? '$(clock) CodeGraphy: 1 change queued'
         : `$(clock) CodeGraphy: ${status.fileCount} changes queued`;
     case 'updating':
+      if (status.progress) {
+        return `$(sync~spin) CodeGraphy: ${status.progress.phase} ${status.progress.current}/${status.progress.total}`;
+      }
       return status.fileCount === 1
         ? '$(sync~spin) CodeGraphy: Updating 1 file'
         : `$(sync~spin) CodeGraphy: Updating ${status.fileCount} files`;

--- a/packages/extension/src/webview/components/graphIndexStatus/view.tsx
+++ b/packages/extension/src/webview/components/graphIndexStatus/view.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { OWNED_GRAPH_MINIMAP_RESERVED_LEFT } from '../graph/rendering/surface/owned2d/minimap/layout';
+import { cn } from '../ui/cn';
 
 export interface GraphIndexStatusProgress {
   phase: string;
@@ -22,19 +23,23 @@ export function GraphIndexStatus({
     return null;
   }
 
+  const current = Math.max(0, progress.current);
   const isIndeterminate = progress.total <= 0;
   const percent = !isIndeterminate
-    ? Math.round((progress.current / progress.total) * 100)
+    ? Math.min(100, Math.round((current / progress.total) * 100))
     : 0;
   const progressText = isIndeterminate
-    ? progress.current === 1
-      ? '1 file found'
-      : `${progress.current} files found`
+    ? current === 1
+      ? '1 candidate file found'
+      : `${current} candidate files found`
     : `${percent}%`;
 
   return (
     <div
-      className={`pointer-events-none absolute ${showMinimap ? '' : 'left-2'} right-12 bottom-2 z-20 rounded-md border border-border bg-[var(--cg-popover-translucent)] px-2 py-1.5 shadow-sm backdrop-blur-sm`}
+      className={cn(
+        'pointer-events-none absolute right-12 bottom-2 z-20 rounded-md border border-border bg-[var(--cg-popover-translucent)] px-2 py-1.5 shadow-sm backdrop-blur-sm',
+        !showMinimap && 'left-2',
+      )}
       data-codegraphy-state="graph-indexing"
       data-testid="graph-index-status"
       style={showMinimap ? { left: OWNED_GRAPH_MINIMAP_RESERVED_LEFT } : undefined}
@@ -58,7 +63,7 @@ export function GraphIndexStatus({
       >
         <div
           className={isIndeterminate
-            ? 'h-full w-1/3 animate-pulse rounded-full bg-primary'
+            ? 'h-full w-1/3 animate-index-progress rounded-full bg-primary'
             : 'h-full rounded-full bg-primary transition-all duration-200'}
           data-codegraphy-region="graph-index-progress-fill"
           data-codegraphy-progress={isIndeterminate ? 'indeterminate' : 'determinate'}

--- a/packages/extension/src/webview/components/graphIndexStatus/view.tsx
+++ b/packages/extension/src/webview/components/graphIndexStatus/view.tsx
@@ -22,9 +22,15 @@ export function GraphIndexStatus({
     return null;
   }
 
-  const percent = progress.total > 0
+  const isIndeterminate = progress.total <= 0;
+  const percent = !isIndeterminate
     ? Math.round((progress.current / progress.total) * 100)
     : 0;
+  const progressText = isIndeterminate
+    ? progress.current === 1
+      ? '1 file found'
+      : `${progress.current} files found`
+    : `${percent}%`;
 
   return (
     <div
@@ -35,7 +41,7 @@ export function GraphIndexStatus({
     >
       <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
         <span>{progress.phase}</span>
-        <span>{percent}%</span>
+        <span>{progressText}</span>
       </div>
       <div
         className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
@@ -45,14 +51,19 @@ export function GraphIndexStatus({
         aria-label="Indexing progress"
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuenow={percent}
-        aria-valuetext={`${progress.phase} ${percent}%`}
+        aria-valuenow={isIndeterminate ? undefined : percent}
+        aria-valuetext={isIndeterminate
+          ? `${progress.phase} ${progressText}`
+          : `${progress.phase} ${percent}%`}
       >
         <div
-          className="h-full rounded-full bg-primary transition-all duration-200"
+          className={isIndeterminate
+            ? 'h-full w-1/3 animate-pulse rounded-full bg-primary'
+            : 'h-full rounded-full bg-primary transition-all duration-200'}
           data-codegraphy-region="graph-index-progress-fill"
+          data-codegraphy-progress={isIndeterminate ? 'indeterminate' : 'determinate'}
           data-testid="graph-index-status-fill"
-          style={{ width: `${percent}%` }}
+          style={isIndeterminate ? undefined : { width: `${percent}%` }}
         />
       </div>
     </div>

--- a/packages/extension/tailwind.config.cjs
+++ b/packages/extension/tailwind.config.cjs
@@ -43,6 +43,15 @@ module.exports = {
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
       },
+      keyframes: {
+        'index-progress': {
+          '0%': { transform: 'translateX(-100%)' },
+          '100%': { transform: 'translateX(300%)' },
+        },
+      },
+      animation: {
+        'index-progress': 'index-progress 1.2s ease-in-out infinite',
+      },
     },
   },
   plugins: [],

--- a/packages/extension/tests/extension/graphView/provider/analysis/methods.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/analysis/methods.test.ts
@@ -286,6 +286,57 @@ describe('graphView/provider/analysis/methods', () => {
     ]);
   });
 
+  it('reports queued file progress only after the active reindex releases the pipeline', async () => {
+    const source = createSource();
+    let finishRefresh: (() => void) | undefined;
+    const runAnalysisRequest = vi.fn(async (state, handlers) => {
+      if (state.mode === 'refresh') {
+        await new Promise<void>(resolve => {
+          finishRefresh = resolve;
+        });
+      }
+      await handlers.executeAnalysis(new AbortController().signal, 11);
+    });
+    const executeAnalysis = vi.fn(async (_signal, _requestId, state, handlers) => {
+      if (state.mode === 'incremental') {
+        handlers.sendIndexProgress({
+          phase: 'Analyzing Files',
+          current: 25,
+          total: 58,
+        });
+      }
+    });
+    const methods = createGraphViewProviderAnalysisMethods(source as never, {
+      runAnalysisRequest,
+      executeAnalysis,
+      markWorkspaceReady: vi.fn(),
+      isAnalysisStale: vi.fn(() => false),
+      isAbortError: vi.fn(() => false),
+      hasWorkspace: vi.fn(() => true),
+      logError: vi.fn(),
+    });
+    const onProgress = vi.fn();
+
+    const refresh = methods._refreshAndSendData();
+    await Promise.resolve();
+    const update = methods._updateChangedFilesAndSendData(
+      ['/workspace/src/saved.ts'],
+      undefined,
+      onProgress,
+    );
+
+    expect(onProgress).not.toHaveBeenCalled();
+    finishRefresh?.();
+    await refresh;
+    await update;
+
+    expect(onProgress).toHaveBeenCalledWith({
+      phase: 'Analyzing Files',
+      current: 25,
+      total: 58,
+    });
+  });
+
   it('serializes saved-file updates from direct actions and ambient events', async () => {
     const source = createSource();
     let finishFirstUpdate: (() => void) | undefined;

--- a/packages/extension/tests/extension/graphView/provider/analysis/request.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/analysis/request.test.ts
@@ -76,7 +76,12 @@ describe('graphView/provider/analysis/request', () => {
       'index',
     )();
 
-    expect(doAnalyzeAndSendData).toHaveBeenCalledWith(expect.any(AbortSignal), 4);
+    expect(doAnalyzeAndSendData).toHaveBeenCalledWith(
+      expect.any(AbortSignal),
+      4,
+      undefined,
+      undefined,
+    );
     expect(source._analysisController).toBeInstanceOf(AbortController);
     expect(source._analysisRequestId).toBe(4);
     expect(source._analyzerInitialized).toBe(true);
@@ -104,7 +109,12 @@ describe('graphView/provider/analysis/request', () => {
       'load',
     )();
 
-    expect(loadAndSendData).toHaveBeenCalledWith(expect.any(AbortSignal), 7);
+    expect(loadAndSendData).toHaveBeenCalledWith(
+      expect.any(AbortSignal),
+      7,
+      undefined,
+      undefined,
+    );
     expect(source._doLoadAndSendData).not.toHaveBeenCalled();
   });
 
@@ -137,6 +147,7 @@ describe('graphView/provider/analysis/request', () => {
       expect.any(AbortSignal),
       9,
       filePaths,
+      undefined,
     );
   });
 });

--- a/packages/extension/tests/extension/graphView/provider/wiring/publicApi.test.ts
+++ b/packages/extension/tests/extension/graphView/provider/wiring/publicApi.test.ts
@@ -127,7 +127,8 @@ describe('assignGraphViewProviderPublicMethods', () => {
     target.refreshSettings();
     target.refreshToggleSettings();
     await target.clearCacheAndRefresh();
-    await target.updateWorkspaceFiles(['/workspace/src/app.ts']);
+    const onProgress = vi.fn();
+    await target.updateWorkspaceFiles(['/workspace/src/app.ts'], undefined, onProgress);
     target.refreshIndexStatus();
     target.sendCommand('FIT_VIEW');
     expect(await target.undo()).toBe('undo');
@@ -152,7 +153,7 @@ describe('assignGraphViewProviderPublicMethods', () => {
     expect(target._methodContainers.refresh.clearCacheAndRefresh).toHaveBeenCalledTimes(1);
     expect(
       target._methodContainers.analysis._updateChangedFilesAndSendData,
-    ).toHaveBeenCalledWith(['/workspace/src/app.ts']);
+    ).toHaveBeenCalledWith(['/workspace/src/app.ts'], undefined, onProgress);
     expect(target._methodContainers.analysis._refreshIndexStatus).toHaveBeenCalledOnce();
     expect(target._methodContainers.command.sendCommand).toHaveBeenCalledWith('FIT_VIEW');
     expect(target._methodContainers.command.undo).toHaveBeenCalledTimes(1);

--- a/packages/extension/tests/extension/pipeline/analysis.test.ts
+++ b/packages/extension/tests/extension/pipeline/analysis.test.ts
@@ -555,6 +555,7 @@ describe('WorkspacePipeline analysis', () => {
       filter: ['**/*.generated.ts'],
       respectGitignore: false,
       signal,
+      onProgress: expect.any(Function),
     });
     expect(getPluginFilterPatterns).toHaveBeenCalledWith(new Set<string>());
     expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();

--- a/packages/extension/tests/extension/workspaceFiles/cacheUpdates/fingerprint.test.ts
+++ b/packages/extension/tests/extension/workspaceFiles/cacheUpdates/fingerprint.test.ts
@@ -49,7 +49,30 @@ describe('workspaceFiles/cacheUpdates/fingerprint', () => {
     await update(paths, new AbortController().signal);
 
     expect(maxActiveReads).toBe(8);
-    expect(updateWorkspaceFiles).toHaveBeenCalledWith(paths, expect.any(AbortSignal));
+    expect(updateWorkspaceFiles).toHaveBeenCalledWith(paths, expect.any(AbortSignal), undefined);
+  });
+
+  it('forwards active update progress through the fingerprinting boundary', async () => {
+    const onProgress = vi.fn();
+    const updateWorkspaceFiles = vi.fn(async (
+      _filePaths: readonly string[],
+      _signal: AbortSignal,
+      report?: (progress: { phase: string; current: number; total: number }) => void,
+    ) => {
+      report?.({ phase: 'Analyzing Files', current: 25, total: 58 });
+    });
+    const update = createFingerprintingWorkspaceCacheUpdate({
+      pathSignature: vi.fn(async () => 'signature'),
+      update: updateWorkspaceFiles,
+    });
+
+    await update(['/workspace/src/app.ts'], new AbortController().signal, onProgress);
+
+    expect(onProgress).toHaveBeenCalledWith({
+      phase: 'Analyzing Files',
+      current: 25,
+      total: 58,
+    });
   });
 
   it('does not coalesce paths whose signature read failed', async () => {

--- a/packages/extension/tests/extension/workspaceFiles/cacheUpdates/register.test.ts
+++ b/packages/extension/tests/extension/workspaceFiles/cacheUpdates/register.test.ts
@@ -297,6 +297,7 @@ describe('workspaceFiles/cacheUpdates/register', () => {
     expect(updateWorkspaceFiles).toHaveBeenCalledWith(
       ['/workspace/src/saved.ts'],
       controller.signal,
+      expect.any(Function),
     );
   });
 });

--- a/packages/extension/tests/extension/workspaceFiles/cacheUpdates/statusBar.test.ts
+++ b/packages/extension/tests/extension/workspaceFiles/cacheUpdates/statusBar.test.ts
@@ -30,6 +30,7 @@ describe('workspaceFiles/cacheUpdates/statusBar', () => {
       fileCount: 2,
       progress: { phase: 'Applying Changes', current: 1, total: 2 },
     });
+    expect(statusBarItem.text).toBe('$(sync~spin) CodeGraphy: Applying Changes 1/2');
     expect(statusBarItem.tooltip).toBe('Applying Changes: 1 of 2.');
 
     renderWorkspaceCacheUpdateStatus(statusBarItem, {

--- a/packages/extension/tests/playwright-vscode/live-workspace-indexing.spec.ts
+++ b/packages/extension/tests/playwright-vscode/live-workspace-indexing.spec.ts
@@ -17,6 +17,80 @@ import { copyExampleTypescriptWorkspace, createWorkspaceTempRoot } from '../acce
 
 const EXPLORER_SHORTCUT = process.platform === 'darwin' ? 'Meta+Shift+E' : 'Control+Shift+E';
 
+test('Re-index streams live progress and drains workspace changes queued during the run', async () => {
+  const context = await createGraphViewAcceptanceContext(undefined);
+  try {
+    context.workspaceTempRoot = createWorkspaceTempRoot();
+    context.workspacePath = copyExampleTypescriptWorkspace(context.workspaceTempRoot, {
+      includeImportEdges: false,
+      includeNestsEdges: true,
+    });
+    const bulkPath = path.join(context.workspacePath, 'bulk');
+    fs.mkdirSync(bulkPath);
+    for (let index = 0; index < 800; index += 1) {
+      fs.writeFileSync(
+        path.join(bulkPath, `file-${index}.ts`),
+        `export const value${index} = ${index};\n`,
+      );
+    }
+
+    context.vscode = await launchVSCodeWithWorkspace(context.workspacePath);
+    await openGraphView(context.vscode.page);
+    context.graphFrame = await waitForGraphFrame(context.vscode.page);
+    const frame = requireGraphFrame(context);
+    await frame.getByRole('button', { name: 'Index Workspace' }).click();
+    await expect(frame.getByRole('progressbar', { name: 'Indexing progress' }))
+      .toBeHidden({ timeout: 60_000 });
+    await context.vscode.page.evaluate(() => {
+      const statusHistory: string[] = [];
+      const captureStatus = (): void => {
+        const statusText = [...document.querySelectorAll('.statusbar-item')]
+          .map(item => item.textContent?.trim() ?? '')
+          .find(text => text.includes('CodeGraphy:'));
+        if (statusText && statusHistory.at(-1) !== statusText) {
+          statusHistory.push(statusText);
+        }
+      };
+      (globalThis as typeof globalThis & { codegraphyStatusHistory?: string[] })
+        .codegraphyStatusHistory = statusHistory;
+      new MutationObserver(captureStatus).observe(document.body, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+      captureStatus();
+    });
+
+    await frame.getByRole('button', { name: 'Re-index Workspace' }).click();
+    await expect(frame.getByText(/\d+ files found/)).toBeVisible({ timeout: 15_000 });
+    for (let index = 0; index < 58; index += 1) {
+      fs.appendFileSync(
+        path.join(bulkPath, `file-${index}.ts`),
+        `// changed during re-index ${'x'.repeat(100_000)}\n`,
+      );
+    }
+
+    const cacheUpdateStatus = context.vscode.page.getByText(
+      /CodeGraphy: (?:\d+ changes? queued|Updating \d+ files?|.+ \d+\/\d+)/,
+    );
+    await expect(cacheUpdateStatus).toBeVisible({ timeout: 15_000 });
+    await expect(context.vscode.page.getByText(/CodeGraphy: .+ \d+\/\d+/))
+      .toBeVisible({ timeout: 15_000 });
+    await expect(frame.getByRole('progressbar', { name: 'Indexing progress' }))
+      .toBeHidden({ timeout: 60_000 });
+    await expect(cacheUpdateStatus).toBeHidden({ timeout: 30_000 });
+    const statusHistory = await context.vscode.page.evaluate(() => (
+      (globalThis as typeof globalThis & { codegraphyStatusHistory?: string[] })
+        .codegraphyStatusHistory ?? []
+    ));
+    expect(statusHistory).toEqual(expect.arrayContaining([
+      expect.stringMatching(/CodeGraphy: .+ \d+\/\d+/),
+    ]));
+  } finally {
+    await context.cleanup();
+  }
+});
+
 for (const { kind, name } of [
   { kind: 'File', name: 'bug-247-child.ts' },
   { kind: 'Folder', name: 'bug-247-child' },

--- a/packages/extension/tests/playwright-vscode/live-workspace-indexing.spec.ts
+++ b/packages/extension/tests/playwright-vscode/live-workspace-indexing.spec.ts
@@ -60,9 +60,37 @@ test('Re-index streams live progress and drains workspace changes queued during 
       });
       captureStatus();
     });
+    await frame.locator('body').evaluate(() => {
+      const progressHistory: string[] = [];
+      const captureProgress = (): void => {
+        const value = document.querySelector('[data-testid="graph-index-status-track"]')
+          ?.getAttribute('aria-valuetext');
+        if (value && progressHistory.at(-1) !== value) {
+          progressHistory.push(value);
+        }
+      };
+      (globalThis as typeof globalThis & { codegraphyIndexProgressHistory?: string[] })
+        .codegraphyIndexProgressHistory = progressHistory;
+      new MutationObserver(captureProgress).observe(document.body, {
+        attributes: true,
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+      captureProgress();
+    });
 
     await frame.getByRole('button', { name: 'Re-index Workspace' }).click();
-    await expect(frame.getByText(/\d+ files found/)).toBeVisible({ timeout: 15_000 });
+    await expect.poll(async () => frame.locator('body').evaluate(() => {
+      const history = (
+        globalThis as typeof globalThis & { codegraphyIndexProgressHistory?: string[] }
+      ).codegraphyIndexProgressHistory ?? [];
+      const progressIsVisible = document.querySelector(
+        '[data-testid="graph-index-status-track"]',
+      ) !== null;
+      return progressIsVisible
+        && history.some(value => /^Discovering Files \d+ candidate files? found$/.test(value));
+    }), { timeout: 15_000 }).toBe(true);
     for (let index = 0; index < 58; index += 1) {
       fs.appendFileSync(
         path.join(bulkPath, `file-${index}.ts`),
@@ -74,18 +102,44 @@ test('Re-index streams live progress and drains workspace changes queued during 
       /CodeGraphy: (?:\d+ changes? queued|Updating \d+ files?|.+ \d+\/\d+)/,
     );
     await expect(cacheUpdateStatus).toBeVisible({ timeout: 15_000 });
-    await expect(context.vscode.page.getByText(/CodeGraphy: .+ \d+\/\d+/))
-      .toBeVisible({ timeout: 15_000 });
+    const vscodePage = context.vscode.page;
+    await expect.poll(() => vscodePage.evaluate(() => (
+      (globalThis as typeof globalThis & { codegraphyStatusHistory?: string[] })
+        .codegraphyStatusHistory?.some(value => /CodeGraphy: .+ \d+\/\d+/.test(value))
+        ?? false
+    )), { timeout: 15_000 }).toBe(true);
     await expect(frame.getByRole('progressbar', { name: 'Indexing progress' }))
       .toBeHidden({ timeout: 60_000 });
     await expect(cacheUpdateStatus).toBeHidden({ timeout: 30_000 });
+    const indexProgressHistory = await frame.locator('body').evaluate(() => (
+      (globalThis as typeof globalThis & { codegraphyIndexProgressHistory?: string[] })
+        .codegraphyIndexProgressHistory ?? []
+    ));
+    const discoveryCounts = indexProgressHistory.flatMap((value) => {
+      const match = /^Discovering Files (\d+) candidate files? found$/.exec(value);
+      return match?.[1] ? [Number(match[1])] : [];
+    });
+    const analysisPercents = indexProgressHistory.flatMap((value) => {
+      const match = /^Analyzing Files (\d+)%$/.exec(value);
+      return match?.[1] ? [Number(match[1])] : [];
+    });
+    expect(new Set(discoveryCounts).size).toBeGreaterThanOrEqual(2);
+    expect(Math.max(...discoveryCounts)).toBeGreaterThan(Math.min(...discoveryCounts));
+    expect(new Set(analysisPercents).size).toBeGreaterThanOrEqual(2);
+    expect(Math.max(...analysisPercents)).toBeGreaterThan(Math.min(...analysisPercents));
     const statusHistory = await context.vscode.page.evaluate(() => (
       (globalThis as typeof globalThis & { codegraphyStatusHistory?: string[] })
         .codegraphyStatusHistory ?? []
     ));
-    expect(statusHistory).toEqual(expect.arrayContaining([
-      expect.stringMatching(/CodeGraphy: .+ \d+\/\d+/),
-    ]));
+    const applyingChanges = statusHistory.flatMap((value) => {
+      const match = /CodeGraphy: Applying Changes (\d+)\/(\d+)/.exec(value);
+      return match?.[1] && match[2]
+        ? [{ current: Number(match[1]), total: Number(match[2]) }]
+        : [];
+    });
+    expect(applyingChanges.length).toBeGreaterThanOrEqual(2);
+    expect(applyingChanges.some(({ current, total }) => current < total)).toBe(true);
+    expect(applyingChanges.at(-1)).toEqual({ current: 58, total: 58 });
   } finally {
     await context.cleanup();
   }

--- a/packages/extension/tests/webview/graphIndexStatus/view.test.tsx
+++ b/packages/extension/tests/webview/graphIndexStatus/view.test.tsx
@@ -85,16 +85,22 @@ describe('GraphIndexStatus', () => {
     expect(status.className).not.toContain('left-2');
   });
 
-  it('shows zero progress when the total is zero', () => {
+  it('shows live discovery counts as indeterminate progress when the total is unknown', () => {
     render(
       <GraphIndexStatus
         isIndexing={true}
-        progress={{ phase: 'Indexing Workspace', current: 3, total: 0 }}
+        progress={{ phase: 'Discovering Files', current: 25, total: 0 }}
         showMinimap={false}
       />,
     );
 
-    expect(screen.getByText('0%')).toBeInTheDocument();
-    expect(screen.getByTestId('graph-index-status-fill')).toHaveStyle({ width: '0%' });
+    expect(screen.getByText('25 files found')).toBeInTheDocument();
+    expect(screen.queryByText('0%')).not.toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Indexing progress' }))
+      .not.toHaveAttribute('aria-valuenow');
+    expect(screen.getByTestId('graph-index-status-fill')).toHaveAttribute(
+      'data-codegraphy-progress',
+      'indeterminate',
+    );
   });
 });

--- a/packages/extension/tests/webview/graphIndexStatus/view.test.tsx
+++ b/packages/extension/tests/webview/graphIndexStatus/view.test.tsx
@@ -36,8 +36,14 @@ describe('GraphIndexStatus', () => {
     expect(screen.getByTestId('graph-index-status')).toBeInTheDocument();
     expect(screen.getByText('Indexing Workspace')).toBeInTheDocument();
     expect(screen.getByText('25%')).toBeInTheDocument();
-    expect(screen.getByRole('progressbar', { name: 'Indexing progress' })).toHaveAttribute('aria-valuenow', '25');
-    expect(screen.getByTestId('graph-index-status-fill')).toHaveStyle({ width: '25%' });
+    expect(screen.getByRole('progressbar', { name: 'Indexing progress' }))
+      .toHaveAttribute('aria-valuenow', '25');
+    expect(screen.getByRole('progressbar', { name: 'Indexing progress' }))
+      .toHaveAttribute('aria-valuetext', 'Indexing Workspace 25%');
+    const fill = screen.getByTestId('graph-index-status-fill');
+    expect(fill).toHaveStyle({ width: '25%' });
+    expect(fill.className).toContain('transition-all');
+    expect(fill).toHaveAttribute('data-codegraphy-progress', 'determinate');
   });
 
   it('does not capture pointer events from graph controls and popups', () => {
@@ -81,6 +87,9 @@ describe('GraphIndexStatus', () => {
 
     const status = screen.getByTestId('graph-index-status');
     expect(status).toHaveStyle({ left: '192px' });
+    expect(status.className).toBe(
+      'pointer-events-none absolute right-12 bottom-2 z-20 rounded-md border border-border bg-[var(--cg-popover-translucent)] px-2 py-1.5 shadow-sm backdrop-blur-sm',
+    );
     expect(status.className).not.toContain('left-44');
     expect(status.className).not.toContain('left-2');
   });
@@ -94,13 +103,44 @@ describe('GraphIndexStatus', () => {
       />,
     );
 
-    expect(screen.getByText('25 files found')).toBeInTheDocument();
+    expect(screen.getByText('25 candidate files found')).toBeInTheDocument();
     expect(screen.queryByText('0%')).not.toBeInTheDocument();
     expect(screen.getByRole('progressbar', { name: 'Indexing progress' }))
       .not.toHaveAttribute('aria-valuenow');
+    expect(screen.getByRole('progressbar', { name: 'Indexing progress' }))
+      .toHaveAttribute('aria-valuetext', 'Discovering Files 25 candidate files found');
     expect(screen.getByTestId('graph-index-status-fill')).toHaveAttribute(
       'data-codegraphy-progress',
       'indeterminate',
     );
+    expect(screen.getByTestId('graph-index-status-fill').className)
+      .toContain('animate-index-progress');
+  });
+
+  it('uses singular discovery wording for one candidate file', () => {
+    render(
+      <GraphIndexStatus
+        isIndexing={true}
+        progress={{ phase: 'Discovering Files', current: 1, total: 0 }}
+        showMinimap={false}
+      />,
+    );
+
+    expect(screen.getByText('1 candidate file found')).toBeInTheDocument();
+  });
+
+  it('keeps invalid determinate values inside the progress range', () => {
+    render(
+      <GraphIndexStatus
+        isIndexing={true}
+        progress={{ phase: 'Analyzing Files', current: 12, total: 10 }}
+        showMinimap={false}
+      />,
+    );
+
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Indexing progress' }))
+      .toHaveAttribute('aria-valuenow', '100');
+    expect(screen.getByTestId('graph-index-status-fill')).toHaveStyle({ width: '100%' });
   });
 });


### PR DESCRIPTION
## Summary

- stream candidate-file counts during File Discovery and move an indeterminate bar until the total is known
- yield cached analysis every 25 files so VS Code can paint per-file progress
- forward incremental update progress through the fingerprint and provider boundaries
- show live phase and current/total values in the VS Code footer, then hide it when the queue drains
- clamp displayed progress values and label discovery counts as candidate files

## Root cause

File Discovery emitted only 0/1 before scanning and 1/1 after scanning. Cached analysis could finish a long microtask chain before VS Code received a host turn to paint. For queued workspace changes, later events could replace the active status with queued while the active batch waited behind Re-index, and the fingerprint adapter discarded its progress callback.

## Cleanup

- reuse the existing GraphViewIndexingProgress type across the provider path
- remove compatibility-style optional-argument branching
- name the discovery and analysis scheduling intervals
- add patch changesets for Core and the VS Code extension
- strengthen the real-host test to require multiple increasing discovery, analysis, and queued-update values

## Verification

- Core focused tests: 53 passed
- Extension focused node tests: 46 passed
- Extension focused webview tests: 9 passed
- Complete extension node suite: 531 files and 2,830 tests passed
- Direct Core, extension, extension-test, and Playwright TypeScript checks: passed
- Changed-file ESLint: passed
- GraphIndexStatus mutation testing: 37/37 mutants killed, 100% score
- File Discovery mutation testing: all 10 progress-behavior mutants killed; the older module remains at 76.92% overall with 156 mutation sites
- VS Code 1.129.1 Playwright: 800-file workspace, 58 edits during Re-index, multiple live discovery counts, multiple analysis percentages, partial and final Applying Changes values, and final footer removal: passed in 8.6s
- Extension VS Code build: 10 package tasks passed
- Changesets status: Core and extension patch releases resolve successfully
- Final pushed commit: 509e9b8bc
- Final-head CI: all 36 jobs passed

## Visual proof

Live analysis progress from the final build:

![Live analysis progress](https://github.com/user-attachments/assets/faab4566-5f05-4741-8831-9a7465ef9670)

Queued workspace updates advancing after Re-index:

![Live queued update progress](https://github.com/user-attachments/assets/9a8fe48c-a6ee-41b5-aa84-807fe9a92d63)



