### PR TITLE
Stabilize Favorite and VSIX activation CI tests

### DIFF
--- a/packages/extension/src/e2e/suite/graph/fixture.ts
+++ b/packages/extension/src/e2e/suite/graph/fixture.ts
@@ -5,10 +5,10 @@ import * as vscode from 'vscode';
 import type { IGraphData } from '../../../shared/graph/contracts';
 import { getCurrentE2EScenario } from '../../scenarios';
 import {
-  waitForExtensionMessage,
   waitForExtensionMessageWhere,
   waitForGraphIndexStatus,
 } from './messages';
+import { includesExpectedEdgeIds } from './readiness';
 
 export interface CodeGraphyAPI {
   refresh(): Promise<void>;
@@ -68,17 +68,13 @@ export function assertIncludesAll(
   assert.deepStrictEqual(missingIds, [], `${label} missing from ${actualIds.join(', ')}`);
 }
 
-function edgeIdMatchesExpected(actualId: string, expectedId: string): boolean {
-  return actualId === expectedId || actualId.startsWith(`${expectedId}:`);
-}
-
 export function assertIncludesAllEdges(
   actualIds: readonly string[],
   expectedIds: readonly string[],
   label: string,
 ): void {
   const missingIds = expectedIds.filter(
-    expectedId => !actualIds.some(actualId => edgeIdMatchesExpected(actualId, expectedId)),
+    expectedId => !includesExpectedEdgeIds(actualIds, [expectedId]),
   );
   assert.deepStrictEqual(missingIds, [], `${label} missing from ${actualIds.join(', ')}`);
 }
@@ -142,17 +138,20 @@ export async function ensureIndexedGraph(api: CodeGraphyAPI): Promise<void> {
 
   indexedGraphPromise ??= (async () => {
     const timeoutMs = getIndexTimeoutMs();
-    const graphUpdated = scenario.name === 'codegraphy-root'
-      ? waitForExtensionMessageWhere<{
-        type: 'GRAPH_DATA_UPDATED';
-        payload: IGraphData;
-      }>(
-        api,
-        'GRAPH_DATA_UPDATED',
-        message => message.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD,
-        timeoutMs,
-      )
-      : waitForExtensionMessage(api, 'GRAPH_DATA_UPDATED', timeoutMs);
+    const graphUpdated = waitForExtensionMessageWhere<{
+      type: 'GRAPH_DATA_UPDATED';
+      payload: IGraphData;
+    }>(
+      api,
+      'GRAPH_DATA_UPDATED',
+      message => scenario.name === 'codegraphy-root'
+        ? message.payload.edges.length > CODEGRAPHY_ROOT_PROVIDER_EDGE_THRESHOLD
+        : includesExpectedEdgeIds(
+          message.payload.edges.map(edge => String(edge.id)),
+          scenario.minimumExpectedEdgeIds,
+        ),
+      timeoutMs,
+    );
     const indexUpdated = waitForGraphIndexStatus(api, true, timeoutMs);
     await api.dispatchWebviewMessage({ type: 'INDEX_GRAPH' });
     await Promise.all([graphUpdated, indexUpdated]);

--- a/packages/extension/src/e2e/suite/graph/fixture.ts
+++ b/packages/extension/src/e2e/suite/graph/fixture.ts
@@ -8,7 +8,7 @@ import {
   waitForExtensionMessageWhere,
   waitForGraphIndexStatus,
 } from './messages';
-import { includesExpectedEdgeIds } from './readiness';
+import { includesExpectedEdgeIds, missingExpectedEdgeIds } from './readiness';
 
 export interface CodeGraphyAPI {
   refresh(): Promise<void>;
@@ -151,6 +151,13 @@ export async function ensureIndexedGraph(api: CodeGraphyAPI): Promise<void> {
           scenario.minimumExpectedEdgeIds,
         ),
       timeoutMs,
+      message => {
+        const edgeIds = message.payload.edges.map(edge => String(edge.id));
+        const missingIds = scenario.name === 'codegraphy-root'
+          ? []
+          : missingExpectedEdgeIds(edgeIds, scenario.minimumExpectedEdgeIds);
+        return `${message.payload.nodes.length} node(s), ${edgeIds.length} edge(s), missing ${missingIds.join(', ') || 'none'}`;
+      },
     );
     const indexUpdated = waitForGraphIndexStatus(api, true, timeoutMs);
     await api.dispatchWebviewMessage({ type: 'INDEX_GRAPH' });

--- a/packages/extension/src/e2e/suite/graph/messages.ts
+++ b/packages/extension/src/e2e/suite/graph/messages.ts
@@ -26,15 +26,21 @@ export function waitForExtensionMessageWhere<TMessage>(
   type: string,
   predicate: (message: TMessage) => boolean,
   timeoutMs: number,
+  describeCandidate?: (message: TMessage) => string,
 ): Promise<TMessage> {
   return new Promise((resolve, reject) => {
+    let lastCandidateDescription = 'no message of this type was received';
     const timer = setTimeout(
-      () => reject(new Error(`Timed out waiting for webview message: ${type}`)),
+      () => reject(new Error(
+        `Timed out waiting for webview message: ${type}. Last candidate: ${lastCandidateDescription}`,
+      )),
       timeoutMs,
     );
     const disposable = api.onExtensionMessage((candidate: unknown) => {
       const message = candidate as TMessage & { type?: string };
-      if (message.type !== type || !predicate(message)) return;
+      if (message.type !== type) return;
+      lastCandidateDescription = describeCandidate?.(message) ?? 'message did not match the predicate';
+      if (!predicate(message)) return;
       clearTimeout(timer);
       disposable.dispose();
       resolve(message);

--- a/packages/extension/src/e2e/suite/graph/readiness.ts
+++ b/packages/extension/src/e2e/suite/graph/readiness.ts
@@ -6,7 +6,14 @@ export function includesExpectedEdgeIds(
   actualIds: readonly string[],
   expectedIds: readonly string[],
 ): boolean {
-  return expectedIds.every(
-    expectedId => actualIds.some(actualId => edgeIdMatchesExpected(actualId, expectedId)),
+  return missingExpectedEdgeIds(actualIds, expectedIds).length === 0;
+}
+
+export function missingExpectedEdgeIds(
+  actualIds: readonly string[],
+  expectedIds: readonly string[],
+): string[] {
+  return expectedIds.filter(
+    expectedId => !actualIds.some(actualId => edgeIdMatchesExpected(actualId, expectedId)),
   );
 }

--- a/packages/extension/src/e2e/suite/graph/readiness.ts
+++ b/packages/extension/src/e2e/suite/graph/readiness.ts
@@ -1,0 +1,12 @@
+function edgeIdMatchesExpected(actualId: string, expectedId: string): boolean {
+  return actualId === expectedId || actualId.startsWith(`${expectedId}:`);
+}
+
+export function includesExpectedEdgeIds(
+  actualIds: readonly string[],
+  expectedIds: readonly string[],
+): boolean {
+  return expectedIds.every(
+    expectedId => actualIds.some(actualId => edgeIdMatchesExpected(actualId, expectedId)),
+  );
+}

--- a/packages/extension/tests/acceptance/graphView/canvas.ts
+++ b/packages/extension/tests/acceptance/graphView/canvas.ts
@@ -520,20 +520,26 @@ export async function expectNodeHasLabel(frame: Frame, probe: NodeProbe): Promis
 
 export async function expectNodeIsOutlined(
   frame: Frame,
-  probe: NodeProbe,
+  nodePath: string,
   color: NodeOutlineColor = 'white',
 ): Promise<void> {
   await expect.poll(
-    async () => (await analyzeNodePixels(frame, probe, NODE_OUTLINE_RGB[color])).outlinePixelCount,
+    async () => {
+      const currentProbe = await readNodeProbe(frame, nodePath);
+      return (await analyzeNodePixels(frame, currentProbe, NODE_OUTLINE_RGB[color])).outlinePixelCount;
+    },
   ).toBeGreaterThan(MIN_VISIBLE_PIXEL_COUNT);
 }
 
 export async function expectNodeIsNotOutlined(
   frame: Frame,
-  probe: NodeProbe,
+  nodePath: string,
 ): Promise<void> {
   await expect.poll(
-    async () => (await analyzeNodePixels(frame, probe, NODE_OUTLINE_RGB.white)).outlinePixelCount,
+    async () => {
+      const currentProbe = await readNodeProbe(frame, nodePath);
+      return (await analyzeNodePixels(frame, currentProbe, NODE_OUTLINE_RGB.white)).outlinePixelCount;
+    },
   ).toBeLessThanOrEqual(MIN_VISIBLE_PIXEL_COUNT);
 }
 

--- a/packages/extension/tests/acceptance/graphView/steps.ts
+++ b/packages/extension/tests/acceptance/graphView/steps.ts
@@ -514,7 +514,8 @@ const exactGraphViewAcceptanceSteps: Record<string, AcceptanceStepImplementation
   },
 
   'the src/index.ts node is visibly outlined': async (context) => {
-    await expectNodeIsOutlined(requireGraphFrame(context), await findNodeProbe(context, TARGET_NODE));
+    await findNodeProbe(context, TARGET_NODE);
+    await expectNodeIsOutlined(requireGraphFrame(context), TARGET_NODE);
   },
 
   'src/index.ts opens in VS Code': async (context) => {
@@ -669,7 +670,8 @@ const patternGraphViewAcceptanceSteps: PatternAcceptanceStep[] = [
   }),
 
   step(/^the (.+) node is no longer visibly outlined$/, async (context, _step, match) => {
-    await expectNodeIsNotOutlined(requireGraphFrame(context), await findNodeProbe(context, match[1]));
+    await findNodeProbe(context, match[1]);
+    await expectNodeIsNotOutlined(requireGraphFrame(context), match[1]);
   }),
 
   step(/^Escape closes each built-in panel and focuses the Graph Stage$/, async (context) => {
@@ -806,11 +808,13 @@ const patternGraphViewAcceptanceSteps: PatternAcceptanceStep[] = [
   }),
 
   step(/^the (.+) node is visibly outlined in white$/, async (context, _step, match) => {
-    await expectNodeIsOutlined(requireGraphFrame(context), await findNodeProbe(context, match[1]));
+    await findNodeProbe(context, match[1]);
+    await expectNodeIsOutlined(requireGraphFrame(context), match[1]);
   }),
 
   step(/^the (.+) node is visibly outlined in orange$/, async (context, _step, match) => {
-    await expectNodeIsOutlined(requireGraphFrame(context), await findNodeProbe(context, match[1]), 'orange');
+    await findNodeProbe(context, match[1]);
+    await expectNodeIsOutlined(requireGraphFrame(context), match[1], 'orange');
   }),
 
   step(/^the (.+) node is no longer outlined$/, async (context, _step, match) => {
@@ -1154,7 +1158,8 @@ const patternGraphViewAcceptanceSteps: PatternAcceptanceStep[] = [
   }),
 
   step(/^I see all the selected nodes outlined in white$/, async (context) => {
-    await expectNodeIsOutlined(requireGraphFrame(context), await findNodeProbe(context, TARGET_NODE));
+    await findNodeProbe(context, TARGET_NODE);
+    await expectNodeIsOutlined(requireGraphFrame(context), TARGET_NODE);
   }),
 
   step(/^VS Code should navigate to the Explorer sidebar tab$/, async (context) => {

--- a/packages/extension/tests/e2eGraphReadiness.test.ts
+++ b/packages/extension/tests/e2eGraphReadiness.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { includesExpectedEdgeIds } from '../src/e2e/suite/graph/readiness';
+import {
+  includesExpectedEdgeIds,
+  missingExpectedEdgeIds,
+} from '../src/e2e/suite/graph/readiness';
 
 const REQUIRED_EDGE_IDS = [
   'src/index.ts->src/palette.ts#import',
@@ -22,5 +25,13 @@ describe('E2E graph readiness', () => {
     expect(includesExpectedEdgeIds([
       'src/index.ts->src/palette.ts#import',
     ], REQUIRED_EDGE_IDS)).toBe(false);
+  });
+
+  it('reports the exact required Edges absent from the last graph publication', () => {
+    expect(missingExpectedEdgeIds([
+      'src/index.ts->src/palette.ts#import',
+    ], REQUIRED_EDGE_IDS)).toEqual([
+      'src/index.ts->src/types.ts#import',
+    ]);
   });
 });

--- a/packages/extension/tests/e2eGraphReadiness.test.ts
+++ b/packages/extension/tests/e2eGraphReadiness.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { includesExpectedEdgeIds } from '../src/e2e/suite/graph/readiness';
+
+const REQUIRED_EDGE_IDS = [
+  'src/index.ts->src/palette.ts#import',
+  'src/index.ts->src/types.ts#import',
+];
+
+describe('E2E graph readiness', () => {
+  it('does not accept the empty graph publication sent while Indexing starts', () => {
+    expect(includesExpectedEdgeIds([], REQUIRED_EDGE_IDS)).toBe(false);
+  });
+
+  it('accepts a graph publication only after all required scenario Edges arrive', () => {
+    expect(includesExpectedEdgeIds([
+      'src/index.ts->src/palette.ts#import:tree-sitter',
+      'src/index.ts->src/types.ts#import',
+    ], REQUIRED_EDGE_IDS)).toBe(true);
+  });
+
+  it('keeps waiting when a graph publication contains only part of the scenario', () => {
+    expect(includesExpectedEdgeIds([
+      'src/index.ts->src/palette.ts#import',
+    ], REQUIRED_EDGE_IDS)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [Trello #272](https://trello.com/c/WngADWJZ/272-stabilize-flaky-favorite-playwright-and-windows-vsix-activation-ci-tests).

- refreshes the live Node probe for every Favorite outline pixel sample so active software-WebGPU layout cannot leave the assertion sampling stale coordinates
- waits for a `GRAPH_DATA_UPDATED` publication that contains every required scenario Edge instead of accepting the empty publication emitted while Indexing starts
- adds focused graph-readiness regression tests for empty, partial, and complete publications
- reports the last publication's Node and Edge counts plus exact missing required Edge IDs when Indexing is genuinely incomplete

## Diagnosis

- Favorite CI rendered the graph and target Node, but the assertion reused coordinates captured before the context-menu action while layout continued.
- Windows VSIX logged `Graph built: 18 nodes, 26 edges`, but `ensureIndexedGraph` resolved on an earlier empty graph publication and the smoke assertion read `[]`.

## Verification

- focused graph-readiness and canvas helper tests: 11 passed
- Extension E2E TypeScript compilation: passed
- software-WebGPU Favorite Playwright scenario: 3/3 repeated runs passed
- installed Darwin VSIX activation smoke: 3/3 repeated runs passed; every run built 18 Nodes and 26 Edges and passed all three smoke assertions

- exact head `81fe46ad`: 38/38 CI checks passed, including the software-WebGPU Favorite shard and Windows VSIX activation
