### PR TITLE
chore: add Core release changeset

### DIFF
--- a/.changeset/faster-eligible-discovery.md
+++ b/.changeset/faster-eligible-discovery.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/core": patch
+---
+
+Speed up filtered and Git-ignored File discovery by enumerating eligible Git paths before Indexing, report accurate candidate counts, and keep packaged CLI version output working in Extension builds.


### PR DESCRIPTION
## Summary

Add the missing Core patch Changeset for the public changes merged in #344 and #345.

## Release impact

- `@codegraphy-dev/core`: patch

This restores the release metadata required before running the CodeGraphy release workflow.