### PR TITLE
Fix remaining CodeGraphy papercuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,5 @@ After you change code, make sure the relevant TypeScript typecheck passes.
 Use the smallest check that can disprove a change. Prefer focused unit tests while iterating. Run a focused Playwright scenario when the behavior needs a real browser or extension host; let CI run the complete Playwright suite in parallel. Push checkpoints and check the pull request periodically while useful work continues so failures appear before the branch drifts far from a green state.
 
 Treat the quality tools as focused diagnostics, not a checklist to run after every change. Select the tool that fits the risk and scope it to the changed file or feature. Mutation testing is the most expensive: run it against one source file, use its survivors to improve the code or tests, then repeat that same scoped run until its output is clean.
+
+Use `@codegraphy-dev/extension` as the Extension workspace filter. ESLint belongs to the workspace root; run focused lint as `pnpm exec eslint <paths>`, without a package filter.

--- a/packages/core/src/cli/version.ts
+++ b/packages/core/src/cli/version.ts
@@ -1,11 +1,5 @@
-import { readFileSync } from 'node:fs';
-
-interface PackageMetadata {
-  version: string;
-}
+import packageMetadata from '../../package.json' with { type: 'json' };
 
 export function readCliVersion(): string {
-  const packagePath = new URL('../../package.json', import.meta.url);
-  const metadata = JSON.parse(readFileSync(packagePath, 'utf8')) as PackageMetadata;
-  return `codegraphy ${metadata.version}`;
+  return `codegraphy ${packageMetadata.version}`;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4460,8 +4460,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001777:
-    resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -11514,7 +11514,7 @@ snapshots:
   autoprefixer@10.4.27(postcss@8.5.15):
     dependencies:
       browserslist: 4.28.1
-      caniuse-lite: 1.0.30001777
+      caniuse-lite: 1.0.30001806
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.15
@@ -11585,7 +11585,7 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001777
+      caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.307
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -11631,7 +11631,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001777: {}
+  caniuse-lite@1.0.30001806: {}
 
   chai@5.3.3:
     dependencies:
@@ -13441,7 +13441,7 @@ snapshots:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001777
+      caniuse-lite: 1.0.30001806
       postcss: 8.5.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)


### PR DESCRIPTION
## Summary

- document the correct Extension workspace filter and focused root ESLint command
- inline Core package metadata so the CommonJS Extension build does not receive `import.meta`
- refresh Browserslist data in the lockfile

## Verification

- `pnpm --filter @codegraphy-dev/core typecheck`
- Core test suite: 305 files and 1,290 tests passed
- `pnpm exec eslint packages/core/src/cli/version.ts`
- `node packages/core/dist/cli/main.js --version` returned `codegraphy 5.0.3`
- forced cold `build:vscode`: 12 scoped packages passed with zero cache hits
- verified the `import.meta` and stale Browserslist warnings are absent
