### PR TITLE
Fix Folder Nodes missing from the minimap

### DIFF
--- a/.changeset/bright-folders-map.md
+++ b/.changeset/bright-folders-map.md
@@ -1,0 +1,5 @@
+---
+"@codegraphy-dev/extension": patch
+---
+
+Show Folder Nodes in the Graph View minimap when folder scope is enabled.

--- a/packages/extension/src/webview/components/graph/rendering/nodes/canvasStyle.ts
+++ b/packages/extension/src/webview/components/graph/rendering/nodes/canvasStyle.ts
@@ -1,11 +1,30 @@
-import { DEFAULT_NODE_COLOR } from '../../../../../shared/fileColors';
+import {
+  DEFAULT_FOLDER_NODE_COLOR,
+  DEFAULT_NODE_COLOR,
+} from '../../../../../shared/fileColors';
 import type { FGNode } from '../../model/build';
 import type { NodeCanvasRendererDependencies } from '../node/canvasShared';
 import type { OwnedGraphNodeStyle } from '../surface/owned2d/view/surface/contracts';
+import { isFullyTransparentColor } from '../../../../colorParsing/transparent';
 import { normalizedNodeFillOpacity } from './canvasOpacity';
 
 function nodeColor(dependencies: NodeCanvasRendererDependencies, node: FGNode): string {
   return dependencies.resolveColor(node.color, DEFAULT_NODE_COLOR);
+}
+
+function minimapNodeColor(dependencies: NodeCanvasRendererDependencies, node: FGNode): string {
+  return node.nodeType === 'folder' && isFullyTransparentColor(node.color)
+    ? DEFAULT_FOLDER_NODE_COLOR
+    : nodeColor(dependencies, node);
+}
+
+function minimapNodeBorderColor(
+  dependencies: NodeCanvasRendererDependencies,
+  node: FGNode,
+): string {
+  return node.nodeType === 'folder' && isFullyTransparentColor(node.color)
+    ? DEFAULT_FOLDER_NODE_COLOR
+    : borderColor(dependencies, node, false);
 }
 
 function borderColor(dependencies: NodeCanvasRendererDependencies, node: FGNode, selected: boolean): string {
@@ -42,11 +61,12 @@ export function getBaseNodeCanvasStyle(
   dependencies: NodeCanvasRendererDependencies,
   node: FGNode,
 ): OwnedGraphNodeStyle {
+  const color = minimapNodeColor(dependencies, node);
   return {
-    borderColor: borderColor(dependencies, node, false),
+    borderColor: minimapNodeBorderColor(dependencies, node),
     borderWidth: node.borderWidth,
     cornerRadius: Math.max(0, node.cornerRadius2D ?? 0),
-    fillColor: nodeColor(dependencies, node),
+    fillColor: color,
     fillOpacity: normalizedNodeFillOpacity(node.fillOpacity2D),
     height: node.shapeSize2D?.height ?? node.size * 2,
     opacity: node.baseOpacity,

--- a/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
+++ b/packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts
@@ -138,6 +138,23 @@ describe('graph/rendering/nodes/canvas2d', () => {
     });
   });
 
+  it('keeps transparent folder icon nodes visible in the minimap', () => {
+    const style = getBaseNodeCanvasStyle(
+      createDependencies(),
+      createNode({
+        borderColor: 'rgba(0, 0, 0, 0)',
+        color: 'rgba(0, 0, 0, 0)',
+        imageUrl: 'data:image/svg+xml;base64,folder',
+        nodeType: 'folder',
+      }),
+    );
+
+    expect(style).toMatchObject({
+      borderColor: '#A1A1AA',
+      fillColor: '#A1A1AA',
+    });
+  });
+
   it('resolves plugin CSS colors before sending them to WebGPU', () => {
     const style = getNodeCanvasStyle(
       createDependencies({


### PR DESCRIPTION
## Summary

- render transparent Material Icon Theme Folder Nodes with the default folder color in the minimap
- preserve the SVG folder icons and transparent base shapes on the main Graph Stage
- add a regression test for the missing Folder Node symptom

## Verification

- `pnpm exec vitest run --config packages/extension/vitest.config.ts --project webview packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts`
- `pnpm exec eslint packages/extension/src/webview/components/graph/rendering/nodes/canvasStyle.ts packages/extension/tests/webview/graph/rendering/nodes/canvas2d.test.ts`
- `TURBO_FORCE=true pnpm --filter @codegraphy-dev/extension run typecheck`

## Visual proof

_Pending real VS Code Graph View capture._

Trello: https://trello.com/c/Xm1pu8Aa/270-folder-nodes-dont-show-up-in-minimap
