### PR TITLE
Speed up filtered and Git-ignored file discovery

### DIFF
--- a/packages/core/src/discovery/contracts.ts
+++ b/packages/core/src/discovery/contracts.ts
@@ -23,7 +23,7 @@ export interface IDiscoveryOptions {
   extensions?: string[];
   /** Abort signal for cancelling long-running discovery */
   signal?: AbortSignal;
-  /** Reports candidate files while the workspace scan is still running. */
+  /** Reports files eligible for fresh indexing after Filters and Git ignored state apply. */
   onProgress?: (progress: { current: number }) => void;
 }
 

--- a/packages/core/src/discovery/contracts.ts
+++ b/packages/core/src/discovery/contracts.ts
@@ -64,4 +64,6 @@ export interface IDiscoveryResult {
 /** Internal indexing result with paths allowed to remain in the Graph Cache. */
 export interface IFileDiscoveryResult extends IDiscoveryResult {
   cacheFilePaths: string[];
+  /** Directory roots whose cached descendants remain reusable without filesystem traversal. */
+  cachePathPrefixes: string[];
 }

--- a/packages/core/src/discovery/file/service.ts
+++ b/packages/core/src/discovery/file/service.ts
@@ -15,6 +15,12 @@ import { DEFAULT_INCLUDE, EMPTY_PATTERNS, DEFAULT_MAX_FILES } from './defaults';
 
 const DISCOVERY_PROGRESS_INTERVAL = 25;
 
+interface GitWorkspacePaths {
+  candidatePaths: string[];
+  ignoredPaths: string[];
+  ignoredPathPrefixes: string[];
+}
+
 function reportEligibleFileProgress(
   eligibleFileCount: number,
   onProgress?: IDiscoveryOptions['onProgress'],
@@ -58,6 +64,52 @@ function createDiscoveredFile(
 
 function toGitPath(relativePath: string): string {
   return relativePath.split(path.sep).join('/');
+}
+
+function fromGitPath(gitPath: string): string {
+  return gitPath.split('/').join(path.sep);
+}
+
+function runGitPathQuery(rootPath: string, args: readonly string[]): string[] | undefined {
+  const result = spawnSync('git', ['-C', rootPath, ...args], {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.error || result.status !== 0) return undefined;
+  return result.stdout.split('\0').filter(Boolean);
+}
+
+function collectGitWorkspacePaths(rootPath: string): GitWorkspacePaths | undefined {
+  const candidateGitPaths = runGitPathQuery(rootPath, [
+    'ls-files',
+    '--cached',
+    '--others',
+    '--exclude-standard',
+    '--deduplicate',
+    '-z',
+  ]);
+  const ignoredGitPaths = runGitPathQuery(rootPath, [
+    'ls-files',
+    '--others',
+    '--ignored',
+    '--exclude-standard',
+    '--directory',
+    '-z',
+  ]);
+  if (!candidateGitPaths || !ignoredGitPaths) return undefined;
+
+  const ignoredPaths: string[] = [];
+  const ignoredPathPrefixes: string[] = [];
+  for (const gitPath of ignoredGitPaths) {
+    const directory = gitPath.endsWith('/');
+    const relativePath = fromGitPath(directory ? gitPath.slice(0, -1) : gitPath);
+    (directory ? ignoredPathPrefixes : ignoredPaths).push(relativePath);
+  }
+  return {
+    candidatePaths: candidateGitPaths.map(fromGitPath),
+    ignoredPaths,
+    ignoredPathPrefixes,
+  };
 }
 
 function createGitPathBatches(gitPaths: readonly string[]): string[][] {
@@ -143,6 +195,34 @@ function collectContainingDirectories(filePaths: readonly string[]): Set<string>
   return directories;
 }
 
+function collectGitCandidateFiles(
+  rootPath: string,
+  relativePaths: readonly string[],
+  includePatterns: string[],
+  excludePatterns: string[],
+  extensions: string[],
+): Array<{ absolutePath: string; relativePath: string }> {
+  const files: Array<{ absolutePath: string; relativePath: string }> = [];
+  for (const relativePath of relativePaths) {
+    const absolutePath = path.join(rootPath, relativePath);
+    let isFile = false;
+    try {
+      isFile = fs.lstatSync(absolutePath).isFile();
+    } catch {
+      continue;
+    }
+    if (isFile && shouldIncludeFile(relativePath, absolutePath, {
+      includePatterns,
+      excludePatterns,
+      extensions,
+      gitignore: null,
+    })) {
+      files.push({ absolutePath, relativePath });
+    }
+  }
+  return files;
+}
+
 function filterEligibleDirectories(
   directories: readonly string[],
   candidateFilePaths: readonly string[],
@@ -178,38 +258,53 @@ export class FileDiscovery {
     throwIfAborted(signal);
 
     const allExclude = [...DEFAULT_EXCLUDE, ...excludePatterns];
+    const gitWorkspacePaths = respectGitignore ? collectGitWorkspacePaths(rootPath) : undefined;
     const candidateFiles: Array<{ absolutePath: string; relativePath: string }> = [];
     const directories: string[] = [];
-
-    await walkDirectory(
-      rootPath,
-      rootPath,
-      (relativePath, absolutePath) => {
-        throwIfAborted(signal);
-
-        if (shouldIncludeFile(relativePath, absolutePath, {
-          includePatterns,
-          excludePatterns: allExclude,
-          extensions,
-          gitignore: null,
-        })) {
-          candidateFiles.push({ absolutePath, relativePath });
-        }
-        return true;
-      },
-      relativePath => {
-        directories.push(relativePath);
-      },
-      signal,
-    );
-
-    const gitIgnoredPaths = respectGitignore
-      ? collectGitIgnoredPaths(
+    if (gitWorkspacePaths) {
+      candidateFiles.push(...collectGitCandidateFiles(
         rootPath,
+        gitWorkspacePaths.candidatePaths,
+        includePatterns,
+        allExclude,
+        extensions,
+      ));
+      directories.push(...collectContainingDirectories(
         candidateFiles.map(file => file.relativePath),
-        directories,
-      )
-      : new Set<string>();
+      ));
+    } else {
+      await walkDirectory(
+        rootPath,
+        rootPath,
+        (relativePath, absolutePath) => {
+          throwIfAborted(signal);
+
+          if (shouldIncludeFile(relativePath, absolutePath, {
+            includePatterns,
+            excludePatterns: allExclude,
+            extensions,
+            gitignore: null,
+          })) {
+            candidateFiles.push({ absolutePath, relativePath });
+          }
+          return true;
+        },
+        relativePath => {
+          directories.push(relativePath);
+        },
+        signal,
+      );
+    }
+
+    const gitIgnoredPaths = gitWorkspacePaths
+      ? new Set(gitWorkspacePaths.ignoredPaths)
+      : respectGitignore
+        ? collectGitIgnoredPaths(
+          rootPath,
+          candidateFiles.map(file => file.relativePath),
+          directories,
+        )
+        : new Set<string>();
     const eligibleFiles = candidateFiles.filter(file => (
       !matchesAnyPattern(file.relativePath, filterPatterns)
       && !gitIgnoredPaths.has(file.relativePath)
@@ -219,12 +314,15 @@ export class FileDiscovery {
     const indexedFiles = eligibleFiles.slice(0, maxFiles);
     const indexedFilePaths = new Set(indexedFiles.map(file => file.relativePath));
     const eligibleFilePaths = new Set(eligibleFiles.map(file => file.relativePath));
-    const cacheFilePaths = candidateFiles
+    const cacheFilePaths = [
+      ...candidateFiles
       .filter(file => (
         !eligibleFilePaths.has(file.relativePath)
         || indexedFilePaths.has(file.relativePath)
       ))
-      .map(file => file.relativePath);
+      .map(file => file.relativePath),
+      ...gitIgnoredPaths,
+    ];
     const files = indexedFiles
       .map(file => createDiscoveredFile(file.relativePath, file.absolutePath, false));
     const eligibleDirectories = filterEligibleDirectories(
@@ -239,8 +337,12 @@ export class FileDiscovery {
     return {
       files,
       cacheFilePaths,
+      cachePathPrefixes: gitWorkspacePaths?.ignoredPathPrefixes ?? [],
       directories: eligibleDirectories,
-      gitIgnoredPaths: [...gitIgnoredPaths],
+      gitIgnoredPaths: [
+        ...gitIgnoredPaths,
+        ...(gitWorkspacePaths?.ignoredPathPrefixes ?? []),
+      ],
       limitReached,
       totalFound: limitReached ? eligibleFiles.length : undefined,
       durationMs,

--- a/packages/core/src/discovery/file/service.ts
+++ b/packages/core/src/discovery/file/service.ts
@@ -15,6 +15,22 @@ import { DEFAULT_INCLUDE, EMPTY_PATTERNS, DEFAULT_MAX_FILES } from './defaults';
 
 const DISCOVERY_PROGRESS_INTERVAL = 25;
 
+function reportEligibleFileProgress(
+  eligibleFileCount: number,
+  onProgress?: IDiscoveryOptions['onProgress'],
+): void {
+  if (eligibleFileCount === 0) return;
+
+  onProgress?.({ current: 1 });
+  for (
+    let current = DISCOVERY_PROGRESS_INTERVAL;
+    current <= eligibleFileCount;
+    current += DISCOVERY_PROGRESS_INTERVAL
+  ) {
+    onProgress?.({ current });
+  }
+}
+
 function getDiscoveryConfig(options: IDiscoveryOptions) {
   return {
     maxFiles: options.maxFiles ?? DEFAULT_MAX_FILES,
@@ -178,10 +194,6 @@ export class FileDiscovery {
           gitignore: null,
         })) {
           candidateFiles.push({ absolutePath, relativePath });
-          const current = candidateFiles.length;
-          if (current === 1 || current % DISCOVERY_PROGRESS_INTERVAL === 0) {
-            options.onProgress?.({ current });
-          }
         }
         return true;
       },
@@ -202,6 +214,7 @@ export class FileDiscovery {
       !matchesAnyPattern(file.relativePath, filterPatterns)
       && !gitIgnoredPaths.has(file.relativePath)
     ));
+    reportEligibleFileProgress(eligibleFiles.length, options.onProgress);
     const limitReached = eligibleFiles.length > maxFiles;
     const indexedFiles = eligibleFiles.slice(0, maxFiles);
     const indexedFilePaths = new Set(indexedFiles.map(file => file.relativePath));

--- a/packages/core/src/discovery/pathMatching.ts
+++ b/packages/core/src/discovery/pathMatching.ts
@@ -13,3 +13,17 @@ export function matchesAnyPattern(relativePath: string, patterns: readonly strin
     minimatch(normalizedPath, pattern, { dot: true, matchBase: true })
   );
 }
+
+export function matchesPathOrAncestor(
+  relativePath: string,
+  paths: ReadonlySet<string>,
+): boolean {
+  let candidate = normalizeDiscoveryPath(relativePath);
+  while (candidate) {
+    if (paths.has(candidate)) return true;
+    const separatorIndex = candidate.lastIndexOf('/');
+    if (separatorIndex < 0) return false;
+    candidate = candidate.slice(0, separatorIndex);
+  }
+  return false;
+}

--- a/packages/core/src/graph/fileNodes.ts
+++ b/packages/core/src/graph/fileNodes.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import type { IGraphNode } from './contracts';
+import { matchesPathOrAncestor } from '../discovery/pathMatching';
 import {
   getExternalPackageLabelFromNodeId,
   isExternalPackageNodeId,
@@ -49,7 +50,7 @@ export function buildWorkspaceFileNodes(options: {
       : createWorkspaceFileNode(
           filePath,
           options.cacheFiles,
-          options.gitIgnoredPathSet.has(filePath),
+          matchesPathOrAncestor(filePath, options.gitIgnoredPathSet),
         ));
   }
 

--- a/packages/core/src/graph/folderNodes.ts
+++ b/packages/core/src/graph/folderNodes.ts
@@ -1,5 +1,6 @@
 import type { IGraphNode } from './contracts';
 import { isExternalPackageNodeId } from './packageSpecifiers/nodeId';
+import { matchesPathOrAncestor } from '../discovery/pathMatching';
 
 const GIT_IGNORED_REASON = 'Git ignored';
 
@@ -46,7 +47,7 @@ export function buildDiscoveredDirectoryNodes(
 
   for (const directoryPath of directoryPaths) {
     const normalizedPath = normalizeDirectoryPath(directoryPath);
-    const isGitIgnoredDirectory = gitIgnoredPathSet.has(normalizedPath);
+    const isGitIgnoredDirectory = matchesPathOrAncestor(normalizedPath, gitIgnoredPathSet);
     const alreadyRepresented = !isGitIgnoredDirectory && fileFolderPaths.has(normalizedPath);
     if (!normalizedPath || alreadyRepresented || seen.has(normalizedPath)) {
       continue;

--- a/packages/core/src/graph/symbols.ts
+++ b/packages/core/src/graph/symbols.ts
@@ -1,4 +1,5 @@
 import type { IFileAnalysisResult } from '@codegraphy-dev/plugin-api';
+import { matchesPathOrAncestor } from '../discovery/pathMatching';
 import type { IGraphEdge, IGraphNode } from './contracts';
 import { collectProjectableNamespaceSymbolIds } from './namespaceSymbols';
 import { createCanonicalSymbolIds } from './symbolIds';
@@ -48,7 +49,9 @@ export function buildSymbolNodesAndEdges(
   const symbolIds = createCanonicalSymbolIds(fileAnalysis, workspaceRoot);
   const projectableNamespaceSymbolIds = collectProjectableNamespaceSymbolIds(fileAnalysis);
   const explicitlyContainedSymbolIds = collectExplicitlyContainedSymbolIds(fileAnalysis);
-  const gitIgnoredPathSet = new Set(options.gitIgnoredPaths ?? []);
+  const gitIgnoredPathSet = new Set(
+    (options.gitIgnoredPaths ?? []).map(relativePath => relativePath.replace(/\\/g, '/')),
+  );
   const containingFileIds = new Set<string>();
   const nodes: IGraphNode[] = [];
   const edges: IGraphEdge[] = [];
@@ -89,6 +92,6 @@ function createContainingFileMetadata(
 ): { fileSize?: number; gitIgnored: boolean } {
   return {
     fileSize: options.cacheFiles?.[relativeFilePath]?.size,
-    gitIgnored: options.gitIgnoredPathSet.has(relativeFilePath),
+    gitIgnored: matchesPathOrAncestor(relativeFilePath, options.gitIgnoredPathSet),
   };
 }

--- a/packages/core/src/indexing/discovery.ts
+++ b/packages/core/src/indexing/discovery.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_INCLUDE, DEFAULT_MAX_FILES } from '../discovery/file/defaults';
 import type { IFileDiscoveryResult } from '../discovery/contracts';
 import { FileDiscovery } from '../discovery/file/service';
+import { normalizeDiscoveryPath } from '../discovery/pathMatching';
 import type { CodeGraphyWorkspaceSettings } from '../workspace/settings';
 import type { IndexCodeGraphyWorkspaceOptions } from './contracts';
 
@@ -37,4 +38,17 @@ export async function discoverWorkspaceIndexFiles(input: {
   );
 
   return discoveryResult;
+}
+
+export function isRetainedWorkspaceIndexCachePath(
+  filePath: string,
+  cacheFilePaths: ReadonlySet<string>,
+  cachePathPrefixes: readonly string[],
+): boolean {
+  if (cacheFilePaths.has(filePath)) return true;
+  const normalizedFilePath = normalizeDiscoveryPath(filePath);
+  return cachePathPrefixes.some(prefix => (
+    normalizedFilePath === normalizeDiscoveryPath(prefix)
+    || normalizedFilePath.startsWith(`${normalizeDiscoveryPath(prefix)}/`)
+  ));
 }

--- a/packages/core/src/indexing/engineIndex.ts
+++ b/packages/core/src/indexing/engineIndex.ts
@@ -4,6 +4,7 @@ import { buildWorkspaceEngineGraph, createWorkspaceEngineIndexResult, replaceWor
 import { assertWorkspaceEngineActive, type WorkspaceEngineRuntime } from './engineRuntime';
 import { createWorkspaceEngineDisabledPlugins, discoverWorkspaceEngineFiles, initializeWorkspaceEngine } from './engineSetup';
 import { createWorkspaceIndexFileContentReader, findChangedWorkspaceIndexFiles } from './workspace/changes';
+import { isRetainedWorkspaceIndexCachePath } from './discovery';
 
 function sameDiscoveredFiles(
   before: readonly { relativePath: string }[],
@@ -26,7 +27,11 @@ export async function indexWorkspaceEngine(
   assertWorkspaceEngineActive(runtime);
   const cacheFilePaths = new Set(state.discoveryResult!.cacheFilePaths);
   for (const filePath of Object.keys(state.cache.files)) {
-    if (!cacheFilePaths.has(filePath)) {
+    if (!isRetainedWorkspaceIndexCachePath(
+      filePath,
+      cacheFilePaths,
+      state.discoveryResult!.cachePathPrefixes,
+    )) {
       delete state.cache.files[filePath];
     }
   }

--- a/packages/core/src/indexing/liveUpdate/eligibility.ts
+++ b/packages/core/src/indexing/liveUpdate/eligibility.ts
@@ -1,4 +1,4 @@
-import { matchesAnyPattern } from '../../discovery/pathMatching';
+import { matchesAnyPattern, matchesPathOrAncestor } from '../../discovery/pathMatching';
 import { isWorkspaceDiscoveryLifecyclePath } from '../../workspace/discoveryLifecycle';
 import type { CodeGraphyWorkspaceSettings } from '../../workspace/settings';
 
@@ -18,6 +18,6 @@ export function isWorkspaceLiveUpdatePathEligible(
 ): boolean {
   return isWorkspaceDiscoveryLifecyclePath(workspacePath) || (
     !matchesAnyPattern(workspacePath, activeFilterPatterns)
-    && !gitIgnoredPaths.has(workspacePath)
+    && !matchesPathOrAncestor(workspacePath, gitIgnoredPaths)
   );
 }

--- a/packages/core/src/indexing/workspace.ts
+++ b/packages/core/src/indexing/workspace.ts
@@ -17,7 +17,10 @@ import { readCodeGraphyWorkspaceStatus } from '../workspace/status';
 import { readCodeGraphyWorkspaceMeta } from '../workspace/meta';
 import { analyzeWorkspaceIndexFiles } from './analysis';
 import type { IndexCodeGraphyWorkspaceOptions, IndexCodeGraphyWorkspaceResult } from './contracts';
-import { discoverWorkspaceIndexFiles } from './discovery';
+import {
+  discoverWorkspaceIndexFiles,
+  isRetainedWorkspaceIndexCachePath,
+} from './discovery';
 import {
   createWorkspaceIndexPluginBuildSignature,
   createWorkspaceIndexPluginSignature,
@@ -224,7 +227,11 @@ export async function indexCodeGraphyWorkspace(
   }
   const cacheFilePaths = new Set(discoveryResult.cacheFilePaths);
   const deletedFilePaths = Object.keys(cache.files)
-    .filter(filePath => !cacheFilePaths.has(filePath));
+    .filter(filePath => !isRetainedWorkspaceIndexCachePath(
+      filePath,
+      cacheFilePaths,
+      discoveryResult.cachePathPrefixes,
+    ));
   const readContent = createWorkspaceIndexFileContentReader(discovery);
 
   if (canReusePersistedCache) {

--- a/packages/core/tests/discovery/file/discovery.discover.test.ts
+++ b/packages/core/tests/discovery/file/discovery.discover.test.ts
@@ -54,7 +54,7 @@ describe('FileDiscovery discover', () => {
     );
   });
 
-  it('reports candidate file counts while discovery is still running', async () => {
+  it('reports eligible candidate file counts during discovery', async () => {
     for (let index = 0; index < 26; index += 1) {
       createFile(`src/file-${index}.ts`);
     }
@@ -63,6 +63,27 @@ describe('FileDiscovery discover', () => {
     await discovery.discover({ rootPath: tempDir, onProgress });
 
     expect(onProgress.mock.calls.map(([progress]) => progress.current)).toEqual([1, 25]);
+  });
+
+  it('does not report filtered or Git-ignored files as discovery candidates', async () => {
+    initGitRepo();
+    createFile('.gitignore', 'ignored/**\n');
+    for (let index = 0; index < 26; index += 1) {
+      createFile(`ignored/file-${index}.ts`);
+    }
+    createFile('filtered/one.ts');
+    createFile('src/app.ts');
+    const onProgress = vi.fn();
+
+    const result = await discovery.discover({
+      rootPath: tempDir,
+      include: ['**/*.ts'],
+      filter: ['filtered/**'],
+      onProgress,
+    });
+
+    expect(result.files.map(file => file.relativePath)).toEqual([path.join('src', 'app.ts')]);
+    expect(onProgress.mock.calls.map(([progress]) => progress.current)).toEqual([1]);
   });
 
   it('includes file metadata', async () => {

--- a/packages/core/tests/discovery/file/discovery.discover.test.ts
+++ b/packages/core/tests/discovery/file/discovery.discover.test.ts
@@ -86,6 +86,26 @@ describe('FileDiscovery discover', () => {
     expect(onProgress.mock.calls.map(([progress]) => progress.current)).toEqual([1]);
   });
 
+  it('uses Git paths without recursively reading ignored or filtered workspace trees', async () => {
+    initGitRepo();
+    createFile('.gitignore', 'ignored/**\n');
+    createFile('ignored/generated/deep.ts');
+    createFile('filtered/generated/deep.ts');
+    createFile('src/app.ts');
+    const readdir = vi.spyOn(fs.promises, 'readdir');
+
+    const result = await discovery.discover({
+      rootPath: tempDir,
+      include: ['**/*.ts'],
+      filter: ['filtered/**'],
+    });
+
+    expect(result.files.map(file => file.relativePath)).toEqual([path.join('src', 'app.ts')]);
+    expect(result.cacheFilePaths).toContain(path.join('filtered', 'generated', 'deep.ts'));
+    expect(result.cachePathPrefixes).toContain('ignored');
+    expect(readdir).not.toHaveBeenCalled();
+  });
+
   it('includes file metadata', async () => {
     createFile('src/app.ts');
 
@@ -254,7 +274,7 @@ describe('FileDiscovery discover', () => {
     expect(result.files.map((file) => file.name)).not.toContain('a.log');
   });
 
-  it('classifies Git-ignored paths when their combined output exceeds the process buffer', async () => {
+  it('compacts a large Git-ignored tree to its directory root', async () => {
     initGitRepo();
     createFile('.gitignore', 'ignored/\n');
     for (let index = 0; index < 5_000; index += 1) {
@@ -270,7 +290,7 @@ describe('FileDiscovery discover', () => {
     });
 
     expect(result.files.map(file => file.relativePath)).toEqual(['z.ts']);
-    expect(result.gitIgnoredPaths).toHaveLength(5_001);
+    expect(result.gitIgnoredPaths).toEqual(['ignored']);
   }, 15_000);
 
   it('does not infer gitignored state from .gitignore outside a Git repository', async () => {
@@ -309,10 +329,7 @@ describe('FileDiscovery discover', () => {
 
     expect(result.directories).not.toContain('generated');
     expect(result.files.map(file => file.relativePath)).not.toContain(path.join('generated', 'output.ts'));
-    expect(result.gitIgnoredPaths).toEqual(expect.arrayContaining([
-      'generated',
-      path.join('generated', 'output.ts'),
-    ]));
+    expect(result.gitIgnoredPaths).toEqual(['generated']);
   });
 
   it('does not mark tracked files as gitignored even when they match gitignore patterns', async () => {

--- a/packages/core/tests/graph/data/gitignored.test.ts
+++ b/packages/core/tests/graph/data/gitignored.test.ts
@@ -26,7 +26,7 @@ describe('core/graph/data gitignored metadata', () => {
           relations: [],
         }],
       ]),
-      gitIgnoredPaths: ['example-python/app.py'],
+      gitIgnoredPaths: ['example-python'],
       showOrphans: true,
       nodeVisibility: SYMBOL_NODE_VISIBILITY,
       workspaceRoot: '/workspace',

--- a/packages/core/tests/indexing/discovery.test.ts
+++ b/packages/core/tests/indexing/discovery.test.ts
@@ -1,10 +1,26 @@
 import { describe, expect, it, vi } from 'vitest';
 import { DEFAULT_INCLUDE } from '../../src/discovery/file/defaults';
 import type { FileDiscovery } from '../../src/discovery/file/service';
-import { discoverWorkspaceIndexFiles } from '../../src/indexing/discovery';
+import {
+  discoverWorkspaceIndexFiles,
+  isRetainedWorkspaceIndexCachePath,
+} from '../../src/indexing/discovery';
 import { createDefaultCodeGraphyWorkspaceSettings } from '../../src/workspace/settingsDefaults';
 
 describe('indexing/discovery', () => {
+  it('retains cached descendants of compact ignored directory roots', () => {
+    const cacheFilePaths = new Set(['src/app.ts']);
+    expect(isRetainedWorkspaceIndexCachePath(
+      'ignored/deep/file.ts',
+      cacheFilePaths,
+      ['ignored'],
+    )).toBe(true);
+    expect(isRetainedWorkspaceIndexCachePath(
+      'ignored-sibling/file.ts',
+      cacheFilePaths,
+      ['ignored'],
+    )).toBe(false);
+  });
   it('excludes active custom filters from fresh indexing', async () => {
     const discover = vi.fn(async () => ({
       files: [],


### PR DESCRIPTION
## What changed

- Report discovery progress from files eligible for fresh indexing.
- Apply active Filters and Git ignored state before a path affects the displayed candidate count.
- Use Git's tracked and non-ignored path index instead of recursively reading every workspace directory.
- Compact ignored trees to directory roots while retaining cached descendant facts.
- Add focused regressions for progress eligibility, zero recursive reads, cache retention, and ignored descendants.

## Why

The Graph View labeled the raw pre-filter workspace scan count as candidate files. A workspace could therefore show 14,000 candidates even when only about 2,300 files were eligible for indexing.

Core already excluded those paths from analysis and the file budget, but only after recursively walking them. This change makes the progress count use the same eligibility boundary and makes Git-backed discovery enumerate eligible paths through Git instead of traversing ignored and filtered trees.

On the CodeGraphyV4 workspace, the same discovery harness improved from more than 60 seconds (aborted) to 666 ms. It found 2,812 eligible files while retaining 4,638 cache paths and representing ignored content with 114 compact roots.

## Validation

- `pnpm --filter @codegraphy-dev/core test` (1,555 passed)
- `pnpm --filter @codegraphy-dev/core lint`
- `pnpm --filter @codegraphy-dev/core typecheck`
- `git diff --check`
